### PR TITLE
Adapted for AVX512F intrinsics.

### DIFF
--- a/makefile/Makefile
+++ b/makefile/Makefile
@@ -60,11 +60,14 @@ VECTORIZE_CODE ?= SSE
 # AVX2     - VectorizedCellProcessor with AVX2 intrinsics
 # KNL_MASK - VectorizedCellProcessor with KNL intrinsics and masking
 # KNL_G_S  - VectorizedCellProcessor with KNL intrinsics and gather-scatter (not fully optimized yet in this branch)
+# SKX_MASK - VectorizedCellProcessor with SKX intrinsics and masking
+# SKX_G_S  - VectorizedCellProcessor with SKX intrinsics and gather-scatter (not fully optimized yet in this branch)
+### note to the SKX variants: Uses only AVX512F. Only the flags passed to the compiler assume SKX, but not the used intrinsics code.
 # SOA      - VectorizedCellProcessor with no intrinsics
 # (Support dropped!) KNC_MASK - VectorizedCellProcessor with KNC intrinsics and masking
 # (Support dropped!) KNC_G_S  -VectorizedCellProcessor with KNC intrinsics and gather-scatter (not fully optimized yet in this branch)
 # see "make help_vect"
-vec_options := AOS SSE AVX AVX2 KNC_MASK KNC_G_S KNL_MASK KNL_G_S SOA SSEAMD AVXAMD
+vec_options := AOS SSE AVX AVX2 KNC_MASK KNC_G_S KNL_MASK KNL_G_S SKX_MASK SKX_G_S SOA SSEAMD AVXAMD
 ifeq (, $(filter $(VECTORIZE_CODE), $(vec_options)))
   $(error ERROR: invalid vectorize code option chosen. see "make help_vect")
 endif
@@ -366,6 +369,12 @@ help_vect:
 	@echo "            Speed-up not yet tested."
 	@echo " KNL_G_S  - use the VectorizedCellProcessor with AVX512 (knights landing) intrinsics."
 	@echo "            Works only on Xeon Phis of the second generation (knights landing)."
+	@echo "            Speed-up not yet tested."
+	@echo " SKX_MASK - use the VectorizedCellProcessor with AVX512F intrinsics."
+	@echo "            Uses only AVX512F. Only the flags passed to the compiler assume SKX, but not the used intrinsics code."
+	@echo "            Speed-up not yet tested."
+	@echo " SKX_G_S  - use the VectorizedCellProcessor with AVX512F intrinsics."
+	@echo "            Uses only AVX512F. Only the flags passed to the compiler assume SKX, but not the used intrinsics code."
 	@echo "            Speed-up not yet tested."
 	@echo "            Please make sure that you are using a reasonably updated compiler!"
 	@echo " SOA      - use the VectorizedCellProcessor with no intrinsics ("no-vec" mode)"

--- a/makefile/cfg/common_clang.mk
+++ b/makefile/cfg/common_clang.mk
@@ -32,6 +32,12 @@ endif
 ifeq ($(VECTORIZE_CODE),KNL_G_S)
 CXXFLAGS_VECTORIZE = -march=knl -D__VCP_GATHER__
 endif
+ifeq ($(VECTORIZE_CODE),KNL_MASK)
+CXXFLAGS_VECTORIZE = -march=skylake-avx512
+endif
+ifeq ($(VECTORIZE_CODE),KNL_G_S)
+CXXFLAGS_VECTORIZE = -march=skylake-avx512 -D__VCP_GATHER__
+endif
 
 # On AMD BUlldozer:
 ifeq ($(VECTORIZE_CODE),SSEAMD)

--- a/makefile/cfg/common_gcc.mk
+++ b/makefile/cfg/common_gcc.mk
@@ -32,6 +32,12 @@ endif
 ifeq ($(VECTORIZE_CODE),KNL_G_S)
 CXXFLAGS_VECTORIZE = -march=knl -D__VCP_GATHER__
 endif
+ifeq ($(VECTORIZE_CODE),SKX_MASK)
+CXXFLAGS_VECTORIZE = -march=skylake-avx512
+endif
+ifeq ($(VECTORIZE_CODE),SKX_G_S)
+CXXFLAGS_VECTORIZE = -march=skylake-avx512 -D__VCP_GATHER__
+endif
 
 # On AMD BUlldozer:
 ifeq ($(VECTORIZE_CODE),SSEAMD)

--- a/makefile/cfg/common_icc.mk
+++ b/makefile/cfg/common_icc.mk
@@ -23,6 +23,12 @@ endif
 ifeq ($(VECTORIZE_CODE),KNL_G_S)
 CXXFLAGS_VECTORIZE = -xMIC-AVX512 -D__VCP_GATHER__ -fp-model precise
 endif
+ifeq ($(VECTORIZE_CODE),KNL_MASK)
+CXXFLAGS_VECTORIZE = -xCore-AVX512 -fp-model precise
+endif
+ifeq ($(VECTORIZE_CODE),KNL_G_S)
+CXXFLAGS_VECTORIZE = -xCore-AVX512 -D__VCP_GATHER__ -fp-model precise
+endif
 
 # OpenMP settings:
 #########################################

--- a/src/bhfmm/cellProcessors/VectorizedChargeP2PCellProcessor.cpp
+++ b/src/bhfmm/cellProcessors/VectorizedChargeP2PCellProcessor.cpp
@@ -32,6 +32,8 @@ VectorizedChargeP2PCellProcessor::VectorizedChargeP2PCellProcessor(Domain & doma
 	global_log->info() << "VectorizedChargeP2PCellProcessor: using AVX2 intrinsics." << std::endl;
 #elif (VCP_VEC_TYPE==VCP_VEC_KNL) || (VCP_VEC_TYPE==VCP_VEC_KNL_GATHER)
 	global_log->info() << "VectorizedChargeP2PCellProcessor: using KNL intrinsics." << std::endl;
+#elif (VCP_VEC_TYPE==VCP_VEC_AVX512F) || (VCP_VEC_TYPE==VCP_VEC_AVX512F_GATHER)
+	global_log->info() << "VectorizedChargeP2PCellProcessor: using SKX intrinsics." << std::endl;
 #endif
 
 	// initialize thread data
@@ -454,7 +456,7 @@ void VectorizedChargeP2PCellProcessor::_calculatePairs(CellDataSoA & soa1, CellD
 						vcp_simd_load_add_store<MaskGatherChooser>(soa2_charges_V_z, j, Vz, lookupORforceMask);
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER  or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_charges);

--- a/src/bhfmm/cellProcessors/VectorizedLJP2PCellProcessor.cpp
+++ b/src/bhfmm/cellProcessors/VectorizedLJP2PCellProcessor.cpp
@@ -34,6 +34,8 @@ VectorizedLJP2PCellProcessor::VectorizedLJP2PCellProcessor(Domain & domain, doub
 	global_log->info() << "VectorizedLJP2PCellProcessor: using AVX2 intrinsics." << std::endl;
 #elif (VCP_VEC_TYPE==VCP_VEC_KNL) || (VCP_VEC_TYPE==VCP_VEC_KNL_GATHER)
 	global_log->info() << "VectorizedLJP2PCellProcessor: using KNL intrinsics." << std::endl;
+#elif (VCP_VEC_TYPE==VCP_VEC_AVX512F) || (VCP_VEC_TYPE==VCP_VEC_AVX512F_GATHER)
+	global_log->info() << "VectorizedLJP2PCellProcessor: using SKX intrinsics." << std::endl;
 #endif
 
 	ComponentList components = *(_simulation.getEnsemble()->getComponents());
@@ -384,7 +386,7 @@ void VectorizedLJP2PCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataS
 						sum_Vz1 = sum_Vz1 + Vz;
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_ljc);

--- a/src/particleContainer/adapter/VCP1CLJRMM.cpp
+++ b/src/particleContainer/adapter/VCP1CLJRMM.cpp
@@ -24,6 +24,8 @@ VCP1CLJRMM::VCP1CLJRMM(Domain& domain, double cutoffRadius, double LJcutoffRadiu
 	global_log->info() << "VCP1CLJRMM: using AVX2 intrinsics." << std::endl;
 #elif (VCP_VEC_TYPE==VCP_VEC_KNL) || (VCP_VEC_TYPE==VCP_VEC_KNL_GATHER)
 	global_log->info() << "VCP1CLJRMM: using KNL intrinsics." << std::endl;
+#elif (VCP_VEC_TYPE==VCP_VEC_AVX512F) || (VCP_VEC_TYPE==VCP_VEC_AVX512F_GATHER)
+	global_log->info() << "VCP1CLJRMM: using SKX intrinsics." << std::endl;
 #endif
 
 	const Component& componentZero = _simulation.getEnsemble()->getComponents()->front();
@@ -275,7 +277,7 @@ vcp_inline void VCP1CLJRMM::_calculatePairs(CellDataSoARMM& soa1, CellDataSoARMM
 	const size_t end_ljc_j = vcp_floor_to_vec_size(soa2.getMolNum());
 	const size_t end_ljc_j_longloop = vcp_ceil_to_vec_size(soa2.getMolNum());//this is ceil _ljc_num, VCP_VEC_SIZE
 
-#if not (VCP_VEC_TYPE == VCP_VEC_KNL_GATHER)
+#if not (VCP_VEC_TYPE == VCP_VEC_KNL_GATHER) and not (VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER)
 
 	const size_t soa1_mol_num = soa1.getMolNum();
 	for (size_t i = 0; i < soa1_mol_num; ++i) {
@@ -362,6 +364,6 @@ vcp_inline void VCP1CLJRMM::_calculatePairs(CellDataSoARMM& soa1, CellDataSoARMM
 	sum_virial.aligned_load_add_store(&my_threadData._virialV[0]);
 
 #else
-#pragma message "TODO: RMM Mode is not implemented yet for KNL_G_S."
+#pragma message "TODO: RMM Mode is not implemented yet for KNL_G_S and SKX_G_S."
 #endif
 }

--- a/src/particleContainer/adapter/VectorizedCellProcessor.cpp
+++ b/src/particleContainer/adapter/VectorizedCellProcessor.cpp
@@ -34,6 +34,8 @@ VectorizedCellProcessor::VectorizedCellProcessor(Domain & domain, double cutoffR
 	global_log->info() << "VectorizedCellProcessor: using AVX2 intrinsics." << std::endl;
 #elif (VCP_VEC_TYPE==VCP_VEC_KNL) || (VCP_VEC_TYPE==VCP_VEC_KNL_GATHER)
 	global_log->info() << "VectorizedCellProcessor: using KNL intrinsics." << std::endl;
+#elif (VCP_VEC_TYPE==VCP_VEC_AVX512F) || (VCP_VEC_TYPE==VCP_VEC_AVX512F_GATHER)
+	global_log->info() << "VectorizedCellProcessor: using SKX intrinsics." << std::endl;
 #endif
 
 	ComponentList components = *(_simulation.getEnsemble()->getComponents());
@@ -244,7 +246,11 @@ void VectorizedCellProcessor::endTraversal() {
 		const RealCalcVec c_dr2 = RealCalcVec::scal_prod(c_dx, c_dy, c_dz, c_dx, c_dy, c_dz);
 
 		const RealCalcVec c_dr2_inv = RealCalcVec::fastReciprocal_mask(c_dr2, forceMask);//masked
-#if VCP_VEC_TYPE == VCP_VEC_AVX2 or VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_AVX2 or \
+	VCP_VEC_TYPE == VCP_VEC_KNL or \
+	VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 	    const RealCalcVec c_dr_inv = RealCalcVec::fastReciprocSqrt_mask(c_dr2, forceMask);//masked
 #else
 	    const RealCalcVec c_dr_inv = RealCalcVec::sqrt(c_dr2_inv);//masked
@@ -294,8 +300,12 @@ void VectorizedCellProcessor::endTraversal() {
 		const RealCalcVec dr2 = RealCalcVec::scal_prod(dx, dy, dz, dx, dy, dz);
 
 		const RealCalcVec dr2_inv = RealCalcVec::fastReciprocal_mask(dr2, forceMask);
-#if VCP_VEC_TYPE == VCP_VEC_AVX2 or VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
-	    const RealCalcVec dr_inv = RealCalcVec::fastReciprocSqrt_mask(dr2, forceMask);
+#if VCP_VEC_TYPE == VCP_VEC_AVX2 or \
+	VCP_VEC_TYPE == VCP_VEC_KNL or \
+	VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
+		const RealCalcVec dr_inv = RealCalcVec::fastReciprocSqrt_mask(dr2, forceMask);
 #else
 	    const RealCalcVec dr_inv = RealCalcVec::sqrt(dr2_inv);
 #endif
@@ -363,7 +373,11 @@ void VectorizedCellProcessor::endTraversal() {
 		const RealCalcVec dr2 = RealCalcVec::scal_prod(dx, dy, dz, dx, dy, dz);
 
 		const RealCalcVec dr2_inv = RealCalcVec::fastReciprocal_mask(dr2, forceMask);
-#if VCP_VEC_TYPE == VCP_VEC_AVX2 or VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_AVX2 or \
+	VCP_VEC_TYPE == VCP_VEC_KNL or \
+	VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 	    const RealCalcVec dr_inv = RealCalcVec::fastReciprocSqrt_mask(dr2, forceMask);
 #else
 	    const RealCalcVec dr_inv = RealCalcVec::sqrt(dr2_inv);
@@ -451,7 +465,11 @@ void VectorizedCellProcessor::endTraversal() {
 		const RealCalcVec c_dr2 = RealCalcVec::scal_prod(c_dx, c_dy, c_dz, c_dx, c_dy, c_dz);
 
 		const RealCalcVec invdr2 = RealCalcVec::fastReciprocal_mask(c_dr2, forceMask);
-#if VCP_VEC_TYPE == VCP_VEC_AVX2 or VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_AVX2 or \
+	VCP_VEC_TYPE == VCP_VEC_KNL or \
+	VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 	    const RealCalcVec invdr = RealCalcVec::fastReciprocSqrt_mask(c_dr2, forceMask);
 #else
 	    const RealCalcVec invdr = RealCalcVec::sqrt(invdr2);
@@ -532,7 +550,11 @@ void VectorizedCellProcessor::endTraversal() {
 		const RealCalcVec c_dr2 = RealCalcVec::scal_prod(c_dx, c_dy, c_dz, c_dx, c_dy, c_dz);
 
 		const RealCalcVec invdr2 = RealCalcVec::fastReciprocal_mask(c_dr2, forceMask);
-#if VCP_VEC_TYPE == VCP_VEC_AVX2 or VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_AVX2 or \
+	VCP_VEC_TYPE == VCP_VEC_KNL or \
+	VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 	    const RealCalcVec invdr = RealCalcVec::fastReciprocSqrt_mask(c_dr2, forceMask);
 #else
 	    const RealCalcVec invdr = RealCalcVec::sqrt(invdr2);
@@ -651,7 +673,11 @@ void VectorizedCellProcessor::endTraversal() {
 		const RealCalcVec c_dr2 = RealCalcVec::scal_prod(c_dx, c_dy, c_dz, c_dx, c_dy, c_dz);
 
 		const RealCalcVec invdr2 = RealCalcVec::fastReciprocal_mask(c_dr2, forceMask);
-#if VCP_VEC_TYPE == VCP_VEC_AVX2 or VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_AVX2 or \
+	VCP_VEC_TYPE == VCP_VEC_KNL or \
+	VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 	    const RealCalcVec invdr = RealCalcVec::fastReciprocSqrt_mask(c_dr2, forceMask);
 #else
 	    const RealCalcVec invdr = RealCalcVec::sqrt(invdr2);
@@ -1076,7 +1102,7 @@ void VectorizedCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataSoA & 
 						sum_Vz1 = sum_Vz1 + Vz;
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_ljc);
@@ -1227,7 +1253,7 @@ void VectorizedCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataSoA & 
 						vcp_simd_load_add_store<MaskGatherChooser>(soa2_charges_V_z, j, Vz, lookupORforceMask);
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_charges);
@@ -1373,7 +1399,7 @@ void VectorizedCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataSoA & 
 						sum_M_z = sum_M_z + M_z;
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_charges);
@@ -1538,7 +1564,7 @@ void VectorizedCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataSoA & 
 						sum_M1_z = sum_M1_z + M_z;
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_charges);
@@ -1728,7 +1754,7 @@ void VectorizedCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataSoA & 
 
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_dipoles);
@@ -1899,7 +1925,7 @@ void VectorizedCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataSoA & 
 
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_dipoles);
@@ -2070,7 +2096,7 @@ void VectorizedCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataSoA & 
 
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_dipoles);
@@ -2264,7 +2290,7 @@ void VectorizedCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataSoA & 
 						vcp_simd_load_add_store<MaskGatherChooser>(soa2_quadrupoles_M_z, j, M2_z, lookupORforceMask);//newton 3
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_quadrupoles);
@@ -2431,7 +2457,7 @@ void VectorizedCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataSoA & 
 
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_quadrupoles);
@@ -2603,7 +2629,7 @@ void VectorizedCellProcessor::_calculatePairs(CellDataSoA & soa1, CellDataSoA & 
 
 					}
 				}
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 				if(MaskGatherChooser::hasRemainder()){//remainder computations, that's not an if, but a constant branch... compiler is wise.
 			#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 					const __mmask16 remainderM = MaskGatherChooser::getRemainder(compute_molecule_quadrupoles);

--- a/src/particleContainer/adapter/tests/RealCalcVecTest.cpp
+++ b/src/particleContainer/adapter/tests/RealCalcVecTest.cpp
@@ -8,22 +8,30 @@
 #include "utils/AlignedArray.h"
 #include "utils/mardyn_assert.h"
 
-#if VCP_VEC_TYPE == VCP_VEC_AVX2 or VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_AVX2 or \
+	VCP_VEC_TYPE == VCP_VEC_KNL or \
+	VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 	TEST_SUITE_REGISTRATION(RealCalcVecTest);
 #else
-	#pragma message "Compilation info: The unit tests for the fast reciproce methods are only executed with AVX2 or KNL"
+	#pragma message "Compilation info: The unit tests for the fast reciproce methods are only executed with AVX2, KNL and AVX512"
 #endif
 
 
 RealCalcVecTest::RealCalcVecTest() {
 #if VCP_VEC_TYPE == VCP_VEC_AVX2 or VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
-	test_log->info() << "Testing RealCalcVec fast reciproce with "
+	test_log->info() << "Testing RealCalcVec fast reciprocal with "
 	#if VCP_VEC_TYPE==VCP_VEC_AVX2
 		<< "AVX2 intrinsics." << std::endl;
 	#elif VCP_VEC_TYPE==VCP_VEC_KNL
 		<< "KNL_MASK intrinsics." << std::endl;
 	#elif VCP_VEC_TYPE==VCP_VEC_KNL_GATHER
 		<< "KNL_G_S intrinsics." << std::endl;
+	#elif VCP_VEC_TYPE==VCP_VEC_AVX512F
+		<< "SKX_MASK intrinsics." << std::endl;
+	#elif VCP_VEC_TYPE==VCP_VEC_AVX512F_GATHER
+		<< "SKX_G_S intrinsics." << std::endl;
 	#endif
 #endif
 }
@@ -35,7 +43,11 @@ void RealCalcVecTest::setUp() {}
 void RealCalcVecTest::tearDown() {}
 
 void RealCalcVecTest::testFastReciprocalMask() {
-#if VCP_VEC_TYPE == VCP_VEC_AVX2 or VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_AVX2 or \
+	VCP_VEC_TYPE == VCP_VEC_KNL or \
+	VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 
 	AlignedArray<vcp_real_calc> storageLegacy(VCP_VEC_SIZE);
 	storageLegacy.appendValue(1.0, 0);
@@ -85,7 +97,11 @@ void RealCalcVecTest::testFastReciprocalMask() {
 }
 
 void RealCalcVecTest::testFastReciprocSqrtMask() {
-#if VCP_VEC_TYPE == VCP_VEC_AVX2 or VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_AVX2 or \
+	VCP_VEC_TYPE == VCP_VEC_KNL or \
+	VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F or \
+	VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 
 	AlignedArray<vcp_real_calc> storageLegacy(VCP_VEC_SIZE);
 	storageLegacy.appendValue(1.0, 0);

--- a/src/particleContainer/adapter/tests/VectorizedCellProcessorTest.cpp
+++ b/src/particleContainer/adapter/tests/VectorizedCellProcessorTest.cpp
@@ -28,6 +28,14 @@ VectorizedCellProcessorTest::VectorizedCellProcessorTest() {
 	test_log->info() << "VectorizedCellProcessorTest: testing AVX intrinsics." << std::endl;
 #elif VCP_VEC_TYPE==VCP_VEC_AVX2
 	test_log->info() << "VectorizedCellProcessorTest: testing AVX2 intrinsics." << std::endl;
+#elif VCP_VEC_TYPE==VCP_VEC_KNL
+	test_log->info() << "VectorizedCellProcessorTest: testing KNL_MASK intrinsics." << std::endl;
+#elif VCP_VEC_TYPE==VCP_VEC_KNL_GATHER
+	test_log->info() << "VectorizedCellProcessorTest: testing KNL_GATHER intrinsics." << std::endl;
+#elif VCP_VEC_TYPE==VCP_VEC_AVX512F
+	test_log->info() << "VectorizedCellProcessorTest: testing AVX512F_MASK intrinsics." << std::endl;
+#elif VCP_VEC_TYPE==VCP_VEC_AVX512F_GATHER
+	test_log->info() << "VectorizedCellProcessorTest: testing AVX512F_GATHER intrinsics." << std::endl;
 #endif
 }
 

--- a/src/particleContainer/adapter/vectorization/MaskGatherChooser.h
+++ b/src/particleContainer/adapter/vectorization/MaskGatherChooser.h
@@ -60,7 +60,7 @@ public:
 	}
 
 };
-#if VCP_VEC_TYPE==VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE==VCP_VEC_KNL_GATHER or VCP_VEC_TYPE==VCP_VEC_AVX512F_GATHER
 class GatherChooser { //KNL ONLY!!!
 private:
 	__m512i indices;
@@ -194,7 +194,7 @@ public:
 };
 #endif
 
-#if VCP_VEC_TYPE!=VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE!=VCP_VEC_KNL_GATHER and VCP_VEC_TYPE!=VCP_VEC_AVX512F_GATHER
 	typedef MaskingChooser MaskGatherC;
 #else
 	typedef GatherChooser MaskGatherC;

--- a/src/particleContainer/adapter/vectorization/MaskVecDouble.h
+++ b/src/particleContainer/adapter/vectorization/MaskVecDouble.h
@@ -33,7 +33,7 @@ private:
 		typedef __mmask8 mask_vec;
 		typedef __mmask8 mask_single;
 
-		#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+		#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 			typedef __m512i lookupOrMask_vec;
 			typedef countertype32 lookupOrMask_single;
 		#endif
@@ -134,7 +134,7 @@ public:
 	}
 
 
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 	vcp_inline
 	static lookupOrMask_vec aligned_load(const lookupOrMask_single * const a) {
 		return _mm512_load_epi64(a);

--- a/src/particleContainer/adapter/vectorization/MaskVecFloat.h
+++ b/src/particleContainer/adapter/vectorization/MaskVecFloat.h
@@ -33,7 +33,7 @@ private:
 		typedef __mmask16 mask_vec;
 		typedef __mmask16 mask_single;
 
-		#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+		#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 			typedef __m512i lookupOrMask_vec;
 			typedef countertype32 lookupOrMask_single;
 		#endif
@@ -134,7 +134,7 @@ public:
 	}
 
 
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE==VCP_VEC_AVX512F_GATHER
 	vcp_inline
 	static lookupOrMask_vec aligned_load(const lookupOrMask_single * const a) {
 		return _mm512_load_epi32(a);

--- a/src/particleContainer/adapter/vectorization/RealAccumVecSPDP.h
+++ b/src/particleContainer/adapter/vectorization/RealAccumVecSPDP.h
@@ -162,7 +162,7 @@ public:
 	}
 
 
-#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE == VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 	vcp_inline
 	static RealAccumVecSPDP gather_load(const double * const src, const size_t& offset, const vcp_lookupOrMask_vec& lookup) {
 		__m256i lookup_256i_lo = _mm512_extracti64x4_epi64(lookup, 0);

--- a/src/particleContainer/adapter/vectorization/RealVecFloat.h
+++ b/src/particleContainer/adapter/vectorization/RealVecFloat.h
@@ -432,8 +432,10 @@ public:
 		/* reciprocal */
 			#if VCP_VEC_WIDTH == VCP_VEC_W_256 and VCP_VEC_TYPE == VCP_VEC_AVX2
 				const real_vec inv_unmasked = _mm256_rcp_ps(d); //12bit
-			#elif VCP_VEC_WIDTH == VCP_VEC_W_512
+			#elif VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL
 				const RealVec inv_prec = _mm512_maskz_rcp28_ps(m, d); //28bit
+			#elif VCP_VEC_TYPE == VCP_VEC_AVX512F or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
+				const RealVec inv = _mm512_maskz_rcp14_ps(m, d); //14bit
 			#else /* VCP_VEC_WIDTH == 64/128/256AVX */
 				const RealVec inv_unmasked = set1(1.0) / d;
 			#endif
@@ -443,9 +445,11 @@ public:
 				const RealVec inv = apply_mask(inv_unmasked, m); //12bit
 
 				const RealVec inv_prec = inv * fnmadd(d, inv, set1(2.0)); //24bit, 1 N-R-Iteration
-			#elif VCP_VEC_WIDTH == VCP_VEC_W_512
+			#elif VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL
 				//do nothing
 				//no Newton-Raphson required in SP, as the rcp-intrinsic is already precise enough
+			#elif VCP_VEC_TYPE == VCP_VEC_AVX512F or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
+				const RealVec inv_prec = inv * fnmadd(d, inv, set1(2.0)); // 28bit, 1 N-R-Iteration
 			#else /* VCP_VEC_WIDTH == 64/128/256AVX */
 				const RealVec inv_prec = apply_mask(inv_unmasked, m);
 			#endif
@@ -500,8 +504,10 @@ public:
 		/* reciprocal sqrt */
 			#if VCP_VEC_WIDTH == VCP_VEC_W_256 and VCP_VEC_TYPE == VCP_VEC_AVX2
 				const real_vec invSqrt_unmasked = _mm256_rsqrt_ps(d); //12bit
-			#elif VCP_VEC_WIDTH == VCP_VEC_W_512
+			#elif VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL
 				const RealVec invSqrt_prec = _mm512_maskz_rsqrt28_ps(m, d); //28bit
+			#elif VCP_VEC_TYPE == VCP_VEC_AVX512F or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
+				const RealVec invSqrt = _mm512_maskz_rsqrt14_ps(m, d); //14bit
 			#else /* VCP_VEC_WIDTH == 64/128/256AVX */
 				const RealVec invSqrt_unmasked = set1(1.0) / sqrt(d);
 			#endif
@@ -511,9 +517,11 @@ public:
 				const RealVec invSqrt = apply_mask(invSqrt_unmasked, m); //12bit
 
 				const RealVec invSqrt_prec = invSqrt * fnmadd(d * set1(0.5), invSqrt * invSqrt, set1(1.5)); //24bit, 1 N-R-Iteration
-			#elif VCP_VEC_WIDTH == VCP_VEC_W_512
+			#elif VCP_VEC_TYPE == VCP_VEC_KNL or VCP_VEC_TYPE == VCP_VEC_KNL
 				//do nothing
 				//no Newton-Raphson required in SP, as the rsqrt-intrinsic is already precise enough
+			#elif VCP_VEC_TYPE == VCP_VEC_AVX512F or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
+				const RealVec invSqrt_prec = invSqrt * fnmadd(d * set1(0.5), invSqrt * invSqrt, set1(1.5)); //28bit, 1 N-R-Iteration
 			#else /* VCP_VEC_WIDTH == 64/128/256AVX */
 				const RealVec invSqrt_prec = apply_mask(invSqrt_unmasked, m);
 			#endif

--- a/src/particleContainer/adapter/vectorization/SIMD_DEFINITIONS.h
+++ b/src/particleContainer/adapter/vectorization/SIMD_DEFINITIONS.h
@@ -45,8 +45,8 @@ namespace vcp {
 constexpr size_t VCP_VEC_SIZE = sizeof(vcp::RealCalcVec) / sizeof(vcp_real_calc);
 constexpr size_t VCP_VEC_SIZE_M1 = VCP_VEC_SIZE - 1u;
 
-constexpr size_t VCP_INDICES_PER_LOOKUP_SINGLE = (VCP_VEC_TYPE != VCP_VEC_KNL) ? 1u : VCP_VEC_SIZE;
-constexpr size_t VCP_INDICES_PER_LOOKUP_SINGLE_M1 = (VCP_VEC_TYPE != VCP_VEC_KNL) ? 0u : VCP_VEC_SIZE_M1;
+constexpr size_t VCP_INDICES_PER_LOOKUP_SINGLE    = (VCP_VEC_TYPE != VCP_VEC_KNL) and (VCP_VEC_TYPE != VCP_VEC_AVX512F) ? 1u : VCP_VEC_SIZE;
+constexpr size_t VCP_INDICES_PER_LOOKUP_SINGLE_M1 = (VCP_VEC_TYPE != VCP_VEC_KNL) and (VCP_VEC_TYPE != VCP_VEC_AVX512F) ? 0u : VCP_VEC_SIZE_M1;
 
 constexpr size_t VCP_ALIGNMENT = (VCP_VEC_TYPE != VCP_NOVEC) ? sizeof(vcp::RealCalcVec) : 8u;
 
@@ -148,7 +148,7 @@ using namespace vcp;
 			}
 		}
 	#endif
-#elif VCP_VEC_TYPE==VCP_VEC_KNL or VCP_VEC_TYPE==VCP_VEC_KNL_GATHER
+#elif VCP_VEC_WIDTH==VCP_VEC_W_512
 
 	#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 		static vcp_inline MaskCalcVec vcp_simd_getInitMask(const size_t& i){

--- a/src/particleContainer/adapter/vectorization/SIMD_VectorizedCellProcessorHelpers.h
+++ b/src/particleContainer/adapter/vectorization/SIMD_VectorizedCellProcessorHelpers.h
@@ -27,7 +27,7 @@ static vcp_inline
 void unpackEps24Sig2(RealCalcVec& eps_24, RealCalcVec& sig2, const AlignedArray<vcp_real_calc>& eps_sigI,
 		const vcp_ljc_id_t* const id_j, const vcp_ljc_id_t& offset, const vcp_lookupOrMask_vec& lookupORforceMask __attribute__((unused))) {
 
-#if VCP_VEC_TYPE != VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE != VCP_VEC_KNL_GATHER and VCP_VEC_TYPE != VCP_VEC_AVX512F_GATHER
 	const vcp_ljc_id_t* id_j_shifted = id_j + offset;//this is the pointer, to where the stuff is stored.
 #endif
 
@@ -113,7 +113,7 @@ void unpackEps24Sig2(RealCalcVec& eps_24, RealCalcVec& sig2, const AlignedArray<
 
 	#endif /* VCP_PREC */
 
-#elif VCP_VEC_TYPE==VCP_VEC_KNL
+#elif VCP_VEC_TYPE==VCP_VEC_KNL or VCP_VEC_TYPE==VCP_VEC_AVX512F
 	#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 		__m512i indices = _mm512_load_epi32(id_j_shifted);
 		indices = _mm512_add_epi32(indices, indices);//only every second...
@@ -127,7 +127,7 @@ void unpackEps24Sig2(RealCalcVec& eps_24, RealCalcVec& sig2, const AlignedArray<
 	#endif
 
 
-#elif VCP_VEC_TYPE==VCP_VEC_KNL_GATHER
+#elif VCP_VEC_TYPE==VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 
 	#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 		__m512i indices = _mm512_i32gather_epi32(lookupORforceMask, (const int *) id_j, 4);
@@ -233,7 +233,7 @@ void unpackShift6(RealCalcVec& shift6, const AlignedArray<vcp_real_calc>& shift6
 
 
 
-#elif VCP_VEC_TYPE==VCP_VEC_KNL
+#elif VCP_VEC_TYPE==VCP_VEC_KNL or VCP_VEC_TYPE==VCP_VEC_AVX512F
 
 	#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 		const __m512i indices = _mm512_load_epi32(id_j_shifted);
@@ -245,7 +245,7 @@ void unpackShift6(RealCalcVec& shift6, const AlignedArray<vcp_real_calc>& shift6
 	#endif
 
 
-#elif VCP_VEC_TYPE==VCP_VEC_KNL_GATHER
+#elif VCP_VEC_TYPE==VCP_VEC_KNL_GATHER or VCP_VEC_TYPE == VCP_VEC_AVX512F_GATHER
 
 	#if VCP_PREC == VCP_SPSP or VCP_PREC == VCP_SPDP
 		__m512i indices = _mm512_i32gather_epi32(lookupORforceMask, (const int *) id_j, 4);
@@ -353,7 +353,7 @@ public:
 
 	vcp_inline static size_t InitJ2 (const size_t i __attribute__((unused)))  // needed for alignment. (guarantees, that one simd_load always accesses the same cache line.
 	{
-#if VCP_VEC_TYPE!=VCP_VEC_KNL_GATHER
+#if VCP_VEC_TYPE!=VCP_VEC_KNL_GATHER and VCP_VEC_TYPE!=VCP_VEC_AVX512F_GATHER
 		return InitJ(i);
 #else
 		return 0;


### PR DESCRIPTION
Adapted intrinsics wrappers for AVX512F, for usage with SKX. The compile flags are for SKX, but the intrinsics assume only AVX512F. 