### PR TITLE
fixing compilation using autopas and openmp

### DIFF
--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -25,6 +25,7 @@ if(ENABLE_AUTOPAS)
             -DBUILD_TESTS=OFF
             -DBUILD_EXAMPLES=OFF
             -DENABLE_ADDRESS_SANITIZER=${ENABLE_ADDRESS_SANITIZER}
+            -DOPENMP=${OPENMP}
     )
 
     # Get autopas source and binary directories from CMake project
@@ -34,12 +35,17 @@ if(ENABLE_AUTOPAS)
     add_library(libautopas IMPORTED STATIC GLOBAL)
     add_dependencies(libautopas autopas)
 
+    # Using target_compile_definitions for imported targets is only possible starting with cmake 3.11, so we use add_definitions here.
+    if(OPENMP)
+        add_definitions(-DAUTOPAS_OPENMP)
+    endif(OPENMP)
+
     set_target_properties(libautopas PROPERTIES
             "IMPORTED_LOCATION" "${binary_dir}/src/autopas/libautopas.a"
             "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
             )
 
-    # I couldn't make it work with INTERFACE_INCLUDE_DIRECTORIES
+    # Using INTERFACE_INCLUDE_DIRECTORIES is only possible starting with cmake 3.11, so we use include_directories here!
     include_directories(SYSTEM
             "${source_dir}/src"
             "${source_dir}/libs/spdlog-0.16.3/include"


### PR DESCRIPTION
Fixes Compilation when using the AutoPas library and OpenMP is enabled.

# Bug
Target properties of AutoPas cannot be exported using external_project. So AUTOPAS_OPENMP was not defined.

# Fix
Define AUTOPAS_OPENMP ourselves