### PR TITLE
AutoPas readXML

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ ENABLE_TESTING()
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules/)
 
 # ----- first: include option files
+option(GIT_SUBMODULES_SSH "Use SSH for git submodules instead of HTTPS" OFF)
 # include vectorization module
 include(vectorization)
 # include OpenMP module

--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -1,6 +1,5 @@
 # autopas library
 option(ENABLE_AUTOPAS "Use autopas library" OFF)
-option(GIT_SUBMODULES_SSH "Use SSH for git submodules instead of HTTPS" OFF)
 if(ENABLE_AUTOPAS)
     message(STATUS "Using AutoPas.")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMARDYN_AUTOPAS")

--- a/cmake/modules/lz4.cmake
+++ b/cmake/modules/lz4.cmake
@@ -8,10 +8,17 @@ if(ENABLE_LZ4)
 
     set(LZ4_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/lz4)
     set(LZ4_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libs/lz4)
+
+    # Select https (default) or ssh path.
+    set(lz4RepoPath https://github.com/lz4/lz4.git)
+    if(GIT_SUBMODULES_SSH)
+        set(lz4RepoPath git@github.com:lz4/lz4.git)
+    endif()
+
     # Download and install lz4
     ExternalProject_Add(
             lz4
-            GIT_REPOSITORY https://github.com/lz4/lz4.git
+            GIT_REPOSITORY ${lz4RepoPath}
             GIT_TAG dev
             SOURCE_DIR ${LZ4_SOURCE_DIR}
             BINARY_DIR ${LZ4_BINARY_DIR}

--- a/cmake/modules/vtk.cmake
+++ b/cmake/modules/vtk.cmake
@@ -9,6 +9,10 @@ if(ENABLE_VTK)
         message(FATAL_ERROR "xerces-c lib not found. Disable VTK support, if you do not need it.")
     endif()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVTK")
+    include_directories(SYSTEM
+            "${PROJECT_SOURCE_DIR}/dependencies-external/libxsd"
+            "$ENV{XERCES_INCDIR}"
+            )
 else()
     message(STATUS "VTK Disabled")
 endif()

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -157,6 +157,30 @@
           </traversalData>
       </datastructure>
 
+      <datastructure type="AutoPas">
+        <!-- specify all allowed traversals as a comma separated list -->
+        <allowedTraversals>c08, sli</allowedTraversals>
+        <!-- specify all allowed containers as a comma separated list -->
+        <!-- possible values:
+          - directSum
+          - linkedCells
+          - verlet
+          - vcells
+          - vcluster
+          -->
+        <allowedContainers>linkedCells, vcells, vcluster</allowedContainers>
+        <!-- specify what metric the respective selector should use to determine the optimal traversal -->
+        <!-- possible values: fastetAbsolute, fastestMean, fastestMedian -->
+        <traversalSelectorStrategy>fastestMedian</traversalSelectorStrategy>
+        <containerSelectorStrategy>fastestMedian</containerSelectorStrategy>
+        <!-- Data layout to be used: AoS or SoA -->
+        <dataLayout>SoA</dataLayout>
+        <!-- How many iterations before retuning -->
+        <tuningInterval>1000</tuningInterval>
+        <!-- How many samples should the tuner take for each tested combination -->
+        <tuningSamples>5</tuningSamples>
+      </datastructure>
+
       <!-- cutoff definitions -->
       <cutoffs type="CenterOfMass" >
         <!-- Lennard Jones cutoff radius -->

--- a/src/io/vtk/VTKGridWriter.cpp
+++ b/src/io/vtk/VTKGridWriter.cpp
@@ -5,6 +5,8 @@
  * @Author: eckhardw
  */
 
+#ifndef MARDYN_AUTOPAS
+
 #include "VTKGridWriter.h"
 #include "particleContainer/LinkedCells.h"
 #include "io/vtk/VTKGridWriterImplementation.h"
@@ -46,7 +48,7 @@ void  VTKGridWriter::endStep(
 	LinkedCells* container = dynamic_cast<LinkedCells*>(particleContainer);
 #ifndef NDEBUG
 	if (container == NULL) {
-		global_log->error() << "VTKGridWriter works only with PlottableLinkCells!" << std::endl;
+		global_log->error() << "VTKGridWriter works only with plottable LinkCells!" << std::endl;
 		Simulation::exit(1);
 	}
 #endif
@@ -185,3 +187,5 @@ void VTKGridWriter::getCellData(LinkedCells* container, VTKGridCell& cell) {
 //! NOP
 void  VTKGridWriter::finish(ParticleContainer * /*particleContainer*/,
 							DomainDecompBase * /*domainDecomp*/, Domain * /*domain*/) { }
+
+#endif /* MARDYN_AUTOPAS */

--- a/src/io/vtk/VTKGridWriter.cpp
+++ b/src/io/vtk/VTKGridWriter.cpp
@@ -48,7 +48,7 @@ void  VTKGridWriter::endStep(
 	LinkedCells* container = dynamic_cast<LinkedCells*>(particleContainer);
 #ifndef NDEBUG
 	if (container == NULL) {
-		global_log->error() << "VTKGridWriter works only with plottable LinkCells!" << std::endl;
+		global_log->error() << "VTKGridWriter works only with plottable LinkedCells!" << std::endl;
 		Simulation::exit(1);
 	}
 #endif

--- a/src/io/vtk/VTKGridWriter.h
+++ b/src/io/vtk/VTKGridWriter.h
@@ -5,8 +5,9 @@
  * @Author: eckhardw
  */
 
-#ifndef VTKGRIDWRITER_H_
-#define VTKGRIDWRITER_H_
+#pragma once
+
+#ifndef MARDYN_AUTOPAS
 
 #include "plugins/PluginBase.h"
 #include "io/vtk/VTKGridCell.h"
@@ -90,4 +91,4 @@ private:
 
 };
 
-#endif /* VTKGRIDWRITER_H_ */
+#endif /* MARDYN_AUTOPAS */

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -9,6 +9,7 @@
 #include <exception>
 #include "Domain.h"
 #include "Simulation.h"
+#include "autopas/utils/StringParser.h"
 
 AutoPasContainer::AutoPasContainer()
 	: _cutoff(0.), _verletSkin(0.3), _verletRebuildFrequency(10u), _tuningFrequency(100u), _autopasContainer() {
@@ -20,18 +21,18 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 
 	// set default values here!
 
-	_traversalChoices(autopas::utils::StringParser::parseTraversalOptions(
-		string_utils::toLowercase(xmlconfig.getNodeValue_string("allowedTraversals", "c08"))));
-	_containerChoices(autopas::utils::StringParser::parseContainerOptions(
-		string_utils::toLowercase(xmlconfig.getNodeValue_string("allowedContainers", "linked-cell"))));
+	_traversalChoices = autopas::utils::StringParser::parseTraversalOptions(
+		string_utils::toLowercase(xmlconfig.getNodeValue_string("allowedTraversals", "c08")));
+	_containerChoices = autopas::utils::StringParser::parseContainerOptions(
+		string_utils::toLowercase(xmlconfig.getNodeValue_string("allowedContainers", "linked-cell")));
 
-	_traversalSelectorStrategy(autopas::utils::StringParser::parseSelectorStrategy(
-		string_utils::toLowercase(xmlconfig.getNodeValue_string("traversalSelectorStrategy", "median"))));
-	_containerSelectorStrategy(autopas::utils::StringParser::parseSelectorStrategy(
-		string_utils::toLowercase(xmlconfig.getNodeValue_string("containerSelectorStrategy", "median"))));
+	_traversalSelectorStrategy = autopas::utils::StringParser::parseSelectorStrategy(
+		string_utils::toLowercase(xmlconfig.getNodeValue_string("traversalSelectorStrategy", "median")));
+	_containerSelectorStrategy = autopas::utils::StringParser::parseSelectorStrategy(
+		string_utils::toLowercase(xmlconfig.getNodeValue_string("containerSelectorStrategy", "median")));
 
-	_dataLayout(autopas::utils::StringParser::parseDataLayout(
-		string_utils::toLowercase(xmlconfig.getNodeValue_string("dataLayout", "soa"))));
+	_dataLayout = autopas::utils::StringParser::parseDataLayout(
+		string_utils::toLowercase(xmlconfig.getNodeValue_string("dataLayout", "soa")));
 
 	_tuningSamples = (unsigned int)xmlconfig.getNodeValue_int("tuningSamples", 3);
 	_tuningFrequency = (unsigned int)xmlconfig.getNodeValue_int("tuningInterval", 500);

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -9,7 +9,8 @@
 #include <exception>
 #include "Domain.h"
 #include "Simulation.h"
-#include "autopas/utils/StringParser.h"
+#include "autopas/utils/Logger.h"
+#include "autopas/utils/StringUtils.h"
 
 AutoPasContainer::AutoPasContainer()
 	: _cutoff(0.), _verletSkin(0.3), _verletRebuildFrequency(10u), _tuningFrequency(100u), _autopasContainer() {
@@ -21,21 +22,39 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 
 	// set default values here!
 
-	_traversalChoices = autopas::utils::StringParser::parseTraversalOptions(
+	_traversalChoices = autopas::utils::StringUtils::parseTraversalOptions(
 		string_utils::toLowercase(xmlconfig.getNodeValue_string("allowedTraversals", "c08")));
-	_containerChoices = autopas::utils::StringParser::parseContainerOptions(
+	_containerChoices = autopas::utils::StringUtils::parseContainerOptions(
 		string_utils::toLowercase(xmlconfig.getNodeValue_string("allowedContainers", "linked-cell")));
 
-	_traversalSelectorStrategy = autopas::utils::StringParser::parseSelectorStrategy(
+	_traversalSelectorStrategy = autopas::utils::StringUtils::parseSelectorStrategy(
 		string_utils::toLowercase(xmlconfig.getNodeValue_string("traversalSelectorStrategy", "median")));
-	_containerSelectorStrategy = autopas::utils::StringParser::parseSelectorStrategy(
+	_containerSelectorStrategy = autopas::utils::StringUtils::parseSelectorStrategy(
 		string_utils::toLowercase(xmlconfig.getNodeValue_string("containerSelectorStrategy", "median")));
 
-	_dataLayout = autopas::utils::StringParser::parseDataLayout(
+	_dataLayout = autopas::utils::StringUtils::parseDataLayout(
 		string_utils::toLowercase(xmlconfig.getNodeValue_string("dataLayout", "soa")));
 
 	_tuningSamples = (unsigned int)xmlconfig.getNodeValue_int("tuningSamples", 3);
 	_tuningFrequency = (unsigned int)xmlconfig.getNodeValue_int("tuningInterval", 500);
+
+	std::stringstream containerChoicesStram;
+	for_each(_containerChoices.begin(), _containerChoices.end(),
+			 [&](auto &choice) { containerChoicesStram << autopas::utils::StringUtils::to_string(choice) << " "; });
+	std::stringstream traversalChoicesStram;
+	for_each(_traversalChoices.begin(), _traversalChoices.end(),
+			 [&](auto &choice) { traversalChoicesStram << autopas::utils::StringUtils::to_string(choice) << " "; });
+
+	int valueOffset = 28;
+	global_log->info() << "AutoPas configuration:" << endl
+	                   << setw(valueOffset) << left << "Data Layout " << ": " << autopas::utils::StringUtils::to_string(_dataLayout) << endl
+					   << setw(valueOffset) << left << "Container " << ": " << containerChoicesStram.str() << endl
+					   << setw(valueOffset) << left << "Container selector strategy " << ": " << autopas::utils::StringUtils::to_string(_containerSelectorStrategy) << endl
+					   << setw(valueOffset) << left << "Traversals " << ": " << traversalChoicesStram.str() << endl
+					   << setw(valueOffset) << left << "Traversal selector strategy " << ": "  << autopas::utils::StringUtils::to_string(_traversalSelectorStrategy) << endl
+					   << setw(valueOffset) << left << "Tuning frequency" << ": "  << _tuningFrequency << endl
+					   << setw(valueOffset) << left << "Number of samples " << ": "  << _tuningSamples << endl
+					   ;
 }
 
 bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -38,19 +38,19 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 	_tuningSamples = (unsigned int)xmlconfig.getNodeValue_int("tuningSamples", 3);
 	_tuningFrequency = (unsigned int)xmlconfig.getNodeValue_int("tuningInterval", 500);
 
-	std::stringstream containerChoicesStram;
+	std::stringstream containerChoicesStream;
 	for_each(_containerChoices.begin(), _containerChoices.end(),
-			 [&](auto &choice) { containerChoicesStram << autopas::utils::StringUtils::to_string(choice) << " "; });
-	std::stringstream traversalChoicesStram;
+			 [&](auto &choice) { containerChoicesStream << autopas::utils::StringUtils::to_string(choice) << " "; });
+	std::stringstream traversalChoicesStream;
 	for_each(_traversalChoices.begin(), _traversalChoices.end(),
-			 [&](auto &choice) { traversalChoicesStram << autopas::utils::StringUtils::to_string(choice) << " "; });
+			 [&](auto &choice) { traversalChoicesStream << autopas::utils::StringUtils::to_string(choice) << " "; });
 
 	int valueOffset = 28;
 	global_log->info() << "AutoPas configuration:" << endl
 	                   << setw(valueOffset) << left << "Data Layout " << ": " << autopas::utils::StringUtils::to_string(_dataLayout) << endl
-					   << setw(valueOffset) << left << "Container " << ": " << containerChoicesStram.str() << endl
+					   << setw(valueOffset) << left << "Container " << ": " << containerChoicesStream.str() << endl
 					   << setw(valueOffset) << left << "Container selector strategy " << ": " << autopas::utils::StringUtils::to_string(_containerSelectorStrategy) << endl
-					   << setw(valueOffset) << left << "Traversals " << ": " << traversalChoicesStram.str() << endl
+					   << setw(valueOffset) << left << "Traversals " << ": " << traversalChoicesStream.str() << endl
 					   << setw(valueOffset) << left << "Traversal selector strategy " << ": "  << autopas::utils::StringUtils::to_string(_traversalSelectorStrategy) << endl
 					   << setw(valueOffset) << left << "Tuning frequency" << ": "  << _tuningFrequency << endl
 					   << setw(valueOffset) << left << "Number of samples " << ": "  << _tuningSamples << endl
@@ -64,6 +64,7 @@ bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {
 	_autopasContainer.init(boxMin, boxMax, _cutoff, _verletSkin, _verletRebuildFrequency, _containerChoices,
 						   _traversalChoices, _containerSelectorStrategy, _traversalSelectorStrategy, _tuningFrequency,
 						   _tuningSamples);
+	autopas::Logger::get()->set_level(autopas::Logger::LogLevel::debug);
 	memcpy(_boundingBoxMin, bBoxMin, 3 * sizeof(double));
 	memcpy(_boundingBoxMax, bBoxMax, 3 * sizeof(double));
 	/// @todo return sendHaloAndLeavingTogether, (always false) for simplicity.

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -86,6 +86,13 @@ private:
 	double _verletSkin;
 	unsigned int _verletRebuildFrequency;
 	unsigned int _tuningFrequency;
+	unsigned int _tuningSamples;
 	typedef autopas::FullParticleCell<Molecule> CellType;
 	autopas::AutoPas<Molecule, CellType> _autopasContainer;
+
+	std::vector<autopas::TraversalOptions>_traversalChoices;
+	std::vector<autopas::ContainerOptions>_containerChoices;
+	autopas::SelectorStrategy _traversalSelectorStrategy;
+	autopas::SelectorStrategy _containerSelectorStrategy;
+	autopas::DataLayoutOption _dataLayout;
 };

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -94,7 +94,9 @@ void PluginFactory<PluginBase>::registerDefaultPlugins(){
     REGISTER_PLUGIN(XyzWriter);
 #ifdef VTK
     REGISTER_PLUGIN(VTKMoleculeWriter);
+#ifndef MARDYN_AUTOPAS
     REGISTER_PLUGIN(VTKGridWriter);
+#endif
 #endif
 }
 

--- a/src/utils/String_utils.h
+++ b/src/utils/String_utils.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#include <algorithm>
 
 namespace string_utils {
 
@@ -17,6 +18,17 @@ static std::string join(const std::vector<T>& vec, const std::string delimiter) 
 		}
 	}
 	return ss.str();
+}
+
+/**
+ * Converts a string to lower case.
+ * @param s input string.
+ * @return Copy of s in lower case.
+ */
+static std::string toLowercase(const std::string &s) {
+	std::string ret;
+	std::transform(s.begin(), s.end(), ret.begin(), ::tolower);
+	return ret;
 }
 
 }

--- a/src/utils/String_utils.h
+++ b/src/utils/String_utils.h
@@ -1,10 +1,9 @@
-#ifndef STRING_UTILS_H
-#define STRING_UTILS_H
+#pragma once
 
-#include <string>
-#include <sstream>
-#include <vector>
 #include <algorithm>
+#include <sstream>
+#include <string>
+#include <vector>
 
 namespace string_utils {
 
@@ -25,12 +24,11 @@ static std::string join(const std::vector<T>& vec, const std::string delimiter) 
  * @param s input string.
  * @return Copy of s in lower case.
  */
-static std::string toLowercase(const std::string &s) {
+static std::string toLowercase(const std::string& s) {
 	std::string ret;
+	ret.resize(s.length());
 	std::transform(s.begin(), s.end(), ret.begin(), ::tolower);
 	return ret;
 }
 
-}
-
-#endif
+}  // namespace string_utils


### PR DESCRIPTION
Mainly making AutoPas useable in ls1:

- [x] readXML for `AutoPasContainer`
- [x] including new StringUtils from Autopas
- [x] CMake option to checkout git submodules via ssh instead of https for easier tunneling on clusters.
- [x] Disabled VTKGridWriter for AutoPas because so is LinkedCells, which is needed here.