### PR TITLE
Added support for Maximum Wall Time (loop-abort-time)

### DIFF
--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -35,7 +35,7 @@ void initOptions(optparse::OptionParser *op) {
 		"%prog --tests --test-dir <test input data directory> [<name of testcase>]");
 	op->version("%prog " + MARDYN_VERSION);
 	op->description("ls1-MarDyn (Large Scale SImulation MoleculAR DYNamics)");
-	op->add_option("-w", "--walltime").dest("walltime").type("float") .metavar("NUM") .set_default(-1) .help("(optional) max walltime allowed in (s) before stop of main loop (default: %default)");
+	op->add_option("-a", "--loop-abort-time").dest("loop-abort-time").type("float") .metavar("TIME") .set_default(-1) .help("(optional) max walltime allowed in (s) before stop of main loop (default: %default)");
 	op->add_option("-n", "--steps").dest("timesteps").type("int") .metavar("NUM") .set_default(1) .help("number of timesteps to simulate (default: %default)");
 	op->add_option("-p", "--outprefix").dest("outputprefix").type("string") .metavar("STR") .set_default("MarDyn") .help("default prefix for output files (default: %default)");
 	op->add_option("-v", "--verbose").dest("verbose").type("bool") .action("store_true") .set_default(false) .help("verbose mode: print debugging information (default: %default)");
@@ -217,8 +217,8 @@ int main(int argc, char** argv) {
 	if (options.is_set_by_user("timesteps")) {
 		simulation.setNumTimesteps(options.get("timesteps").operator unsigned long int());
 	}
-	if (options.is_set_by_user("walltime")) {
-		simulation.setWallTime(options.get("walltime").operator double());
+	if (options.is_set_by_user("loop-abort-time")) {
+		simulation.setLoopAbortTime(options.get("loop-abort-time").operator double());
 	}
 	global_log->info() << "Simulating " << simulation.getNumTimesteps() << " steps." << endl;
     

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -35,7 +35,7 @@ void initOptions(optparse::OptionParser *op) {
 		"%prog --tests --test-dir <test input data directory> [<name of testcase>]");
 	op->version("%prog " + MARDYN_VERSION);
 	op->description("ls1-MarDyn (Large Scale SImulation MoleculAR DYNamics)");
-	op->add_option("-w", "--walltime").dest("walltime").type("float") .metavar("NUM") .set_default(-1) .help("(optional) seconds of walltime allowed for main loop (default: %default)");
+	op->add_option("-w", "--walltime").dest("walltime").type("float") .metavar("NUM") .set_default(-1) .help("(optional) max walltime allowed in (s) before stop of main loop (default: %default)");
 	op->add_option("-n", "--steps").dest("timesteps").type("int") .metavar("NUM") .set_default(1) .help("number of timesteps to simulate (default: %default)");
 	op->add_option("-p", "--outprefix").dest("outputprefix").type("string") .metavar("STR") .set_default("MarDyn") .help("default prefix for output files (default: %default)");
 	op->add_option("-v", "--verbose").dest("verbose").type("bool") .action("store_true") .set_default(false) .help("verbose mode: print debugging information (default: %default)");

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -35,7 +35,7 @@ void initOptions(optparse::OptionParser *op) {
 		"%prog --tests --test-dir <test input data directory> [<name of testcase>]");
 	op->version("%prog " + MARDYN_VERSION);
 	op->description("ls1-MarDyn (Large Scale SImulation MoleculAR DYNamics)");
-	op->add_option("-l", "--looptime").dest("looptime").type("float") .metavar("NUM") .set_default(-1) .help("seconds of walltime allowed for main loop (default: %default)");
+	op->add_option("-l", "--looptime").dest("looptime").type("float") .metavar("NUM") .set_default(-1) .help("(optional) seconds of walltime allowed for main loop (default: %default)");
 	op->add_option("-n", "--steps").dest("timesteps").type("int") .metavar("NUM") .set_default(1) .help("number of timesteps to simulate (default: %default)");
 	op->add_option("-p", "--outprefix").dest("outputprefix").type("string") .metavar("STR") .set_default("MarDyn") .help("default prefix for output files (default: %default)");
 	op->add_option("-v", "--verbose").dest("verbose").type("bool") .action("store_true") .set_default(false) .help("verbose mode: print debugging information (default: %default)");

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -35,7 +35,7 @@ void initOptions(optparse::OptionParser *op) {
 		"%prog --tests --test-dir <test input data directory> [<name of testcase>]");
 	op->version("%prog " + MARDYN_VERSION);
 	op->description("ls1-MarDyn (Large Scale SImulation MoleculAR DYNamics)");
-	op->add_option("-l", "--looptime").dest("looptime").type("float") .metavar("NUM") .set_default(-1) .help("(optional) seconds of walltime allowed for main loop (default: %default)");
+	op->add_option("-w", "--walltime").dest("walltime").type("float") .metavar("NUM") .set_default(-1) .help("(optional) seconds of walltime allowed for main loop (default: %default)");
 	op->add_option("-n", "--steps").dest("timesteps").type("int") .metavar("NUM") .set_default(1) .help("number of timesteps to simulate (default: %default)");
 	op->add_option("-p", "--outprefix").dest("outputprefix").type("string") .metavar("STR") .set_default("MarDyn") .help("default prefix for output files (default: %default)");
 	op->add_option("-v", "--verbose").dest("verbose").type("bool") .action("store_true") .set_default(false) .help("verbose mode: print debugging information (default: %default)");
@@ -217,8 +217,8 @@ int main(int argc, char** argv) {
 	if (options.is_set_by_user("timesteps")) {
 		simulation.setNumTimesteps(options.get("timesteps").operator unsigned long int());
 	}
-	if (options.is_set_by_user("looptime")) {
-		simulation.setLoopTime(options.get("looptime").operator double());
+	if (options.is_set_by_user("walltime")) {
+		simulation.setWallTime(options.get("walltime").operator double());
 	}
 	global_log->info() << "Simulating " << simulation.getNumTimesteps() << " steps." << endl;
     

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -35,7 +35,7 @@ void initOptions(optparse::OptionParser *op) {
 		"%prog --tests --test-dir <test input data directory> [<name of testcase>]");
 	op->version("%prog " + MARDYN_VERSION);
 	op->description("ls1-MarDyn (Large Scale SImulation MoleculAR DYNamics)");
-
+	op->add_option("-t", "--looptime").dest("looptime").type("float") .metavar("NUM") .set_default(-1) .help("seconds of walltime allowed for main loop (default: %default)");
 	op->add_option("-n", "--steps").dest("timesteps").type("int") .metavar("NUM") .set_default(1) .help("number of timesteps to simulate (default: %default)");
 	op->add_option("-p", "--outprefix").dest("outputprefix").type("string") .metavar("STR") .set_default("MarDyn") .help("default prefix for output files (default: %default)");
 	op->add_option("-v", "--verbose").dest("verbose").type("bool") .action("store_true") .set_default(false) .help("verbose mode: print debugging information (default: %default)");
@@ -216,6 +216,9 @@ int main(int argc, char** argv) {
 
 	if (options.is_set_by_user("timesteps")) {
 		simulation.setNumTimesteps(options.get("timesteps").operator unsigned long int());
+	}
+	if (options.is_set_by_user("looptime")) {
+		simulation.setLoopTime(options.get("looptime").operator double());
 	}
 	global_log->info() << "Simulating " << simulation.getNumTimesteps() << " steps." << endl;
     

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -35,7 +35,7 @@ void initOptions(optparse::OptionParser *op) {
 		"%prog --tests --test-dir <test input data directory> [<name of testcase>]");
 	op->version("%prog " + MARDYN_VERSION);
 	op->description("ls1-MarDyn (Large Scale SImulation MoleculAR DYNamics)");
-	op->add_option("-t", "--looptime").dest("looptime").type("float") .metavar("NUM") .set_default(-1) .help("seconds of walltime allowed for main loop (default: %default)");
+	op->add_option("-l", "--looptime").dest("looptime").type("float") .metavar("NUM") .set_default(-1) .help("seconds of walltime allowed for main loop (default: %default)");
 	op->add_option("-n", "--steps").dest("timesteps").type("int") .metavar("NUM") .set_default(1) .help("number of timesteps to simulate (default: %default)");
 	op->add_option("-p", "--outprefix").dest("outputprefix").type("string") .metavar("STR") .set_default("MarDyn") .help("default prefix for output files (default: %default)");
 	op->add_option("-v", "--verbose").dest("verbose").type("bool") .action("store_true") .set_default(false) .help("verbose mode: print debugging information (default: %default)");

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -945,7 +945,7 @@ void Simulation::simulate() {
 	Timer perStepTimer;
 	perStepTimer.reset();
 
-	// keppRunning increments the simstep counter before the first iteration
+	// keepRunning() increments the simstep counter before the first iteration
 	_simstep = _initSimulation;
 
 	while (keepRunning()) {

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -204,9 +204,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		global_log->info() << "Number of equilibration steps: " << _initStatistics << endl;
 		xmlconfig.getNodeValue("production/steps", _numberOfTimesteps);
 		global_log->info() << "Number of timesteps: " << _numberOfTimesteps << endl;
-		xmlconfig.getNodeValue("production/walltime", _maxWallTime);
+		xmlconfig.getNodeValue("production/loop-abort-time", _maxWallTime);
 		if(_maxWallTime != -1) {
-			global_log->info() << "Maxmimum Wall time of main loop: " << _maxWallTime << endl;
+			global_log->info() << "Max loop-abort-time set: " << _maxWallTime << endl;
 			_wallTimeEnabled = true;
 		}
 		xmlconfig.changecurrentnode("..");

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -124,6 +124,7 @@ Simulation::Simulation()
 	_loopCompTime(0.0),
 	_loopCompTimeSteps(0.0)
 {
+	_timeFromStart.start();
 	_ensemble = new CanonicalEnsemble();
 	initialize();
 }
@@ -1383,8 +1384,8 @@ bool Simulation::keepRunning() {
 		global_log->info() << "Maximum Simstep reached: " << _simstep << std::endl;
 		return false;
 	}
-	// WallTime Criterion
-	else if(_wallTimeEnabled && global_log->getRunTime() > _maxWallTime){
+	// WallTime Criterion, elapsed time since Simulation constructor
+	else if(_wallTimeEnabled && _timeFromStart.get_etime_running() > _maxWallTime){
 		global_log->info() << "Maximum Walltime reached (s): " << _maxWallTime << std::endl;
 		return false;
 	}

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -203,7 +203,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		global_log->info() << "Number of equilibration steps: " << _initStatistics << endl;
 		xmlconfig.getNodeValue("production/steps", _numberOfTimesteps);
 		global_log->info() << "Number of timesteps: " << _numberOfTimesteps << endl;
-		xmlconfig.getNodeValue("production/looptimelimit", _maxWallTime);
+		xmlconfig.getNodeValue("production/looptime", _maxWallTime);
 		if(_maxWallTime != -1) {
 			global_log->info() << "Maxmimum Wall time of main loop: " << _maxWallTime;
 			_wallTimeEnabled = true;

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -1380,12 +1380,12 @@ bool Simulation::keepRunning() {
 
 	// Simstep Criterion
 	if (_simstep > _numberOfTimesteps){
-		global_log->warning() << "Maximum Simstep reached: " << _simstep << std::endl;
+		global_log->info() << "Maximum Simstep reached: " << _simstep << std::endl;
 		return false;
 	}
 	// WallTime Criterion
 	else if(_wallTimeEnabled && global_log->getRunTime() > _maxWallTime){
-		global_log->warning() << "Maximum Walltime reached (s): " << _maxWallTime << std::endl;
+		global_log->info() << "Maximum Walltime reached (s): " << _maxWallTime << std::endl;
 		return false;
 	}
 	else{

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -205,7 +205,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		global_log->info() << "Number of timesteps: " << _numberOfTimesteps << endl;
 		xmlconfig.getNodeValue("production/looptime", _maxWallTime);
 		if(_maxWallTime != -1) {
-			global_log->info() << "Maxmimum Wall time of main loop: " << _maxWallTime;
+			global_log->info() << "Maxmimum Wall time of main loop: " << _maxWallTime << endl;
 			_wallTimeEnabled = true;
 		}
 		xmlconfig.changecurrentnode("..");

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -203,7 +203,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		global_log->info() << "Number of equilibration steps: " << _initStatistics << endl;
 		xmlconfig.getNodeValue("production/steps", _numberOfTimesteps);
 		global_log->info() << "Number of timesteps: " << _numberOfTimesteps << endl;
-		xmlconfig.getNodeValue("production/looptime", _maxWallTime);
+		xmlconfig.getNodeValue("production/walltime", _maxWallTime);
 		if(_maxWallTime != -1) {
 			global_log->info() << "Maxmimum Wall time of main loop: " << _maxWallTime << endl;
 			_wallTimeEnabled = true;
@@ -946,10 +946,7 @@ void Simulation::simulate() {
 	perStepTimer.reset();
 
 	_simstep = _initSimulation + 1;
-#ifdef ENABLE_MPI
-	_mainLoopStartTime = MPI_Wtime();
-#endif
-	// TODO: TESTING
+
 	while (keepRunning()) {
 		global_log->debug() << "timestep: " << getSimulationStep() << endl;
 		global_log->debug() << "simulation time: " << getSimulationTime() << endl;
@@ -1380,21 +1377,13 @@ void Simulation::initialize() {
 
 bool Simulation::keepRunning() {
 
-#ifdef ENABLE_MPI
-	double time = MPI_Wtime();
-#else
-	double time = 0;
-	global_log->error() << "WallTime only works with MPI support" << std::endl;
-	Simulation::exit(-1);
-#endif
-
 	// Simstep Criterion
 	if (_simstep > _numberOfTimesteps){
 		global_log->warning() << "Maximum Simstep reached: " << _simstep << std::endl;
 		return false;
 	}
 	// WallTime Criterion
-	else if(_wallTimeEnabled && time > _mainLoopStartTime + _maxWallTime){
+	else if(_wallTimeEnabled && global_log->getRunTime() > _maxWallTime){
 		global_log->warning() << "Maximum Walltime reached (s): " << _maxWallTime << std::endl;
 		return false;
 	}

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -945,7 +945,8 @@ void Simulation::simulate() {
 	Timer perStepTimer;
 	perStepTimer.reset();
 
-	_simstep = _initSimulation + 1;
+	// keppRunning increments the simstep counter before the first iteration
+	_simstep = _initSimulation;
 
 	while (keepRunning()) {
 		global_log->debug() << "timestep: " << getSimulationStep() << endl;

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -232,6 +232,8 @@ public:
 	unsigned long getNumInitTimesteps() { return _initSimulation; }
 	/** Get the number of the actual time step currently processed in the simulation. */
 	unsigned long getSimulationStep() { return _simstep; }
+	/** Set Loop Time Limit in seconds */
+	void setLoopTime(double time) { _maxWallTime = time; }
 
 	double getcutoffRadius() const { return _cutoffRadius; }
 	void setcutoffRadius(double cutoffRadius) { _cutoffRadius = cutoffRadius; }

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -459,10 +459,11 @@ public:
 	/** @brief Checks if Simsteps or MaxWallTime are reached */
 	bool keepRunning();
 
+private:
+
+	Timer _timeFromStart;
 	double _maxWallTime = -1;
 	bool _wallTimeEnabled = false;
-
- private:
 
 	/** Enable final checkpoint after simulation run. */
 	bool _finalCheckpoint;

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -233,7 +233,11 @@ public:
 	/** Get the number of the actual time step currently processed in the simulation. */
 	unsigned long getSimulationStep() { return _simstep; }
 	/** Set Loop Time Limit in seconds */
-	void setWallTime(double time) { _maxWallTime = time; }
+	void setWallTime(double time) {
+		global_log->info() << "Max Walltime set: " << time << "\n";
+		_wallTimeEnabled = true;
+		_maxWallTime = time;
+	}
 
 	double getcutoffRadius() const { return _cutoffRadius; }
 	void setcutoffRadius(double cutoffRadius) { _cutoffRadius = cutoffRadius; }

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -233,7 +233,7 @@ public:
 	/** Get the number of the actual time step currently processed in the simulation. */
 	unsigned long getSimulationStep() { return _simstep; }
 	/** Set Loop Time Limit in seconds */
-	void setLoopTime(double time) { _maxWallTime = time; }
+	void setWallTime(double time) { _maxWallTime = time; }
 
 	double getcutoffRadius() const { return _cutoffRadius; }
 	void setcutoffRadius(double cutoffRadius) { _cutoffRadius = cutoffRadius; }
@@ -455,7 +455,6 @@ public:
 	/** @brief Checks if Simsteps or MaxWallTime are reached */
 	bool keepRunning();
 
-	double _mainLoopStartTime;
 	double _maxWallTime = -1;
 	bool _wallTimeEnabled = false;
 

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -450,6 +450,13 @@ public:
 	/** @brief Refresh particle IDs to continuous numbering*/
 	void refreshParticleIDs();
 
+	/** @brief Checks if Simsteps or MaxWallTime are reached */
+	bool keepRunning();
+
+	double _mainLoopStartTime;
+	double _maxWallTime = -1;
+	bool _wallTimeEnabled = false;
+
  private:
 
 	/** Enable final checkpoint after simulation run. */

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -233,8 +233,8 @@ public:
 	/** Get the number of the actual time step currently processed in the simulation. */
 	unsigned long getSimulationStep() { return _simstep; }
 	/** Set Loop Time Limit in seconds */
-	void setWallTime(double time) {
-		global_log->info() << "Max Walltime set: " << time << "\n";
+	void setLoopAbortTime(double time) {
+		global_log->info() << "Max loop-abort-time set: " << time << "\n";
 		_wallTimeEnabled = true;
 		_maxWallTime = time;
 	}

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -252,6 +252,8 @@ public:
 		gettimeofday(&tod, 0);
 		double runTime = tod.tv_sec - _starttime.tv_sec + (tod.tv_usec - _starttime.tv_usec) / 1.E6;
 #else
+		time_t t;
+		t = time(NULL);
 		double runTime = t-_starttime;
 #endif
 	return runTime;

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -245,19 +245,7 @@ public:
 	/// allow a set of processes for logging
 	bool set_mpi_output_ranks(int num_nums, int* nums);
 
-	// getRunTime
-	double getRunTime(){
-#ifdef USE_GETTIMEOFDAY
-		timeval tod;
-		gettimeofday(&tod, 0);
-		double runTime = tod.tv_sec - _starttime.tv_sec + (tod.tv_usec - _starttime.tv_usec) / 1.E6;
-#else
-		time_t t;
-		t = time(NULL);
-		double runTime = t-_starttime;
-#endif
-	return runTime;
-	}
+
 
 }; /* end of class Logger */
 } /* end of namespace */

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -245,6 +245,18 @@ public:
 	/// allow a set of processes for logging
 	bool set_mpi_output_ranks(int num_nums, int* nums);
 
+	// getRunTime
+	double getRunTime(){
+#ifdef USE_GETTIMEOFDAY
+		timeval tod;
+		gettimeofday(&tod, 0);
+		double runTime = tod.tv_sec - _starttime.tv_sec + (tod.tv_usec - _starttime.tv_usec) / 1.E6;
+#else
+		double runTime = t-_starttime;
+#endif
+	return runTime;
+	}
+
 }; /* end of class Logger */
 } /* end of namespace */
 

--- a/src/utils/Timer.h
+++ b/src/utils/Timer.h
@@ -113,6 +113,9 @@ public:
 	double get_etime() {
 		return _etime;
 	}
+	double get_etime_running() {
+		return timer() - _start;
+	}
 	timer_state get_state() {
 		return _state;
 	}


### PR DESCRIPTION
**New XML and CLI option `loop-abort-time`**
---

**Closes** #46

So far, the simulation would stop after a given number of simulation steps. This is however not ideal as sometimes the user might want to use all of the Walltime they are given on a system or simply can't foresee how long a number of simulation steps would take. This leads to wasted compute time or worse, simulations getting canceled by job management.

---
This pull request adds a walltime option both to the XML and CLI that is backwards-compatible, meaning if its not specified it will not trigger. It is specified in **seconds**. If the specified number of steps is reached before the maximum walltime, the simulation is halted as well.

The time measurement is taken from a `Timer` started with the `Simulation` constructor.

`loop-abort-time` in this case includes the setup **and** simulation time. So if `--loop-abort-time 10` is specified, the simulation will trigger a stop and checkpoint write after an iteration that started 10 seconds after the program was launched.

**XML**:
```xml 
<run>
    <production>
        <steps>200</steps>
        <loop-abort-time>10</loop-abort-time>       <!-- New + optional -->
    </production>
</run>
```

**CLI**:
`./MarDyn -a 10`
`./MarDyn --loop-abort-time 10` 