### PR TITLE
Add support for autopas verlet list containers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,20 +91,37 @@ pipeline {
             }
           }
         }
-        stage('run with autopas') {
-          steps {
-            unstash 'repo'
-            unstash 'autopas_exec'
-            dir ("build"){
-              sh """
-                ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas.xml --steps=20 | tee autopas_run_log.txt
-                grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-                grep "T = 0.000633975" simstep20.txt
-                grep "U_pot = -2.14161" simstep20.txt
-                grep "p = 5.34057e-07" simstep20.txt
-              """
+        parallel {
+            stage('run with autopas aos') {
+              steps {
+                unstash 'repo'
+                unstash 'autopas_exec'
+                dir ("build"){
+                  sh """
+                    ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_aos.xml --steps=20 | tee autopas_run_log.txt
+                    grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
+                    grep "T = 0.000633975" simstep20.txt
+                    grep "U_pot = -2.14161" simstep20.txt
+                    grep "p = 5.34057e-07" simstep20.txt
+                  """
+                }
+              }
             }
-          }
+            stage('run with autopas soa') {
+              steps {
+                unstash 'repo'
+                unstash 'autopas_exec'
+                dir ("build"){
+                  sh """
+                    ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_soa.xml --steps=20 | tee autopas_run_log.txt
+                    grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
+                    grep "T = 0.000633975" simstep20.txt
+                    grep "U_pot = -2.14161" simstep20.txt
+                    grep "p = 5.34057e-07" simstep20.txt
+                  """
+                }
+              }
+
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -420,7 +420,7 @@ pipeline {
             dir('unarchive') {
               sh 'tar -xf ../Mardyn-src.tar.gz'
               dir('src') {
-                sh 'make'
+                sh 'make -j4'
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,34 +91,36 @@ pipeline {
             }
           }
         }
-        parallel {
-          stage('run with autopas aos') {
-            steps {
-              unstash 'repo'
-              unstash 'autopas_exec'
-              dir ("build"){
-                sh """
-                  ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_aos.xml --steps=20 | tee autopas_run_log.txt
-                  grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-                  grep "T = 0.000633975" simstep20.txt
-                  grep "U_pot = -2.14161" simstep20.txt
-                  grep "p = 5.34057e-07" simstep20.txt
-                """
+        stage('validation tests with autopas') {
+          parallel {
+            stage('run with autopas aos') {
+              steps {
+                unstash 'repo'
+                unstash 'autopas_exec'
+                dir ("build"){
+                  sh """
+                    ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_aos.xml --steps=20 | tee autopas_run_log.txt
+                    grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
+                    grep "T = 0.000633975" simstep20.txt
+                    grep "U_pot = -2.14161" simstep20.txt
+                    grep "p = 5.34057e-07" simstep20.txt
+                  """
+                }
               }
             }
-          }
-          stage('run with autopas soa') {
-            steps {
-              unstash 'repo'
-              unstash 'autopas_exec'
-              dir ("build"){
-                sh """
-                  ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_soa.xml --steps=20 | tee autopas_run_log.txt
-                  grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-                  grep "T = 0.000633975" simstep20.txt
-                  grep "U_pot = -2.14161" simstep20.txt
-                  grep "p = 5.34057e-07" simstep20.txt
-                """
+            stage('run with autopas soa') {
+              steps {
+                unstash 'repo'
+                unstash 'autopas_exec'
+                dir ("build"){
+                  sh """
+                    ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_soa.xml --steps=20 | tee autopas_run_log.txt
+                    grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
+                    grep "T = 0.000633975" simstep20.txt
+                    grep "U_pot = -2.14161" simstep20.txt
+                    grep "p = 5.34057e-07" simstep20.txt
+                  """
+                }
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,36 +92,36 @@ pipeline {
           }
         }
         parallel {
-            stage('run with autopas aos') {
-              steps {
-                unstash 'repo'
-                unstash 'autopas_exec'
-                dir ("build"){
-                  sh """
-                    ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_aos.xml --steps=20 | tee autopas_run_log.txt
-                    grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-                    grep "T = 0.000633975" simstep20.txt
-                    grep "U_pot = -2.14161" simstep20.txt
-                    grep "p = 5.34057e-07" simstep20.txt
-                  """
-                }
+          stage('run with autopas aos') {
+            steps {
+              unstash 'repo'
+              unstash 'autopas_exec'
+              dir ("build"){
+                sh """
+                  ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_aos.xml --steps=20 | tee autopas_run_log.txt
+                  grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
+                  grep "T = 0.000633975" simstep20.txt
+                  grep "U_pot = -2.14161" simstep20.txt
+                  grep "p = 5.34057e-07" simstep20.txt
+                """
               }
             }
-            stage('run with autopas soa') {
-              steps {
-                unstash 'repo'
-                unstash 'autopas_exec'
-                dir ("build"){
-                  sh """
-                    ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_soa.xml --steps=20 | tee autopas_run_log.txt
-                    grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-                    grep "T = 0.000633975" simstep20.txt
-                    grep "U_pot = -2.14161" simstep20.txt
-                    grep "p = 5.34057e-07" simstep20.txt
-                  """
-                }
+          }
+          stage('run with autopas soa') {
+            steps {
+              unstash 'repo'
+              unstash 'autopas_exec'
+              dir ("build"){
+                sh """
+                  ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_soa.xml --steps=20 | tee autopas_run_log.txt
+                  grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
+                  grep "T = 0.000633975" simstep20.txt
+                  grep "U_pot = -2.14161" simstep20.txt
+                  grep "p = 5.34057e-07" simstep20.txt
+                """
               }
-
+            }
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,31 +95,35 @@ pipeline {
           parallel {
             stage('run with autopas aos') {
               steps {
-                unstash 'repo'
-                unstash 'autopas_exec'
-                dir ("build"){
-                  sh """
-                    ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_aos.xml --steps=20 | tee autopas_run_log.txt
-                    grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-                    grep "T = 0.000633975" simstep20.txt
-                    grep "U_pot = -2.14161" simstep20.txt
-                    grep "p = 5.34057e-07" simstep20.txt
-                  """
+                dir('aostest'){
+                  unstash 'repo'
+                  unstash 'autopas_exec'
+                  dir ("build"){
+                    sh """
+                      ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_aos.xml --steps=20 | tee autopas_run_log.txt
+                      grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
+                      grep "T = 0.000633975" simstep20.txt
+                      grep "U_pot = -2.14161" simstep20.txt
+                      grep "p = 5.34057e-07" simstep20.txt
+                    """
+                  }
                 }
               }
             }
             stage('run with autopas soa') {
               steps {
-                unstash 'repo'
-                unstash 'autopas_exec'
-                dir ("build"){
-                  sh """
-                    ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_soa.xml --steps=20 | tee autopas_run_log.txt
-                    grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-                    grep "T = 0.000633975" simstep20.txt
-                    grep "U_pot = -2.14161" simstep20.txt
-                    grep "p = 5.34057e-07" simstep20.txt
-                  """
+                dir('soatest'){
+                  unstash 'repo'
+                  unstash 'autopas_exec'
+                  dir ("build"){
+                    sh """
+                      ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_soa.xml --steps=20 | tee autopas_run_log.txt
+                      grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
+                      grep "T = 0.000633975" simstep20.txt
+                      grep "U_pot = -2.14161" simstep20.txt
+                      grep "p = 5.34057e-07" simstep20.txt
+                    """
+                  }
                 }
               }
             }

--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -17,7 +17,8 @@ if(ENABLE_AUTOPAS)
     ExternalProject_Add(
             autopas
             GIT_REPOSITORY ${autopasRepoPath}
-            GIT_TAG origin/master
+            #GIT_TAG origin/master
+            GIT_TAG origin/feature/blackBoxVerlet
             #URL https://github.com/AutoPas/AutoPas/archive/0c3d8b07a2e38940057fafd21b98645cb074e729.zip # zip option
             #${CMAKE_SOURCE_DIR}/libs/googletest-master.zip # bundled option
             #URL_HASH MD5=6e70656897167140c1221eecc6ad872d

--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -17,7 +17,8 @@ if(ENABLE_AUTOPAS)
     ExternalProject_Add(
             autopas
             GIT_REPOSITORY ${autopasRepoPath}
-            GIT_TAG origin/master
+            #GIT_TAG origin/master
+            GIT_TAG feature/verletListAutoPasInterfaceUsabilityChanges
             #URL https://github.com/AutoPas/AutoPas/archive/0c3d8b07a2e38940057fafd21b98645cb074e729.zip # zip option
             #${CMAKE_SOURCE_DIR}/libs/googletest-master.zip # bundled option
             #URL_HASH MD5=6e70656897167140c1221eecc6ad872d

--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -17,8 +17,7 @@ if(ENABLE_AUTOPAS)
     ExternalProject_Add(
             autopas
             GIT_REPOSITORY ${autopasRepoPath}
-            #GIT_TAG origin/master
-            GIT_TAG feature/verletListAutoPasInterfaceUsabilityChanges
+            GIT_TAG origin/master
             #URL https://github.com/AutoPas/AutoPas/archive/0c3d8b07a2e38940057fafd21b98645cb074e729.zip # zip option
             #${CMAKE_SOURCE_DIR}/libs/googletest-master.zip # bundled option
             #URL_HASH MD5=6e70656897167140c1221eecc6ad872d

--- a/examples/Argon/200K_18mol_l/config.xml
+++ b/examples/Argon/200K_18mol_l/config.xml
@@ -42,37 +42,10 @@
       </electrostatic>
     </algorithm>
     <output>
-      <outputplugin name="MmpldWriter" type="simple">
-        <include query="/spheres">../sphereparams_argon.xml</include>
-        <writecontrol>
-          <start>0</start>
-          <writefrequency>100</writefrequency>
-          <stop>1000000000</stop>
-          <framesperfile>0</framesperfile>
-        </writecontrol>
-        <outputprefix>megamol</outputprefix>
-      </outputplugin>
-      <outputplugin name="ResultWriter">
-        <writefrequency>5</writefrequency>
-        <outputprefix>Argon</outputprefix>
-      </outputplugin>
-<!--<outputplugin name="FlopRateWriter">
+      <outputplugin name="HaloParticleWriter" >
         <writefrequency>1</writefrequency>
-        <outputprefix>Argon_FLOPS</outputprefix>
-        <mode>stdout</mode>
-      </outputplugin>-->
-      <outputplugin name="SysMonOutput">
-        <writefrequency>10000</writefrequency>
-        <expression label="LoadAvg1">procloadavg:loadavg1</expression>
-        <expression label="Free+BufferRAM [MB]">sysinfo:freeram sysinfo:bufferram + sysinfo:mem_unit * float 1048576 /</expression>
-      </outputplugin>
-      <outputplugin name="VTKMoleculeWriter">
-        <outputprefix>vtkOutput</outputprefix>
-        <writefrequency>1</writefrequency>
+        <outputprefix>halonoauto</outputprefix>
       </outputplugin>
     </output>
-	<plugin name="TestPlugin">
-		<writefrequency>1</writefrequency>
-	</plugin>
   </simulation>
 </mardyn>

--- a/examples/Argon/200K_18mol_l/config_autopas-vl.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas-vl.xml
@@ -48,32 +48,10 @@
       </electrostatic>
     </algorithm>
     <output>
-      <outputplugin name="MmpldWriter" type="simple">
-        <include query="/spheres">../sphereparams_argon.xml</include>
-        <writecontrol>
-          <start>0</start>
-          <writefrequency>100</writefrequency>
-          <stop>1000000000</stop>
-          <framesperfile>0</framesperfile>
-        </writecontrol>
-        <outputprefix>megamol</outputprefix>
-      </outputplugin>
-      <!-- <outputplugin name="ResultWriter"> -->
-        <!-- <writefrequency>5</writefrequency> -->
-        <!-- <outputprefix>Argon</outputprefix> -->
-      <!-- </outputplugin> -->
-      <outputplugin name="SysMonOutput">
-        <writefrequency>10000</writefrequency>
-        <expression label="LoadAvg1">procloadavg:loadavg1</expression>
-        <expression label="Free+BufferRAM [MB]">sysinfo:freeram sysinfo:bufferram + sysinfo:mem_unit * float 1048576 /</expression>
-      </outputplugin>
-      <outputplugin name="VTKMoleculeWriter">
-        <outputprefix>vtkOutput</outputprefix>
+      <outputplugin name="HaloParticleWriter">
+        <outputprefix>haloauto</outputprefix>
         <writefrequency>1</writefrequency>
       </outputplugin>
     </output>
-	<plugin name="TestPlugin">
-		<writefrequency>1</writefrequency>
-	</plugin>
   </simulation>
 </mardyn>

--- a/examples/Argon/200K_18mol_l/config_autopas_aos.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_aos.xml
@@ -32,6 +32,7 @@
     <algorithm>
       <parallelisation type="DomainDecomposition"/>
       <datastructure type="AutoPas">
+	<blackBoxMode>true</blackBoxMode>
         <allowedTraversals>c01, c08, c18, sli, directsumtraversal</allowedTraversals>
         <allowedContainers>linkedCells, verletLists, directsum</allowedContainers>
         <traversalSelectorStrategy>fastestMedian</traversalSelectorStrategy>

--- a/examples/Argon/200K_18mol_l/config_autopas_lc.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_lc.xml
@@ -32,7 +32,7 @@
     <algorithm>
       <parallelisation type="DomainDecomposition"/>
       <datastructure type="AutoPas">
-        <allowedTraversals>c01, c08, c18, sli</allowedTraversals>
+        <allowedTraversals>c08, c18, sli</allowedTraversals>
         <allowedContainers>linkedCells</allowedContainers>
         <traversalSelectorStrategy>fastestMedian</traversalSelectorStrategy>
         <containerSelectorStrategy>fastestMedian</containerSelectorStrategy>

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -213,8 +213,10 @@
           - vcluster
           -->
         <allowedContainers>linkedCells, vcells, vcluster</allowedContainers>
+	<!-- specify whether the blackboxmode shall be used -->
+        <blackBoxMode>true</blackBoxMode>
         <!-- specify what metric the respective selector should use to determine the optimal traversal -->
-        <!-- possible values: fastetAbsolute, fastestMean, fastestMedian -->
+	<!-- possible values: fastetAbsolute, fastestMean, fastestMedian -->
         <traversalSelectorStrategy>fastestMedian</traversalSelectorStrategy>
         <containerSelectorStrategy>fastestMedian</containerSelectorStrategy>
         <!-- Data layout to be used: AoS or SoA -->

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -450,7 +450,7 @@ void Domain::calculateVelocitySums(ParticleContainer* partCont)
 		#endif
 		{
 
-			for(auto tM = partCont->iterator(); tM.isValid(); ++tM) {
+			for(auto tM = partCont->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tM.isValid(); ++tM) {
 				++N;
 				rotationalDOF += tM->component()->getRotationalDegreesOfFreedom();
 				if(this->_universalUndirectedThermostat[0]) {

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -974,8 +974,9 @@ void Simulation::simulate() {
 
 		// TODO: test deletions and insertions
 		global_log->debug() << "Deleting outer particles / clearing halo." << endl;
-		_moleculeContainer->deleteOuterParticles();
-
+		if(not _moleculeContainer->isVerletContainer()) {
+			_moleculeContainer->deleteOuterParticles();
+		}
 
 		if (!(_simstep % _collectThermostatDirectedVelocity))
 			_domain->calculateThermostatDirectedVelocity(_moleculeContainer);
@@ -1163,6 +1164,9 @@ void Simulation::updateParticleContainerAndDecomposition(double lastTraversalTim
 		_domainDecomposition->doVerletHaloCopy(_moleculeContainer, _domain);
 		global_simulation->timers()->stop("SIMULATION_MPI_OMP_COMMUNICATION");
 	} else {
+		if(isVerlet){
+			_moleculeContainer->deleteOuterParticles();
+		}
 		// The particles have moved, so the neighborhood relations have
 		// changed and have to be adjusted
 		_moleculeContainer->update();

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -1181,9 +1181,9 @@ void Simulation::updateParticleContainerAndDecomposition(double lastTraversalTim
 }
 
 void Simulation::performOverlappingDecompositionAndCellTraversalStep(double etime) {
-	bool forceRebalancing = false;
-
 	#ifdef ENABLE_MPI
+		bool forceRebalancing = false;
+
 		#ifdef ENABLE_OVERLAPPING
 			NonBlockingMPIHandlerBase* nonBlockingMPIHandler =
 					new NonBlockingMPIMultiStepHandler(static_cast<DomainDecompMPIBase*>(_domainDecomposition), _moleculeContainer, _domain, _cellProcessor);

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -1153,12 +1153,18 @@ void Simulation::finalize() {
 
 void Simulation::updateParticleContainerAndDecomposition(double lastTraversalTime) {
 	bool isVerlet = _moleculeContainer->isVerletContainer();
-	bool reuseVerlet = false;
+	bool reuseVerlet = false, haloCopyValid = false;
 	if(isVerlet){
 		reuseVerlet = _moleculeContainer->queryVerletListsValid();
+		global_log->info() << "VerletList container detected! VerletListsValid: " << (reuseVerlet ? "true" : "false")
+						   << std::endl;
+		haloCopyValid = _domainDecomposition->haloCopyValid();
+		global_log->info() << "VerletList container detected! haloCopyValid: " << (haloCopyValid ? "true" : "false")
+		                   << std::endl;
 	}
 
-	if(reuseVerlet) {
+
+	if(reuseVerlet and haloCopyValid) {
 		// if we are reusing verlet lists, call different functions of the _domainDecomposition
 		global_simulation->timers()->start("SIMULATION_MPI_OMP_COMMUNICATION");
 		_domainDecomposition->doVerletHaloCopy(_moleculeContainer, _domain);

--- a/src/ensemble/CanonicalEnsemble.cpp
+++ b/src/ensemble/CanonicalEnsemble.cpp
@@ -46,7 +46,7 @@ void CanonicalEnsemble::updateGlobalVariable(ParticleContainer* particleContaine
 		{
 			std::vector<unsigned long> numMolecules_private(numComponents, 0ul);
 
-			for(auto molecule = particleContainer->iterator(); molecule.isValid(); ++molecule) {
+			for(auto molecule = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); molecule.isValid(); ++molecule) {
 				numMolecules_private[molecule->componentid()]++;
 			}
 

--- a/src/integrators/Leapfrog.cpp
+++ b/src/integrators/Leapfrog.cpp
@@ -55,7 +55,7 @@ void Leapfrog::transition1to2(ParticleContainer* molCont, Domain* /*domain*/) {
 	#pragma omp parallel
 	#endif
 	{
-		for (auto i = molCont->iterator(); i.isValid(); ++i) {
+		for (auto i = molCont->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); i.isValid(); ++i) {
 			i->upd_preF(_timestepLength);
 		}
 	}
@@ -121,7 +121,7 @@ void Leapfrog::transition2to3(ParticleContainer* molCont, Domain* domain) {
 			double summv2gt_l = 0.0;
 			double sumIw2gt_l = 0.0;
 
-			for (auto i = molCont->iterator(); i.isValid(); ++i) {
+			for (auto i = molCont->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); i.isValid(); ++i) {
 				i->upd_postF(dt_half, summv2gt_l, sumIw2gt_l);
 				mardyn_assert(summv2gt_l >= 0.0);
 				Ngt_l++;

--- a/src/io/tests/RDFTest.cpp
+++ b/src/io/tests/RDFTest.cpp
@@ -92,7 +92,7 @@ void RDFTest::testRDFCountSequential12(ParticleContainer* moleculeContainer) {
 	rdf.tickRDF();
 
 	// now the same with halo particles present.
-	_domainDecomposition->balanceAndExchange(0., false, moleculeContainer, _domain, false);
+	_domainDecomposition->balanceAndExchange(0., false, moleculeContainer, _domain);
 	moleculeContainer->traverseCells(cellProcessor);
 	rdf.collectRDF(_domainDecomposition);
 	rdf.accumulateRDF();
@@ -134,7 +134,7 @@ void RDFTest::testRDFCount(ParticleContainer* moleculeContainer) {
 	ASSERT_EQUAL((size_t) 1, components->size());
 
 	moleculeContainer->deleteOuterParticles();
-	_domainDecomposition->balanceAndExchange(1.0, false, moleculeContainer, _domain, false);
+	_domainDecomposition->balanceAndExchange(1.0, false, moleculeContainer, _domain);
 	moleculeContainer->updateMoleculeCaches();
 
 	RDF rdf;
@@ -164,7 +164,7 @@ void RDFTest::testRDFCount(ParticleContainer* moleculeContainer) {
 	rdf.reset();
 
 	moleculeContainer->deleteOuterParticles();
-	_domainDecomposition->balanceAndExchange(1.0, false, moleculeContainer, _domain, false);
+	_domainDecomposition->balanceAndExchange(1.0, false, moleculeContainer, _domain);
 	moleculeContainer->updateMoleculeCaches();
 
 	rdf.tickRDF();
@@ -213,7 +213,7 @@ void RDFTest::testSiteSiteRDF(ParticleContainer* moleculeContainer) {
 	vector<Component>* components = global_simulation->getEnsemble()->getComponents();
 	ASSERT_EQUAL((size_t) 1, components->size());
 
-	_domainDecomposition->balanceAndExchange(1.0, true, moleculeContainer, _domain, false);
+	_domainDecomposition->balanceAndExchange(1.0, true, moleculeContainer, _domain);
 	moleculeContainer->update();
 	moleculeContainer->updateMoleculeCaches();
 

--- a/src/io/tests/RDFTest.cpp
+++ b/src/io/tests/RDFTest.cpp
@@ -92,7 +92,7 @@ void RDFTest::testRDFCountSequential12(ParticleContainer* moleculeContainer) {
 	rdf.tickRDF();
 
 	// now the same with halo particles present.
-	_domainDecomposition->exchangeMolecules(moleculeContainer, _domain);
+	_domainDecomposition->balanceAndExchange(0., false, moleculeContainer, _domain, false);
 	moleculeContainer->traverseCells(cellProcessor);
 	rdf.collectRDF(_domainDecomposition);
 	rdf.accumulateRDF();

--- a/src/io/tests/RDFTest.cpp
+++ b/src/io/tests/RDFTest.cpp
@@ -31,11 +31,9 @@ TEST_SUITE_REGISTRATION(RDFTest);
 #endif
 
 
-RDFTest::RDFTest() {
-}
+RDFTest::RDFTest() = default;
 
-RDFTest::~RDFTest() {
-}
+RDFTest::~RDFTest() = default;
 
 
 void RDFTest::initRDF(RDF &rdf, double intervalLength, unsigned int bins, std::vector<Component>* components) {
@@ -136,7 +134,7 @@ void RDFTest::testRDFCount(ParticleContainer* moleculeContainer) {
 	ASSERT_EQUAL((size_t) 1, components->size());
 
 	moleculeContainer->deleteOuterParticles();
-	_domainDecomposition->balanceAndExchange(1.0, false, moleculeContainer, _domain);
+	_domainDecomposition->balanceAndExchange(1.0, false, moleculeContainer, _domain, false);
 	moleculeContainer->updateMoleculeCaches();
 
 	RDF rdf;
@@ -166,7 +164,7 @@ void RDFTest::testRDFCount(ParticleContainer* moleculeContainer) {
 	rdf.reset();
 
 	moleculeContainer->deleteOuterParticles();
-	_domainDecomposition->balanceAndExchange(1.0, false, moleculeContainer, _domain);
+	_domainDecomposition->balanceAndExchange(1.0, false, moleculeContainer, _domain, false);
 	moleculeContainer->updateMoleculeCaches();
 
 	rdf.tickRDF();
@@ -215,7 +213,7 @@ void RDFTest::testSiteSiteRDF(ParticleContainer* moleculeContainer) {
 	vector<Component>* components = global_simulation->getEnsemble()->getComponents();
 	ASSERT_EQUAL((size_t) 1, components->size());
 
-	_domainDecomposition->balanceAndExchange(1.0, true, moleculeContainer, _domain);
+	_domainDecomposition->balanceAndExchange(1.0, true, moleculeContainer, _domain, false);
 	moleculeContainer->update();
 	moleculeContainer->updateMoleculeCaches();
 

--- a/src/molecules/MoleculeInterface.h
+++ b/src/molecules/MoleculeInterface.h
@@ -41,8 +41,8 @@ public:
 	}
 	virtual double r(unsigned short d) const = 0;
 	std::array<double, 3> r_arr() const {
-		std::array<double, 3> ret;
-		for(int d=0; d < 3; ++d) {
+		std::array<double, 3> ret{};
+		for (unsigned short d = 0; d < 3; ++d) {
 			ret[d] = r(d);
 		}
 		return ret;

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -243,7 +243,7 @@ void DomainDecompBase::populateHaloLayerWithCopies(unsigned dim, ParticleContain
 		auto& listI = _verletHaloSendingList[shiftVec];
 		double shift = shiftMagnitude * (-direction);
 
-		double cutoff = moleculeContainer->getCutoff();
+		double cutoff = moleculeContainer->getCutoff() + moleculeContainer->getSkin();
 		double startRegion[3]{moleculeContainer->getBoundingBoxMin(0) - cutoff,
 							  moleculeContainer->getBoundingBoxMin(1) - cutoff,
 							  moleculeContainer->getBoundingBoxMin(2) - cutoff};

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -333,8 +333,14 @@ bool DomainDecompBase::queryBalanceAndExchangeNonBlocking(bool /*forceRebalancin
 	return false;
 }
 
-void DomainDecompBase::balanceAndExchange(double /*lastTraversalTime*/, bool /* forceRebalancing */, ParticleContainer* moleculeContainer, Domain* domain) {
+void DomainDecompBase::balanceAndExchange(double /*lastTraversalTime*/, bool /* forceRebalancing */,
+										  ParticleContainer* moleculeContainer, Domain* domain,
+										  bool generateVerletHaloCopyList) {
 	exchangeMolecules(moleculeContainer, domain);
+}
+
+void DomainDecompBase::doVerletHaloCopy(ParticleContainer* moleculeContainer, Domain* domain){
+
 }
 
 bool DomainDecompBase::procOwnsPos(double x, double y, double z, Domain* domain) {

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -385,7 +385,7 @@ void DomainDecompBase::doVerletHaloCopy(ParticleContainer* moleculeContainer, Do
 					}
 				} else {
 					double pos[3] = {m.r(0), m.r(1), m.r(2)};
-					Molecule* haloPointer = moleculeContainer->getMoleculeCloseToPosition(pos, m.getID());
+					Molecule* haloPointer = moleculeContainer->getHaloMoleculeCloseToPosition(pos, m.getID());
 					for(unsigned short dim = 0; dim < 3; ++dim) {
 						haloPointer->setr(dim, pos[dim]);
 					}

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -3,8 +3,7 @@
 #include "Domain.h"
 #include "molecules/Molecule.h"
 
-DomainDecompBase::DomainDecompBase() : _rank(0), _numProcs(1) {
-}
+DomainDecompBase::DomainDecompBase() : _rank(0), _numProcs(1), _verletHaloSendingList{}, _verletHaloReceivingList{} {}
 
 DomainDecompBase::~DomainDecompBase() {
 }
@@ -17,10 +16,10 @@ void DomainDecompBase::exchangeMolecules(ParticleContainer* moleculeContainer, b
 	for (unsigned d = 0; d < 3; ++d) {
 		handleDomainLeavingParticles(d, moleculeContainer);
 	}
-	if(generateVerletHaloCopyList){
-		_verletHaloSendingList.clear();
-		_verletHaloReceivingList.clear();
-	}
+
+	_verletHaloSendingList.clear();
+	_verletHaloReceivingList.clear();
+
 	for (unsigned d = 0; d < 3; ++d) {
 		populateHaloLayerWithCopies(d, moleculeContainer, generateVerletHaloCopyList);
 	}
@@ -290,7 +289,9 @@ void DomainDecompBase::populateHaloLayerWithCopies(unsigned dim, ParticleContain
 				moleculeContainer->addHaloParticle(m);
 			}
 		}
-		_verletHaloSendingList.emplace_back(shiftVec, listI);
+		if(generateVerletHaloCopyList) {
+			_verletHaloSendingList.emplace_back(shiftVec, listI);
+		}
 	}
 }
 

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -1,13 +1,7 @@
 #include "parallel/DomainDecompBase.h"
 #include "Simulation.h"
 #include "Domain.h"
-#include "ensemble/EnsembleBase.h"
-#include "particleContainer/ParticleContainer.h"
 #include "molecules/Molecule.h"
-#include "utils/mardyn_assert.h"
-
-#include <fstream>
-#include <cmath>
 
 DomainDecompBase::DomainDecompBase() : _rank(0), _numProcs(1) {
 }

--- a/src/parallel/DomainDecompBase.h
+++ b/src/parallel/DomainDecompBase.h
@@ -101,11 +101,19 @@ public:
 	//! This method is then also responsible for redistributing all particles, so after the
 	//! method was called, each process has a domain with all particles belonging to this
 	//! domain (as if exchangeParticles was called after the new decomposition).
-	//! @param balance if true, a rebalancing is forced;
+	//! @param lastTraversalTime Time it took to iterate through the last traversal. Can be used to check the load
+	//! balance.
+	//! @param forceRebalancing if true, a rebalancing is forced;
 	//! 					otherwise automatic balancing of Decomposition is applied
 	//! @param moleculeContainer needed for calculating load and to get the particles
 	//! @param domain is e.g. needed to get the size of the local domain
-	virtual void balanceAndExchange(double lastTraversalTime, bool forceRebalancing, ParticleContainer* moleculeContainer, Domain* domain);
+	//! @param generateVerletHaloCopyList decides, whether a list of halo molecules for the verlet generation should be
+	//! build.
+	virtual void balanceAndExchange(double lastTraversalTime, bool forceRebalancing,
+									ParticleContainer* moleculeContainer, Domain* domain,
+									bool generateVerletHaloCopyList);
+
+	virtual void doVerletHaloCopy(ParticleContainer* moleculeContainer, Domain* domain);
 
 	//! @brief find out whether the given position belongs to the domain of this process
 	//!

--- a/src/parallel/DomainDecompBase.h
+++ b/src/parallel/DomainDecompBase.h
@@ -337,8 +337,8 @@ protected:
 	int _numProcs;
 
 private:
-	std::map<std::array<int, 3>, std::vector<Molecule*>> _verletHaloSendingList;
-	std::map<std::array<int, 3>, std::vector<Molecule*>> _verletHaloReceivingList;
+	std::vector<std::pair<std::array<int, 3>, std::vector<Molecule*>>> _verletHaloSendingList;
+	std::vector<std::pair<std::array<int, 3>, std::vector<Molecule*>>> _verletHaloReceivingList;
 	CollectiveCommBase _collCommBase;
 	int _sendLeavingAndCopiesSeparately = 0;
 };

--- a/src/parallel/DomainDecompBase.h
+++ b/src/parallel/DomainDecompBase.h
@@ -50,6 +50,7 @@ class DomainDecompBase: public MemoryProfilable {
 	friend class NeighbourCommunicationScheme;
 	friend class IndirectNeighbourCommunicationScheme;
 	friend class DirectNeighbourCommunicationScheme;
+	friend class DomainDecompBaseTest;
 public:
 	//! @brief The Constructor determines the own rank and the number of the neighbours                                                       */
 	DomainDecompBase();
@@ -58,16 +59,6 @@ public:
 	virtual ~DomainDecompBase();
 
 	virtual void readXML(XMLfileUnits& xmlconfig);
-
-	//! @brief exchange molecules between processes
-	//!
-	//! molecules which aren't in the domain of their process any
-	//! more are transferred to their neighbours. Additionally, the
-	//! molecules for the halo-region are transferred.
-	//! This implementation is the one used in sequential mode.
-	//! @param moleculeContainer needed to get those molecules which have to be exchanged
-	//! @param domain is e.g. needed to get the size of the local domain
-	void exchangeMolecules(ParticleContainer* moleculeContainer, Domain* domain);
 
 	/**
 	 * @brief Exchanges forces at the domain boundaries if it's required by the cell container.
@@ -289,6 +280,16 @@ public:
 	virtual void printCommunicationPartners(std::string filename) const {};
 
 protected:
+	//! @brief exchange molecules between processes
+	//!
+	//! molecules which aren't in the domain of their process any
+	//! more are transferred to their neighbours. Additionally, the
+	//! molecules for the halo-region are transferred.
+	//! This implementation is the one used in sequential mode.
+	//! @param moleculeContainer needed to get those molecules which have to be exchanged
+	//! @param domain is e.g. needed to get the size of the local domain
+	void exchangeMolecules(ParticleContainer* moleculeContainer, Domain* domain);
+
 	/**
 	 * Handles the sequential version of particles leaving the domain.
 	 * Also used as a fall-back for the MPI variant if a process spans an entire dimension.

--- a/src/parallel/DomainDecompBase.h
+++ b/src/parallel/DomainDecompBase.h
@@ -101,12 +101,9 @@ public:
 	//! @param generateVerletHaloCopyList Determines, whether a list of halo molecules for the verlet generation should be
 	//! build.
 	virtual void balanceAndExchange(double lastTraversalTime, bool forceRebalancing,
-									ParticleContainer* moleculeContainer, Domain* domain,
-									bool generateVerletHaloCopyList);
+									ParticleContainer* moleculeContainer, Domain* domain);
 
 	virtual void doVerletHaloCopy(ParticleContainer* moleculeContainer, Domain* domain);
-
-	virtual bool haloCopyValid() { return _verletHaloSendingList.size() != 0; }
 
 	//! @brief find out whether the given position belongs to the domain of this process
 	//!

--- a/src/parallel/DomainDecompBase.h
+++ b/src/parallel/DomainDecompBase.h
@@ -106,6 +106,8 @@ public:
 
 	virtual void doVerletHaloCopy(ParticleContainer* moleculeContainer, Domain* domain);
 
+	virtual bool haloCopyValid() { return _verletHaloSendingList.size() != 0; }
+
 	//! @brief find out whether the given position belongs to the domain of this process
 	//!
 	//! This method is e.g. used by a particle generator which creates particles within

--- a/src/parallel/DomainDecompBase.h
+++ b/src/parallel/DomainDecompBase.h
@@ -98,7 +98,7 @@ public:
 	//! 					otherwise automatic balancing of Decomposition is applied
 	//! @param moleculeContainer needed for calculating load and to get the particles
 	//! @param domain is e.g. needed to get the size of the local domain
-	//! @param generateVerletHaloCopyList decides, whether a list of halo molecules for the verlet generation should be
+	//! @param generateVerletHaloCopyList Determines, whether a list of halo molecules for the verlet generation should be
 	//! build.
 	virtual void balanceAndExchange(double lastTraversalTime, bool forceRebalancing,
 									ParticleContainer* moleculeContainer, Domain* domain,
@@ -287,8 +287,9 @@ protected:
 	//! molecules for the halo-region are transferred.
 	//! This implementation is the one used in sequential mode.
 	//! @param moleculeContainer needed to get those molecules which have to be exchanged
-	//! @param domain is e.g. needed to get the size of the local domain
-	void exchangeMolecules(ParticleContainer* moleculeContainer, Domain* domain);
+	//! @param generateVerletHaloCopyList Determines, whether a list of halo molecules for the verlet generation should be
+	//! build.
+	void exchangeMolecules(ParticleContainer* moleculeContainer, bool generateVerletHaloCopyList);
 
 	/**
 	 * Handles the sequential version of particles leaving the domain.
@@ -324,7 +325,8 @@ protected:
 	 */
 	virtual void handleForceExchangeDirect(const HaloRegion& haloRegion, ParticleContainer* moleculeContainer) const;
 
-	void populateHaloLayerWithCopies(unsigned dim, ParticleContainer* moleculeContainer) const;
+	void populateHaloLayerWithCopies(unsigned dim, ParticleContainer* moleculeContainer,
+									 bool generateVerletHaloCopyList);
 
 	void populateHaloLayerWithCopiesDirect(const HaloRegion& haloRegion, ParticleContainer* moleculeContainer) const;
 
@@ -335,6 +337,8 @@ protected:
 	int _numProcs;
 
 private:
+	std::map<std::array<int, 3>, std::vector<Molecule*>> _verletHaloSendingList;
+	std::map<std::array<int, 3>, std::vector<Molecule*>> _verletHaloReceivingList;
 	CollectiveCommBase _collCommBase;
 	int _sendLeavingAndCopiesSeparately = 0;
 };

--- a/src/parallel/DomainDecomposition.cpp
+++ b/src/parallel/DomainDecomposition.cpp
@@ -67,7 +67,7 @@ bool DomainDecomposition::queryBalanceAndExchangeNonBlocking(bool /*forceRebalan
 }
 
 void DomainDecomposition::balanceAndExchange(double /*lastTraversalTime*/, bool /*forceRebalancing*/, ParticleContainer* moleculeContainer,
-		Domain* domain) {
+		Domain* domain, bool generateVerletHaloCopyList) {
 	if(sendLeavingWithCopies()){
 		DomainDecompMPIBase::exchangeMoleculesMPI(moleculeContainer, domain, LEAVING_AND_HALO_COPIES);
 	}else{

--- a/src/parallel/DomainDecomposition.cpp
+++ b/src/parallel/DomainDecomposition.cpp
@@ -67,7 +67,11 @@ bool DomainDecomposition::queryBalanceAndExchangeNonBlocking(bool /*forceRebalan
 }
 
 void DomainDecomposition::balanceAndExchange(double /*lastTraversalTime*/, bool /*forceRebalancing*/, ParticleContainer* moleculeContainer,
-		Domain* domain, bool generateVerletHaloCopyList) {
+		Domain* domain) {
+	if(moleculeContainer->isVerletContainer()) {
+		moleculeContainer->deleteOuterParticles();
+	}
+	moleculeContainer->update();
 	if(sendLeavingWithCopies()){
 		DomainDecompMPIBase::exchangeMoleculesMPI(moleculeContainer, domain, LEAVING_AND_HALO_COPIES);
 	}else{

--- a/src/parallel/DomainDecomposition.h
+++ b/src/parallel/DomainDecomposition.h
@@ -1,5 +1,4 @@
-#ifndef DOMAINDECOMPOSITION_H_
-#define DOMAINDECOMPOSITION_H_
+#pragma once
 
 #include "DomainDecompMPIBase.h"
 
@@ -47,7 +46,8 @@ public:
 	// documentation see father class (DomainDecompBase.h)
 	double getBoundingBoxMax(int dimension, Domain* domain) override;
 
-	void balanceAndExchange(double lastTraversalTime, bool forceRebalancing, ParticleContainer* moleculeContainer, Domain* domain) override;
+	void balanceAndExchange(double lastTraversalTime, bool forceRebalancing, ParticleContainer* moleculeContainer,
+							Domain* domain, bool generateVerletHaloCopyList) override;
 
 	//! @brief writes information about the current decomposition into the given file
 	//!
@@ -111,5 +111,3 @@ private:
 	int _gridSize[DIMgeom]; //!< Number of processes in each dimension of the MPI process grid
 	int _coords[DIMgeom]; //!< Coordinate of the process in the MPI process grid
 };
-
-#endif /* DOMAINDECOMPOSITION_H_ */

--- a/src/parallel/DomainDecomposition.h
+++ b/src/parallel/DomainDecomposition.h
@@ -47,7 +47,7 @@ public:
 	double getBoundingBoxMax(int dimension, Domain* domain) override;
 
 	void balanceAndExchange(double lastTraversalTime, bool forceRebalancing, ParticleContainer* moleculeContainer,
-							Domain* domain, bool generateVerletHaloCopyList) override;
+							Domain* domain) override;
 
 	//! @brief writes information about the current decomposition into the given file
 	//!

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -219,8 +219,12 @@ bool KDDecomposition::checkNeedRebalance(double lastTraversalTime) {
 }
 
 void KDDecomposition::balanceAndExchange(double lastTraversalTime, bool forceRebalancing,
-										 ParticleContainer* moleculeContainer, Domain* domain,
-										 bool generateVerletHaloCopyList) {
+										 ParticleContainer* moleculeContainer, Domain* domain) {
+	if(moleculeContainer->isVerletContainer()) {
+		moleculeContainer->deleteOuterParticles();
+	}
+	moleculeContainer->update();
+
 	bool needsRebalance = checkNeedRebalance(lastTraversalTime);
 	bool rebalance = doRebalancing(forceRebalancing, needsRebalance, _steps, _frequency);
 	_steps++;

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -218,7 +218,9 @@ bool KDDecomposition::checkNeedRebalance(double lastTraversalTime) {
 	return needsRebalance;
 }
 
-void KDDecomposition::balanceAndExchange(double lastTraversalTime, bool forceRebalancing, ParticleContainer* moleculeContainer, Domain* domain) {
+void KDDecomposition::balanceAndExchange(double lastTraversalTime, bool forceRebalancing,
+										 ParticleContainer* moleculeContainer, Domain* domain,
+										 bool generateVerletHaloCopyList) {
 	bool needsRebalance = checkNeedRebalance(lastTraversalTime);
 	bool rebalance = doRebalancing(forceRebalancing, needsRebalance, _steps, _frequency);
 	_steps++;

--- a/src/parallel/KDDecomposition.h
+++ b/src/parallel/KDDecomposition.h
@@ -100,7 +100,7 @@ class KDDecomposition: public DomainDecompMPIBase {
 											double etime) override;
 
 	void balanceAndExchange(double lastTraversalTime, bool forceRebalancing, ParticleContainer* moleculeContainer,
-							Domain* domain, bool generateVerletHaloCopyList) override;
+							Domain* domain) override;
 
 	//! @todo comment and thing
 	double getBoundingBoxMin(int dimension, Domain* domain) override;

--- a/src/parallel/KDDecomposition.h
+++ b/src/parallel/KDDecomposition.h
@@ -96,9 +96,11 @@ class KDDecomposition: public DomainDecompMPIBase {
 			unsigned int stageNumber) override;
 
 	// documentation in base class
-	bool queryBalanceAndExchangeNonBlocking(bool forceRebalancing, ParticleContainer* moleculeContainer, Domain* domain, double etime) override;
+	bool queryBalanceAndExchangeNonBlocking(bool forceRebalancing, ParticleContainer* moleculeContainer, Domain* domain,
+											double etime) override;
 
-	void balanceAndExchange(double lastTraversalTime, bool forceRebalancing, ParticleContainer* moleculeContainer, Domain* domain);
+	void balanceAndExchange(double lastTraversalTime, bool forceRebalancing, ParticleContainer* moleculeContainer,
+							Domain* domain, bool generateVerletHaloCopyList) override;
 
 	//! @todo comment and thing
 	double getBoundingBoxMin(int dimension, Domain* domain) override;

--- a/src/parallel/NeighbourCommunicationScheme.cpp
+++ b/src/parallel/NeighbourCommunicationScheme.cpp
@@ -828,13 +828,13 @@ void IndirectNeighbourCommunicationScheme::initExchangeMoleculesMPI1D(ParticleCo
 		switch (msgType) {
 		case LEAVING_AND_HALO_COPIES:
 			domainDecomp->DomainDecompBase::handleDomainLeavingParticles(d, moleculeContainer);
-			domainDecomp->DomainDecompBase::populateHaloLayerWithCopies(d, moleculeContainer);
+			domainDecomp->DomainDecompBase::populateHaloLayerWithCopies(d, moleculeContainer, false);
 			break;
 		case LEAVING_ONLY:
 			domainDecomp->DomainDecompBase::handleDomainLeavingParticles(d, moleculeContainer);
 			break;
 		case HALO_COPIES:
-			domainDecomp->DomainDecompBase::populateHaloLayerWithCopies(d, moleculeContainer);
+			domainDecomp->DomainDecompBase::populateHaloLayerWithCopies(d, moleculeContainer, false);
 			break;
 		case FORCES:
 			domainDecomp->DomainDecompBase::handleForceExchange(d, moleculeContainer);

--- a/src/parallel/NonBlockingMPIHandlerBase.cpp
+++ b/src/parallel/NonBlockingMPIHandlerBase.cpp
@@ -83,7 +83,7 @@ void NonBlockingMPIHandlerBase::performComputation() {
 void NonBlockingMPIHandlerBase::initBalanceAndExchange(bool forceRebalancing, double etime) {
 	global_simulation->timers()->start("SIMULATION_DECOMPOSITION");
 
-	_domainDecomposition->balanceAndExchange(etime, forceRebalancing, _moleculeContainer, _domain, false);
+	_domainDecomposition->balanceAndExchange(etime, forceRebalancing, _moleculeContainer, _domain);
 
 	// The cache of the molecules must be updated/build after the exchange process,
 	// as the cache itself isn't transferred

--- a/src/parallel/NonBlockingMPIHandlerBase.cpp
+++ b/src/parallel/NonBlockingMPIHandlerBase.cpp
@@ -83,7 +83,7 @@ void NonBlockingMPIHandlerBase::performComputation() {
 void NonBlockingMPIHandlerBase::initBalanceAndExchange(bool forceRebalancing, double etime) {
 	global_simulation->timers()->start("SIMULATION_DECOMPOSITION");
 
-	_domainDecomposition->balanceAndExchange(etime, forceRebalancing, _moleculeContainer, _domain);
+	_domainDecomposition->balanceAndExchange(etime, forceRebalancing, _moleculeContainer, _domain, false);
 
 	// The cache of the molecules must be updated/build after the exchange process,
 	// as the cache itself isn't transferred

--- a/src/parallel/tests/DomainDecompBaseTest.cpp
+++ b/src/parallel/tests/DomainDecompBaseTest.cpp
@@ -26,7 +26,7 @@ void DomainDecompBaseTest::testNoDuplicatedParticlesFilename(const char * filena
 	ParticleContainer* container = initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff);
 	unsigned long numMols = container->getNumberOfParticles();
 
-	_domainDecomposition->exchangeMolecules(container, _domain);
+	_domainDecomposition->exchangeMolecules(container, false);
 	container->deleteOuterParticles();
 
 	unsigned long newNumMols = container->getNumberOfParticles();
@@ -81,7 +81,7 @@ void DomainDecompBaseTest::testNoLostParticlesFilename(const char * filename, do
 
 	container->update();
 
-	_domainDecomposition->exchangeMolecules(container, _domain);
+	_domainDecomposition->exchangeMolecules(container, false);
 	container->deleteOuterParticles();
 
 	unsigned long newNumMols = container->getNumberOfParticles();
@@ -129,7 +129,7 @@ void DomainDecompBaseTest::testExchangeMoleculesSimple() {
 	}
 
 	// after the exchange, every molecule should be replicated 7 times, i.e. there have to be 64 molecules in total
-	_domainDecomposition->exchangeMolecules(container, _domain);
+	_domainDecomposition->exchangeMolecules(container, false);
 	ASSERT_EQUAL(64ul, container->getNumberOfParticles());
 
 	m = container->iterator();
@@ -167,7 +167,7 @@ void DomainDecompBaseTest::testExchangeMolecules() {
 	}
 
 	// after the exchange, there have to be 21 copies in the halos, i.e. 24 molecules in total
-	_domainDecomposition->exchangeMolecules(container, _domain);
+	_domainDecomposition->exchangeMolecules(container, false);
 
 	ASSERT_EQUAL(24ul, container->getNumberOfParticles());
 

--- a/src/parallel/tests/DomainDecompositionTest.cpp
+++ b/src/parallel/tests/DomainDecompositionTest.cpp
@@ -34,7 +34,7 @@ void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * fil
 	numMols = _domainDecomposition->collCommGetInt();
 	_domainDecomposition->collCommFinalize();
 
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
+	_domainDecomposition->balanceAndExchange(0., true, container, _domain, false);
 	container->deleteOuterParticles();
 
 	int newNumMols = container->getNumberOfParticles();
@@ -100,7 +100,7 @@ void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename,
 
 	container->update();
 
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
+	_domainDecomposition->balanceAndExchange(0., true, container, _domain, false);
 	container->deleteOuterParticles();
 
 	int newNumMols = container->getNumberOfParticles();

--- a/src/parallel/tests/DomainDecompositionTest.cpp
+++ b/src/parallel/tests/DomainDecompositionTest.cpp
@@ -34,7 +34,7 @@ void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * fil
 	numMols = _domainDecomposition->collCommGetInt();
 	_domainDecomposition->collCommFinalize();
 
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain, false);
+	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
 	container->deleteOuterParticles();
 
 	int newNumMols = container->getNumberOfParticles();
@@ -98,9 +98,7 @@ void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename,
 		}
 	}
 
-	container->update();
-
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain, false);
+	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
 	container->deleteOuterParticles();
 
 	int newNumMols = container->getNumberOfParticles();
@@ -158,7 +156,7 @@ void DomainDecompositionTest::testExchangeMolecules1Proc() {
 	}
 
 	// after the exchange, there have to be 21 copies in the halos, i.e. 24 molecules in total
-	_domainDecomposition->balanceAndExchange(0., false, container, _domain, false);
+	_domainDecomposition->balanceAndExchange(0., false, container, _domain);
 	ASSERT_EQUAL(24ul, container->getNumberOfParticles());
 
 	m = container->iterator();

--- a/src/parallel/tests/DomainDecompositionTest.cpp
+++ b/src/parallel/tests/DomainDecompositionTest.cpp
@@ -158,7 +158,7 @@ void DomainDecompositionTest::testExchangeMolecules1Proc() {
 	}
 
 	// after the exchange, there have to be 21 copies in the halos, i.e. 24 molecules in total
-	_domainDecomposition->exchangeMolecules(container, _domain);
+	_domainDecomposition->balanceAndExchange(0., false, container, _domain, false);
 	ASSERT_EQUAL(24ul, container->getNumberOfParticles());
 
 	m = container->iterator();

--- a/src/parallel/tests/KDDecompositionTest.cpp
+++ b/src/parallel/tests/KDDecompositionTest.cpp
@@ -49,7 +49,7 @@ void KDDecompositionTest::testNoDuplicatedParticlesFilename(
 	numMols = kdd->collCommGetInt();
 	kdd->collCommFinalize();
 
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain, false);
+	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
 	// will rebalance, we thus need a reduce
 	container->deleteOuterParticles();
 
@@ -89,7 +89,7 @@ void KDDecompositionTest::testHaloCorrect() {
 			cutoff);
 
 	kdd->initCommunicationPartners(cutoff, _domain, container);
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain, false);
+	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
 	// this should give us halos at -1., -2., 14., 15.
 	// we will thus iterate over
 
@@ -244,7 +244,7 @@ void KDDecompositionTest::testNoLostParticlesFilename(const char * filename,
 	//needed to properly exchange the particles. In the first step leaving particles are normally not exchanged...
 	dynamic_cast<KDDecomposition*>(_domainDecomposition)->_steps++;
 
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain, false);
+	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
 	container->deleteOuterParticles();
 
 	int newNumMols = container->getNumberOfParticles();
@@ -450,16 +450,11 @@ void KDDecompositionTest::testbalanceAndExchange() {
 
 	kdd->initCommunicationPartners(cutOff, _domain, moleculeContainer);
 
-	moleculeContainer->update();
-
 	// TEST
 
 	const int numReps = 10;
-	if (_rank == 0) {
-		//cout << "running " << numReps << " repetitions" << std::endl;
-	}
 	for (int i = 0; i < numReps; ++i) {
-		kdd->balanceAndExchange(1.0, true, moleculeContainer, _domain, false);
+		kdd->balanceAndExchange(1.0, true, moleculeContainer, _domain);
 		moleculeContainer->updateMoleculeCaches();
 	}
 	delete moleculeContainer;

--- a/src/parallel/tests/KDDecompositionTest.cpp
+++ b/src/parallel/tests/KDDecompositionTest.cpp
@@ -49,7 +49,7 @@ void KDDecompositionTest::testNoDuplicatedParticlesFilename(
 	numMols = kdd->collCommGetInt();
 	kdd->collCommFinalize();
 
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
+	_domainDecomposition->balanceAndExchange(0., true, container, _domain, false);
 	// will rebalance, we thus need a reduce
 	container->deleteOuterParticles();
 
@@ -89,7 +89,7 @@ void KDDecompositionTest::testHaloCorrect() {
 			cutoff);
 
 	kdd->initCommunicationPartners(cutoff, _domain, container);
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
+	_domainDecomposition->balanceAndExchange(0., true, container, _domain, false);
 	// this should give us halos at -1., -2., 14., 15.
 	// we will thus iterate over
 
@@ -244,7 +244,7 @@ void KDDecompositionTest::testNoLostParticlesFilename(const char * filename,
 	//needed to properly exchange the particles. In the first step leaving particles are normally not exchanged...
 	dynamic_cast<KDDecomposition*>(_domainDecomposition)->_steps++;
 
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
+	_domainDecomposition->balanceAndExchange(0., true, container, _domain, false);
 	container->deleteOuterParticles();
 
 	int newNumMols = container->getNumberOfParticles();
@@ -459,7 +459,7 @@ void KDDecompositionTest::testbalanceAndExchange() {
 		//cout << "running " << numReps << " repetitions" << std::endl;
 	}
 	for (int i = 0; i < numReps; ++i) {
-		kdd->balanceAndExchange(1.0, true, moleculeContainer, _domain);
+		kdd->balanceAndExchange(1.0, true, moleculeContainer, _domain, false);
 		moleculeContainer->updateMoleculeCaches();
 	}
 	delete moleculeContainer;

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -133,7 +133,7 @@ void AutoPasContainer::traverseCells(CellProcessor &cellProcessor) {
 		std::array<double, 3> highCorner = {_boundingBoxMax[0], _boundingBoxMax[1], _boundingBoxMax[2]};
 
 		// generate the functor
-		autopas::LJFunctor<Molecule, CellType, /*calculateGlobals*/ true> functor(_cutoff, epsilon, sigma, shift,
+		autopas::LJFunctor<Molecule, CellType, /*newton3*/ true, /*calculateGlobals*/ true> functor(_cutoff, epsilon, sigma, shift,
 																				  lowCorner, highCorner,
 																				  /*duplicatedCalculation*/ true);
 #if defined(_OPENMP)

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -196,14 +196,9 @@ void AutoPasContainer::updateMoleculeCaches() {
 }
 
 bool AutoPasContainer::isVerletContainer() {
-	switch(_autopasContainer.getContainer()->getContainerType()){
-		case autopas::ContainerOptions::verletLists:
-		case autopas::ContainerOptions::verletListsCells:
-		case autopas::ContainerOptions::verletClusterLists:
-			return true;
-		default:
-			return false;
-	}
+	auto type = _autopasContainer.getContainer()->getContainerType();
+	auto typeString = autopas::utils::StringUtils::to_string(type);
+	return typeString.find("Verlet") != std::string::npos;
 }
 
 bool AutoPasContainer::queryVerletListsValid() {

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -176,7 +176,7 @@ double AutoPasContainer::get_halo_L(int /*index*/) const { return _cutoff; }
 
 double AutoPasContainer::getCutoff() { return _cutoff; }
 
-double AutoPasContainer::getSkin() { return _verletSkin; }
+double AutoPasContainer::getSkin() { return isVerletContainer() ? _verletSkin : 0.; }
 
 void AutoPasContainer::deleteMolecule(Molecule &molecule, const bool &rebuildCaches) {
 	throw std::runtime_error("not yet implemented");
@@ -232,7 +232,7 @@ Molecule* AutoPasContainer::getHaloMoleculeCloseToPosition(const double *pos, un
 
 unsigned long AutoPasContainer::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
 											  std::array<double, 3> simBoxLength) {
-	throw std::runtime_error("not yet implemented");
+	throw std::runtime_error("not yet implemented: AutoPasContainer::initCubicGrid");
 }
 
 double *AutoPasContainer::getCellLength() { throw std::runtime_error("not yet implemented"); }

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -210,13 +210,27 @@ bool AutoPasContainer::queryVerletListsValid() {
 
 bool AutoPasContainer::getMoleculeAtPosition(const double *pos, Molecule **result) {
 	std::array<double, 3> pos_arr{pos[0], pos[1], pos[2]};
-	for (auto iter = iterator(); iter.isValid(); ++iter) {
+	std::array<double, 3> lowCorner{pos[0] - _verletSkin, pos[1] - _verletSkin, pos[2] - _verletSkin};
+	std::array<double, 3> highCorner{pos[0] + _verletSkin, pos[1] + _verletSkin, pos[2] + _verletSkin};
+	for (auto iter = _autopasContainer.getRegionIterator( lowCorner,  highCorner); iter.isValid(); ++iter) {
 		if (iter->getR() == pos_arr) {
 			*result = &(*iter);
 			return true;
 		}
 	}
 	return false;
+}
+
+Molecule* AutoPasContainer::getMoleculeCloseToPosition(const double *pos, unsigned long id){
+	std::array<double, 3> lowCorner{pos[0] - _verletSkin, pos[1] - _verletSkin, pos[2] - _verletSkin};
+	std::array<double, 3> highCorner{pos[0] + _verletSkin, pos[1] + _verletSkin, pos[2] + _verletSkin};
+	for (auto iter = _autopasContainer.getRegionIterator(lowCorner, highCorner, autopas::IteratorBehavior::haloOnly);
+		 iter.isValid(); ++iter) {
+		if (iter->getID() == id) {
+			return &*iter;
+		}
+	}
+	throw std::runtime_error("no fitting halo molecule found");
 }
 
 unsigned long AutoPasContainer::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -223,7 +223,7 @@ bool AutoPasContainer::getMoleculeAtPosition(const double *pos, Molecule **resul
 	return false;
 }
 
-Molecule* AutoPasContainer::getMoleculeCloseToPosition(const double *pos, unsigned long id){
+Molecule* AutoPasContainer::getHaloMoleculeCloseToPosition(const double *pos, unsigned long id){
 	std::array<double, 3> lowCorner{pos[0] - _verletSkin, pos[1] - _verletSkin, pos[2] - _verletSkin};
 	std::array<double, 3> highCorner{pos[0] + _verletSkin, pos[1] + _verletSkin, pos[2] + _verletSkin};
 	for (auto iter = _autopasContainer.getRegionIterator(lowCorner, highCorner, autopas::IteratorBehavior::haloOnly);

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -193,6 +193,21 @@ void AutoPasContainer::updateMoleculeCaches() {
 	// nothing needed
 }
 
+bool AutoPasContainer::isVerletContainer() {
+	switch(_autopasContainer.getContainer()->getContainerType()){
+		case autopas::ContainerOptions::verletLists:
+		case autopas::ContainerOptions::verletListsCells:
+		case autopas::ContainerOptions::verletClusterLists:
+			return true;
+		default:
+			return false;
+	}
+}
+
+bool AutoPasContainer::queryVerletListsValid() {
+	return _autopasContainer.isNeighborListValid();
+}
+
 bool AutoPasContainer::getMoleculeAtPosition(const double *pos, Molecule **result) {
 	std::array<double, 3> pos_arr{pos[0], pos[1], pos[2]};
 	for (auto iter = iterator(); iter.isValid(); ++iter) {

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -176,6 +176,8 @@ double AutoPasContainer::get_halo_L(int /*index*/) const { return _cutoff; }
 
 double AutoPasContainer::getCutoff() { return _cutoff; }
 
+double AutoPasContainer::getSkin() { return _verletSkin; }
+
 void AutoPasContainer::deleteMolecule(Molecule &molecule, const bool &rebuildCaches) {
 	throw std::runtime_error("not yet implemented");
 }

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -207,7 +207,7 @@ bool AutoPasContainer::isVerletContainer() {
 }
 
 bool AutoPasContainer::queryVerletListsValid() {
-	return _autopasContainer.isNeighborListValid();
+	return not _autopasContainer.needsContainerUpdate();
 }
 
 bool AutoPasContainer::getMoleculeAtPosition(const double *pos, Molecule **result) {

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -72,6 +72,9 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 }
 
 bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {
+
+	// in ls1 mardyn there do not exist any particles, when this rebuild function is called.
+
 	mardyn_assert(_cutoff > 0.);
 	std::array<double, 3> boxMin{bBoxMin[0], bBoxMin[1], bBoxMin[2]};
 	std::array<double, 3> boxMax{bBoxMax[0], bBoxMax[1], bBoxMax[2]};

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -55,6 +55,8 @@ public:
 
 	double getCutoff() override;
 
+	double getSkin() override;
+
 	void deleteMolecule(Molecule &molecule, const bool &rebuildCaches) override;
 
 	double getEnergy(ParticlePairsHandler *particlePairsHandler, Molecule *m1, CellProcessor &cellProcessor) override;

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -67,6 +67,8 @@ public:
 
 	bool getMoleculeAtPosition(const double pos[3], Molecule **result) override;
 
+	Molecule* getMoleculeCloseToPosition(const double *pos, unsigned long id) override;
+
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
 								std::array<double, 3> simBoxLength) override;
 

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -81,6 +81,10 @@ public:
 
 	void setCutoff(double cutoff) override { _cutoff = cutoff; }
 
+	bool isVerletContainer() override;
+
+	bool queryVerletListsValid() override;
+
 private:
 	double _cutoff;
 	double _verletSkin;

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -95,6 +95,7 @@ private:
 	unsigned int _verletRebuildFrequency;
 	unsigned int _tuningFrequency;
 	unsigned int _tuningSamples;
+	bool _blackBoxMode;
 	typedef autopas::FullParticleCell<Molecule> CellType;
 	autopas::AutoPas<Molecule, CellType> _autopasContainer;
 

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -69,7 +69,7 @@ public:
 
 	bool getMoleculeAtPosition(const double pos[3], Molecule **result) override;
 
-	Molecule* getMoleculeCloseToPosition(const double *pos, unsigned long id) override;
+	Molecule* getHaloMoleculeCloseToPosition(const double *pos, unsigned long id) override;
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
 								std::array<double, 3> simBoxLength) override;

--- a/src/particleContainer/LinkedCells.cpp
+++ b/src/particleContainer/LinkedCells.cpp
@@ -1132,6 +1132,18 @@ bool LinkedCells::getMoleculeAtPosition(const double pos[3], Molecule** result) 
 	return false;
 }
 
+Molecule* LinkedCells::getHaloMoleculeCloseToPosition(const double *pos, unsigned long id) {
+	double lowCorner[3] = {pos[0] - _cutoffRadius, pos[1] - _cutoffRadius, pos[2] - _cutoffRadius};
+	double highCorner[3] = {pos[0] + _cutoffRadius, pos[1] + _cutoffRadius, pos[2] + _cutoffRadius};
+	for (auto iter = regionIterator(lowCorner, highCorner);
+	     iter.isValid(); ++iter) {
+		if (iter->getID() == id) {
+			return &*iter;
+		}
+	}
+	throw std::runtime_error("no fitting halo molecule found");
+}
+
 bool LinkedCells::requiresForceExchange() const {return _traversalTuner->getCurrentOptimalTraversal()->requiresForceExchange();}
 
 std::vector<unsigned long> LinkedCells::getParticleCellStatistics() {

--- a/src/particleContainer/LinkedCells.h
+++ b/src/particleContainer/LinkedCells.h
@@ -191,6 +191,8 @@ public:
 	 */
 	virtual bool getMoleculeAtPosition(const double pos[3], Molecule** result) override;
 
+	Molecule* getHaloMoleculeCloseToPosition(const double *pos, unsigned long id) override;
+
 	//! @brief Get the index in the cell vector to which this Molecule belongs
 	//!
 	//! each spatial position within the bounding box of the linked cells

--- a/src/particleContainer/ParticleContainer.h
+++ b/src/particleContainer/ParticleContainer.h
@@ -194,6 +194,8 @@ public:
 
 	virtual double getCutoff() = 0;
 
+	virtual double getSkin() {return 0.;};
+
     /* TODO: Have a look on this */
 	virtual void deleteMolecule(Molecule& molecule, const bool& rebuildCaches) = 0;
 

--- a/src/particleContainer/ParticleContainer.h
+++ b/src/particleContainer/ParticleContainer.h
@@ -221,6 +221,8 @@ public:
 	 */
 	virtual bool getMoleculeAtPosition(const double pos[3], Molecule** result) = 0; // new
 
+	virtual Molecule* getMoleculeCloseToPosition(const double *pos, unsigned long id) = 0;
+
 	// @brief Should the domain decomposition exchange calculated forces at the boundaries,
 	// or does this particle container calculate all forces.
 	virtual bool requiresForceExchange() const {return false;} // new

--- a/src/particleContainer/ParticleContainer.h
+++ b/src/particleContainer/ParticleContainer.h
@@ -223,7 +223,13 @@ public:
 	 */
 	virtual bool getMoleculeAtPosition(const double pos[3], Molecule** result) = 0; // new
 
-	virtual Molecule* getMoleculeCloseToPosition(const double *pos, unsigned long id) = 0;
+	/**
+	 * Get a halo molecule close to a specified position.
+	 * @param pos
+	 * @param id
+	 * @return
+	 */
+	virtual Molecule* getHaloMoleculeCloseToPosition(const double *pos, unsigned long id) = 0;
 
 	// @brief Should the domain decomposition exchange calculated forces at the boundaries,
 	// or does this particle container calculate all forces.

--- a/src/particleContainer/ParticleContainer.h
+++ b/src/particleContainer/ParticleContainer.h
@@ -239,7 +239,20 @@ public:
 	 * set the cutoff
 	 * @param rc
 	 */
-	virtual void setCutoff(double rc){};
+	virtual void setCutoff(double rc) {}
+
+	/**
+	 * Returns whether this container is a verlet list type container.
+	 * @return true if it is a verlet list type container.
+	 */
+	virtual bool isVerletContainer() { return false; }
+
+	/**
+	 * Query if the verlet lists are valid.
+	 * @return True if they are valid and can be reused.
+	 */
+	virtual bool queryVerletListsValid() {return false; }
+
 protected:
 
 	//!  coordinates of the left, lower, front corner of the bounding box

--- a/src/particleContainer/tests/LinkedCellsTest.cpp
+++ b/src/particleContainer/tests/LinkedCellsTest.cpp
@@ -38,7 +38,7 @@ void LinkedCellsTest::testUpdateAndDeleteOuterParticlesFilename(const char * fil
 			filename, cutoff));
 	int numMols = container->getNumberOfParticles();
 
-	_domainDecomposition->balanceAndExchange(0., false, container, _domain, false);
+	_domainDecomposition->balanceAndExchange(0., false, container, _domain);
 	container->deleteOuterParticles();
 
 	int newNumMols = container->getNumberOfParticles();
@@ -565,8 +565,8 @@ void LinkedCellsTest::doForceComparisonTest(std::string inputFile,
 	container->update();
 	containerTest->update();
 	bool forceRebalancing = false;
-	domainDecompositionFS->balanceAndExchange(0.,forceRebalancing, container, _domain, false);
-	domainDecompositionTest->balanceAndExchange(0.,forceRebalancing, containerTest, _domain, false);
+	domainDecompositionFS->balanceAndExchange(0.,forceRebalancing, container, _domain);
+	domainDecompositionTest->balanceAndExchange(0.,forceRebalancing, containerTest, _domain);
 	container->updateMoleculeCaches();
 	containerTest->updateMoleculeCaches();
 	//------------------------------------------------------------

--- a/src/particleContainer/tests/LinkedCellsTest.cpp
+++ b/src/particleContainer/tests/LinkedCellsTest.cpp
@@ -38,7 +38,7 @@ void LinkedCellsTest::testUpdateAndDeleteOuterParticlesFilename(const char * fil
 			filename, cutoff));
 	int numMols = container->getNumberOfParticles();
 
-	_domainDecomposition->exchangeMolecules(container, _domain);
+	_domainDecomposition->balanceAndExchange(0., false, container, _domain, false);
 	container->deleteOuterParticles();
 
 	int newNumMols = container->getNumberOfParticles();

--- a/src/particleContainer/tests/LinkedCellsTest.cpp
+++ b/src/particleContainer/tests/LinkedCellsTest.cpp
@@ -565,8 +565,8 @@ void LinkedCellsTest::doForceComparisonTest(std::string inputFile,
 	container->update();
 	containerTest->update();
 	bool forceRebalancing = false;
-	domainDecompositionFS->balanceAndExchange(0.,forceRebalancing, container, _domain);
-	domainDecompositionTest->balanceAndExchange(0.,forceRebalancing, containerTest, _domain);
+	domainDecompositionFS->balanceAndExchange(0.,forceRebalancing, container, _domain, false);
+	domainDecompositionTest->balanceAndExchange(0.,forceRebalancing, containerTest, _domain, false);
 	container->updateMoleculeCaches();
 	containerTest->updateMoleculeCaches();
 	//------------------------------------------------------------

--- a/src/thermostats/VelocityScalingThermostat.cpp
+++ b/src/thermostats/VelocityScalingThermostat.cpp
@@ -76,7 +76,7 @@ void VelocityScalingThermostat::apply(ParticleContainer *moleculeContainer) {
 			global_log->debug() << "Beta rot: " << betaRot << endl;
 			global_log->debug() << "Beta trans: " << betaTrans << endl;
 
-			for (auto i = moleculeContainer->iterator(); i.isValid(); ++i) {
+			for (auto i = moleculeContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); i.isValid(); ++i) {
 				if(this->_useGlobalVelocity) {
 					i->vsub(_globalVelocity[0], _globalVelocity[1], _globalVelocity[2]);
 					i->scale_v(betaTrans);

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -105,7 +105,7 @@ public:
 	bool getMoleculeAtPosition(const double pos[3],
 							   Molecule** result) { return false; } // pure virtual in particleContainer.h
 
-	Molecule* getHaloMoleculeCloseToPosition(const double pos[3], unsigned long id) override{};
+	Molecule* getHaloMoleculeCloseToPosition(const double pos[3], unsigned long id) override { return nullptr; }
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
 								std::array<double, 3> simBoxLength) { return 0; }

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -105,7 +105,7 @@ public:
 	bool getMoleculeAtPosition(const double pos[3],
 							   Molecule** result) { return false; } // pure virtual in particleContainer.h
 
-	Molecule* getMoleculeCloseToPosition(const double pos[3], unsigned long id) override{};
+	Molecule* getHaloMoleculeCloseToPosition(const double pos[3], unsigned long id) override{};
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
 								std::array<double, 3> simBoxLength) { return 0; }

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -105,6 +105,8 @@ public:
 	bool getMoleculeAtPosition(const double pos[3],
 							   Molecule** result) { return false; } // pure virtual in particleContainer.h
 
+	Molecule* getMoleculeCloseToPosition(const double pos[3], unsigned long id) override{};
+
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
 								std::array<double, 3> simBoxLength) { return 0; }
 


### PR DESCRIPTION
This pull request aims to add support for the verlet list containers of AutoPas. While they are already supported to run, the lists cannot yet be reused, as the particles are always moved in every time step, the lists currently need to be rebuilt.
In this PR support of leaving the lists intact is added. This is done using the following things:

- [x] Do not send leaving particles in every step.
- [x] Always send the same halo particles in steps where the lists should be reused.
- [x] Do not delete the halo particles in every step - we need to reuse them!
- [x] Enlarge halo particle region by skin
  - [x] check whether this has any influence on openmp (might produce race conditions for list halo copy) => openmp is disabled, so ok!
- [x] Adapt all iterators to properly iterate only on owned molecules. This will probably be done using a new default.
- [x] Adaptions for container changes (auto-tuning)
- [x] ~~Adaptions of sDD and kDD~~ -- works in blackboxmode
- [x] Check OpenMP

Depends on:
- [x] https://github.com/AutoPas/AutoPas/pull/165
- [ ] https://github.com/AutoPas/AutoPas/pull/172

Finally:
- [x] cleanup autopas github tag
- [ ] revert some of the input files