### PR TITLE
fix srun errors on knl

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,6 +142,7 @@ pipeline {
                                 export OMP_NUM_THREADS=10
                                 export I_MPI_PMI_LIBRARY=/usr/lib64/libpmi.so
                                 while : ; do
+                                  set +e
                                   output=`srun -n 2 --time=00:05:00 ./src/${it.join('-')} -t -d ./test_input/ 2>&1`
                                   rc=\$?
                                   if [[ \$rc == 1 && \$output == *"Job violates accounting/QOS policy"* ]] ; then
@@ -149,6 +150,7 @@ pipeline {
                                     sleep 30
                                     continue
                                   fi
+                                  set -e
                                   echo \$output
                                   exit \$rc
                                 done
@@ -159,6 +161,7 @@ pipeline {
                                 export OMP_NUM_THREADS=10
                                 export I_MPI_PMI_LIBRARY=/usr/lib64/libpmi.so
                                 while : ; do
+                                  set +e
                                   output=`srun -n 1 --time=00:05:00 ./src/${it.join('-')} -t -d ./test_input/ 2>&1`
                                   rc=\$?
                                   if [[ \$rc == 1 && \$output == *"Job violates accounting/QOS policy"* ]] ; then
@@ -166,6 +169,7 @@ pipeline {
                                     sleep 30
                                     continue
                                   fi
+                                  set -e
                                   echo \$output
                                   exit \$rc
                                 done

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,14 +143,14 @@ pipeline {
                                 export I_MPI_PMI_LIBRARY=/usr/lib64/libpmi.so
                                 while : ; do
                                   output=`srun -n 2 --time=00:05:00 ./src/${it.join('-')} -t -d ./test_input/ 2>&1`
-                                  rc=$?
-                                  if [[ $rc == 1 &&  $output == *"Job violates accounting/QOS policy"* ]] ; then
+                                  rc=\$?
+                                  if [[ \$rc == 1 && \$output == *"Job violates accounting/QOS policy"* ]] ; then
                                     echo "srun submit limit reached, trying again in 30s"
                                     sleep 30
                                     continue
                                   fi
-                                  echo $output
-                                  exit $rc
+                                  echo \$output
+                                  exit \$rc
                                 done
                               """
                             } else if (ARCH=="KNL" && PARTYPE=="SEQ") {
@@ -160,14 +160,14 @@ pipeline {
                                 export I_MPI_PMI_LIBRARY=/usr/lib64/libpmi.so
                                 while : ; do
                                   output=`srun -n 1 --time=00:05:00 ./src/${it.join('-')} -t -d ./test_input/ 2>&1`
-                                  rc=$?
-                                  if [[ $rc == 1 &&  $output == *"Job violates accounting/QOS policy"* ]] ; then
+                                  rc=\$?
+                                  if [[ \$rc == 1 && \$output == *"Job violates accounting/QOS policy"* ]] ; then
                                     echo "srun submit limit reached, trying again in 30s"
                                     sleep 30
                                     continue
                                   fi
-                                  echo $output
-                                  exit $rc
+                                  echo \$output
+                                  exit \$rc
                                 done
                               """
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,14 +141,34 @@ pipeline {
                                 source /etc/profile.d/modules.sh
                                 export OMP_NUM_THREADS=10
                                 export I_MPI_PMI_LIBRARY=/usr/lib64/libpmi.so
-                                srun -n 2 --time=00:05:00 ./src/${it.join('-')} -t -d ./test_input/
+                                while : ; do
+                                  output=`srun -n 2 --time=00:05:00 ./src/${it.join('-')} -t -d ./test_input/ 2>&1`
+                                  rc=$?
+                                  if [[ $rc == 1 &&  $output == *"Job violates accounting/QOS policy"* ]] ; then
+                                    echo "srun submit limit reached, trying again in 30s"
+                                    sleep 30
+                                    continue
+                                  fi
+                                  echo $output
+                                  exit $rc
+                                done
                               """
                             } else if (ARCH=="KNL" && PARTYPE=="SEQ") {
                               sh """
                                 source /etc/profile.d/modules.sh
-                                export OMP_NUM_THREADS=1
+                                export OMP_NUM_THREADS=10
                                 export I_MPI_PMI_LIBRARY=/usr/lib64/libpmi.so
-                                srun -n 1 --time=00:05:00 ./src/${it.join('-')} -t -d ./test_input/
+                                while : ; do
+                                  output=`srun -n 1 --time=00:05:00 ./src/${it.join('-')} -t -d ./test_input/ 2>&1`
+                                  rc=$?
+                                  if [[ $rc == 1 &&  $output == *"Job violates accounting/QOS policy"* ]] ; then
+                                    echo "srun submit limit reached, trying again in 30s"
+                                    sleep 30
+                                    continue
+                                  fi
+                                  echo $output
+                                  exit $rc
+                                done
                               """
                             }
                             results[it.join('-')].put("unit-test", "success")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -146,8 +146,8 @@ pipeline {
                                   output=`srun -n 2 --time=00:05:00 ./src/${it.join('-')} -t -d ./test_input/ 2>&1`
                                   rc=\$?
                                   if [[ \$rc == 1 && \$output == *"Job violates accounting/QOS policy"* ]] ; then
-                                    echo "srun submit limit reached, trying again in 30s"
-                                    sleep 30
+                                    echo "srun submit limit reached, trying again in 60s"
+                                    sleep 60
                                     continue
                                   fi
                                   set -e
@@ -165,8 +165,8 @@ pipeline {
                                   output=`srun -n 1 --time=00:05:00 ./src/${it.join('-')} -t -d ./test_input/ 2>&1`
                                   rc=\$?
                                   if [[ \$rc == 1 && \$output == *"Job violates accounting/QOS policy"* ]] ; then
-                                    echo "srun submit limit reached, trying again in 30s"
-                                    sleep 30
+                                    echo "srun submit limit reached, trying again in 60s"
+                                    sleep 60
                                     continue
                                   fi
                                   set -e

--- a/validation/validationRun/validationRun.py
+++ b/validation/validationRun/validationRun.py
@@ -303,8 +303,8 @@ def doRun(directory, MardynExe):
         p = Popen(cmd, stdout=PIPE, stderr=PIPE)
         out, err = p.communicate()
         if p.returncode == 1 and "Job violates accounting/QOS policy" in err:
-            print "srun submit limit reached, trying again in 30s"
-            time.sleep(30)
+            print "srun submit limit reached, trying again in 60s"
+            time.sleep(60)
             continue
         break
     t = time.time() - t

--- a/validation/validationRun/validationRun.py
+++ b/validation/validationRun/validationRun.py
@@ -298,8 +298,15 @@ def doRun(directory, MardynExe):
     print cmd
     print "================"
     t = time.time()
-    p = Popen(cmd, stdout=PIPE, stderr=PIPE)
-    out, err = p.communicate()
+    while True:
+        # repeatedly try this if srun was not working
+        p = Popen(cmd, stdout=PIPE, stderr=PIPE)
+        out, err = p.communicate()
+        if p.returncode == 1 and "Job violates accounting/QOS policy" in err:
+            print "srun submit limit reached, trying again in 30s"
+            time.sleep(30)
+            continue
+        break
     t = time.time() - t
     print "elapsed time:", t
     if p.returncode:


### PR DESCRIPTION
srun is rejecting the submission of jobs if more than two jobs are submitted.
This PR fixes this, by repeatedly trying to submit the job until it works. The job is hereby only resubmitted if the error message contains the string `Job violates accounting/QOS policy`