### PR TITLE
Tchipev is halo cell

### DIFF
--- a/src/particleContainer/CellBorderAndFlagManager.h
+++ b/src/particleContainer/CellBorderAndFlagManager.h
@@ -40,6 +40,11 @@ public:
 		_initCalled = true;
 	}
 
+	// NOTE: attempted to optimise isHaloCell for runtime by:
+	// 		* storing bool-s per dimension and computing isHaloCell as a tensor product
+	// 		* simplifying the logic
+	// but neither brought any visible acceleration (tested in RMM mode with low density and low cutoff).
+	// One should instead probably try to reduce the number of calls to isHaloCell().
 	bool isHaloCell(GlobalLinearizedIndex_t cellIndex) const { return isCell(IsCell_t::HALO, cellIndex); }
 	bool isBoundaryCell(GlobalLinearizedIndex_t cellIndex) const { return isCell(IsCell_t::BOUNDARY, cellIndex); }
 	bool isInnerCell(GlobalLinearizedIndex_t cellIndex) const { return isCell(IsCell_t::INNER, cellIndex); }

--- a/src/particleContainer/CellBorderAndFlagManager.h
+++ b/src/particleContainer/CellBorderAndFlagManager.h
@@ -64,12 +64,12 @@ private:
 		if (type == IsCell_t::HALO or type == IsCell_t::BOUNDARY) {
 			ret = false;
 			for (int d = 0; d < 3; ++d) {
-				ret = ret or isCell1D(type, r[d], d);
+				ret |= isCell1D(type, r[d], d);
 			}
 		} else {
 			ret = true;
 			for (int d = 0; d < 3; ++d) {
-				ret = ret and isCell1D(type, r[d], d);
+				ret &= isCell1D(type, r[d], d);
 			}
 		}
 		return ret;

--- a/src/particleContainer/adapter/VCP1CLJRMM.cpp
+++ b/src/particleContainer/adapter/VCP1CLJRMM.cpp
@@ -238,7 +238,7 @@ vcp_inline void VCP1CLJRMM::_loopBodyLJ(
 }
 
 template<class ForcePolicy, bool CalculateMacroscopic, class MaskGatherChooser>
-vcp_inline void VCP1CLJRMM::_calculatePairs(CellDataSoARMM& soa1, CellDataSoARMM& soa2) {
+void VCP1CLJRMM::_calculatePairs(CellDataSoARMM& soa1, CellDataSoARMM& soa2) {
 
 	const int tid = mardyn_get_thread_num();
 	VCP1CLJRMMThreadData &my_threadData = *_threadData[tid];


### PR DESCRIPTION
1) Runtime optimization of isHaloCell. New version uses 1 bit more memory per cell (std::vector<bool> within CellBorderAndFlagManager).
Two unsuccessful optimization attempts added as comments, so that someone doesn't try to reimplement them again.

2) fix g++ "maybe uninitialized" warning in isCell

3) remove unintentional inlining of VCP1CLJRMM::_calculatePairs. Minor performance improvement. Another benefit is easier analysis through profilers, as the loops don't appear six separate times in the profiling output.