### PR TITLE
fixes replicafiller

### DIFF
--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -210,13 +210,9 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 									<< "Aborting simulation." << std::endl;
 				Simulation::exit(12);
 		}
-		if((x < 0.0 || x >= domain->getGlobalLength(0)) || (y < 0.0 || y
-																	   >= domain->getGlobalLength(1)) || (z < 0.0 || z
-																													 >=
-																													 domain->getGlobalLength(
-																															 2))) {
-			global_log->warning() << "Molecule " << id << " out of box: "
-								  << x << ";" << y << ";" << z << endl;
+		if ((x < 0.0 || x >= domain->getGlobalLength(0)) || (y < 0.0 || y >= domain->getGlobalLength(1)) ||
+			(z < 0.0 || z >= domain->getGlobalLength(2))) {
+			global_log->warning() << "Molecule " << id << " out of box: " << x << ";" << y << ";" << z << endl;
 		}
 
 		if(componentid > numcomponents || componentid == 0) {

--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -289,7 +289,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 	global_log->info() << "Reading Molecules done" << endl;
 
 	// TODO: Shouldn't we always calculate this?
-	if(domain->getglobalRho() != 0) {
+	if(domain->getglobalRho() == 0.) {
 		domain->setglobalRho(
 				domain->getglobalNumMolecules() / domain->getGlobalVolume());
 		global_log->info() << "Calculated Rho_global = "

--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -43,7 +43,7 @@ BinaryReader::BinaryReader()
 	// TODO Auto-generated constructor stub
 }
 
-BinaryReader::~BinaryReader() {}
+BinaryReader::~BinaryReader() = default;
 
 void BinaryReader::readXML(XMLfileUnits& xmlconfig) {
 	string pspfile;
@@ -69,7 +69,7 @@ void BinaryReader::setPhaseSpaceHeaderFile(string filename) {
 void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	XMLfileUnits inp(_phaseSpaceHeaderFile);
 
-	if(false == inp.changecurrentnode("/mardyn")) {
+	if(not inp.changecurrentnode("/mardyn")) {
 		global_log->error() << "Could not find root node /mardyn in XML input file." << endl;
 		global_log->fatal() << "Not a valid MarDyn XML input file." << endl;
 		Simulation::exit(1);
@@ -88,7 +88,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	bInputOk = bInputOk && inp.getNodeValue("number", numMolecules);
 	bInputOk = bInputOk && inp.getNodeValue("format@type", strMoleculeFormat);
 
-	if(false == bInputOk) {
+	if(not bInputOk) {
 		global_log->error() << "Content of file: '" << _phaseSpaceHeaderFile << "' corrupted! Program exit ..." << endl;
 		Simulation::exit(1);
 	}
@@ -138,7 +138,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 
 	string token;
 	vector<Component>& dcomponents = *(_simulation.getEnsemble()->getComponents());
-	unsigned int numcomponents = dcomponents.size();
+	size_t numcomponents = dcomponents.size();
 	unsigned long maxid = 0; // stores the highest molecule ID found in the phase space file
 
 #ifdef ENABLE_MPI
@@ -156,7 +156,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 
 	double x, y, z, vx, vy, vz, q0, q1, q2, q3, Dx, Dy, Dz;
 	uint64_t id;
-	uint32_t componentid;
+	uint32_t componentid = 0;
 
 	x = y = z = vx = vy = vz = q1 = q2 = q3 = Dx = Dy = Dz = 0.;
 	q0 = 1.;
@@ -205,6 +205,10 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 				_phaseSpaceFileStream.read(reinterpret_cast<char*> (&vy), 8);
 				_phaseSpaceFileStream.read(reinterpret_cast<char*> (&vz), 8);
 				break;
+			default:
+				global_log->error() << "BinaryReader: Unknown phase space format: " << _nMoleculeFormat << std::endl
+									<< "Aborting simulation." << std::endl;
+				Simulation::exit(12);
 		}
 		if((x < 0.0 || x >= domain->getGlobalLength(0)) || (y < 0.0 || y
 																	   >= domain->getGlobalLength(1)) || (z < 0.0 || z
@@ -289,7 +293,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 	global_log->info() << "Reading Molecules done" << endl;
 
 	// TODO: Shouldn't we always calculate this?
-	if(!domain->getglobalRho()) {
+	if(domain->getglobalRho() != 0) {
 		domain->setglobalRho(
 				domain->getglobalNumMolecules() / domain->getGlobalVolume());
 		global_log->info() << "Calculated Rho_global = "

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -109,6 +109,7 @@ ObjectGenerator::readPhaseSpace(ParticleContainer* particleContainer, Domain* do
 	std::shared_ptr<Object> boundedObject = std::make_shared<ObjectIntersection>(bBox, _object);
 	_filler->setObject(boundedObject);
 	_filler->init();
+
 	Molecule molecule;
 	unsigned long moleculeID = _moleculeIdPool->getNewMoleculeId();
 	while(_filler->getMolecule(&molecule) > 0) {

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -109,7 +109,6 @@ ObjectGenerator::readPhaseSpace(ParticleContainer* particleContainer, Domain* do
 	std::shared_ptr<Object> boundedObject = std::make_shared<ObjectIntersection>(bBox, _object);
 	_filler->setObject(boundedObject);
 	_filler->init();
-
 	Molecule molecule;
 	unsigned long moleculeID = _moleculeIdPool->getNewMoleculeId();
 	while(_filler->getMolecule(&molecule) > 0) {

--- a/src/particleContainer/ParticleContainer.h
+++ b/src/particleContainer/ParticleContainer.h
@@ -166,18 +166,18 @@ public:
 	//! @brief returns one coordinate of the lower corner of the bounding box
 	//!
 	//! @param dimension the coordinate which should be returned
-	double getBoundingBoxMin(int dimension) const;
+	virtual double getBoundingBoxMin(int dimension) const;
 
 	//! @brief checks, whether given coordinates are within the bounding box
 	//! @param r the coordinates to check
 	//! @return true if coordinates within bounding box, false otherwise
-	bool isInBoundingBox(double r[3]) const;
+	virtual bool isInBoundingBox(double r[3]) const;
 
 	virtual int getHaloWidthNumCells();
 	//! @brief returns one coordinate of the higher corner of the bounding box
 	//!
 	//! @param dimension the coordinate which should be returned
-	double getBoundingBoxMax(int dimension) const;
+	virtual double getBoundingBoxMax(int dimension) const;
 
 	//! @brief Delete all molecules in container
 	virtual void clear() = 0;

--- a/src/utils/generator/Basis.cpp
+++ b/src/utils/generator/Basis.cpp
@@ -51,6 +51,6 @@ Molecule Basis::getMolecule(int i) {
 }
 
 
-int Basis::numMolecules(){
+size_t Basis::numMolecules(){
 	return _molecules.size();
 }

--- a/src/utils/generator/Basis.h
+++ b/src/utils/generator/Basis.h
@@ -19,8 +19,8 @@
 /** Structure holding the basis used within a unit cell */
 class Basis {
 public:
-	Basis(){}
-	~Basis(){}
+	Basis() = default;
+	~Basis() = default;
 
 	/** @brief Read in XML configuration for Basis and all its included objects.
 	 *
@@ -45,7 +45,7 @@ public:
 	/** Number of molecules of the basis
 	 * @return  number of molecules in the basis
 	 */
-	int numMolecules();
+	size_t numMolecules();
 
 	/** Obtain molecule from basis
 	 * @param[in]  i  Position of molecule to be returned

--- a/src/utils/generator/ObjectFillerBase.h
+++ b/src/utils/generator/ObjectFillerBase.h
@@ -10,8 +10,8 @@
 /** FillerBase interface */
 class ObjectFillerBase {
 public:
-	ObjectFillerBase(){}
-	virtual ~ObjectFillerBase(){}
+	ObjectFillerBase() = default;
+	virtual ~ObjectFillerBase() = default;
 
 	/** @brief Read in XML configuration for Filler and all its included objects.
 	 *

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -64,19 +64,19 @@ public:
 	unsigned long getNumberOfParticles() override { return _basis.numMolecules(); }
 
 	double getBoundingBoxMin(int dimension) const override {
-		double min[3];
-		_object->getBboxMin(min);
+		double min[3] = {std::numeric_limits<double>::min(),std::numeric_limits<double>::min(),std::numeric_limits<double>::min()};
+	//	_object->getBboxMin(min);
 		return min[dimension];
 	}
 
 	double getBoundingBoxMax(int dimension) const override {
-		double max[3];
-		_object->getBboxMax(max);
+		double max[3] = {std::numeric_limits<double>::max(),std::numeric_limits<double>::max(),std::numeric_limits<double>::max()};
+	//	_object->getBboxMax(max);
 		return max[dimension];
 	}
 
 	bool isInBoundingBox(double r[3]) const override {
-		_object->isInside(r);
+		true;
 	}
 
 	void update() override {}
@@ -175,7 +175,7 @@ void ReplicaFiller::readXML(XMLfileUnits& xmlconfig) {
 void ReplicaFiller::init() {
 	ParticleContainerToBasisWrapper basisContainer;
 	std::shared_ptr<Object> object = std::make_shared<ObjectShifter>(_object, _origin);
-	basisContainer.setBoundingBox(object);
+	basisContainer.setBoundingBox(nullptr);
 
 #ifdef ENABLE_MPI
 	DomainDecomposition domainDecomp;
@@ -189,7 +189,7 @@ void ReplicaFiller::init() {
 	global_log->info() << "Number of molecules in the replica: " << numberOfParticles << endl;
 
 	if(numberOfParticles == 0){
-		global_log->error() << "No molecules in replica, aborting! " << endl;
+		global_log->error_always_output() << "No molecules in replica, aborting! " << endl;
 		Simulation::exit(1);
 	}
 

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -76,6 +76,7 @@ public:
 	}
 
 	bool isInBoundingBox(double r[3]) const override {
+		// _object->isInside(r);
 		true;
 	}
 
@@ -175,7 +176,10 @@ void ReplicaFiller::readXML(XMLfileUnits& xmlconfig) {
 void ReplicaFiller::init() {
 	ParticleContainerToBasisWrapper basisContainer;
 	std::shared_ptr<Object> object = std::make_shared<ObjectShifter>(_object, _origin);
-	basisContainer.setBoundingBox(nullptr);
+
+	// the following line is commented out, because the selection should not yet happen at this stage.
+	// see https://github.com/ls1mardyn/ls1-mardyn/pull/64
+	// basisContainer.setBoundingBox(object);
 
 #ifdef ENABLE_MPI
 	DomainDecomposition domainDecomp;

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -28,16 +28,19 @@
 using Log::global_log;
 using std::endl;
 
-
-/** The ParticleContainerToBasisWrapper class is there to read in any phase space input and save it into a Basis object instead of a regular particle container, so it can be used for the grid filler.
- * @warning While providing all interface methods the ParticleContainerToBasisWrapper is not a fully working particle container!
- * @todo Find a better way to reuse all the different I/O classes and their readPhase space methods. Maybe bring back the Dummy domain decomposition?
+/**
+ * The ParticleContainerToBasisWrapper class is there to read in any phase space input and save it into a Basis object
+ * instead of a regular particle container, so it can be used for the grid filler.
+ * @warning While providing all interface methods the ParticleContainerToBasisWrapper is not a fully working particle
+ * container!
+ * @todo Find a better way to reuse all the different I/O classes and their readPhase space methods. Maybe bring back
+ * the Dummy domain decomposition?
  */
 class ParticleContainerToBasisWrapper : public ParticleContainer {
 public:
 	ParticleContainerToBasisWrapper() = default;
 
-	~ParticleContainerToBasisWrapper() = default;
+	~ParticleContainerToBasisWrapper() override = default;
 
 	void readXML(XMLfileUnits& xmlconfig) override {};
 
@@ -60,19 +63,19 @@ public:
 
 	unsigned long getNumberOfParticles() override { return _basis.numMolecules(); }
 
-	double getBoundingBoxMin(int dimension) const override{
+	double getBoundingBoxMin(int dimension) const override {
 		double min[3];
 		_object->getBboxMin(min);
 		return min[dimension];
 	}
 
-	double getBoundingBoxMax(int dimension) const override{
+	double getBoundingBoxMax(int dimension) const override {
 		double max[3];
 		_object->getBboxMax(max);
 		return max[dimension];
 	}
 
-	bool isInBoundingBox(double r[3]) const override{
+	bool isInBoundingBox(double r[3]) const override {
 		_object->isInside(r);
 	}
 
@@ -173,7 +176,6 @@ void ReplicaFiller::init() {
 	ParticleContainerToBasisWrapper basisContainer;
 	std::shared_ptr<Object> object = std::make_shared<ObjectShifter>(_object, _origin);
 	basisContainer.setBoundingBox(object);
-
 
 #ifdef ENABLE_MPI
 	DomainDecomposition domainDecomp;


### PR DESCRIPTION
fixes replicafiller also when using mpi.

assumes:
* The ParticleContainerToBasisWrapper does not have to do any cutting of particles
* Removing particles happens later, i.e., by the ReplicaFiller!

what has been done:
* src/particleContainer/ParticleContainer.h: make various functions virtual, s.t. it actually is used by the ParticleContainerToBasisWrapper!
* src/utils/generator/ReplicaFiller.cpp: make the ParticleContainerToBasisWrapper accept all particles, by implementing getBoundingBoxMin, getBoundingBoxMax, isInBoundingBox
* don't pass any object to the ParticleContainerToBasisWrapper, no check needs to be done here yet!
* abort if no particles have been added to the ParticleContainerToBasisWrapper

in addition:
* some clang-tidy fixes

remark:
* some tidy-up work could still be done inside of the ParticleContainerToBasisWrapper
