### PR TITLE
Tchipev small fixes

### DIFF
--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -56,41 +56,45 @@ void initOptions(optparse::OptionParser *op) {
  * @brief Helper function outputting program build information to given logger
  */
 void program_build_info(Log::Logger *log) {
+	log->info() << "Compilation info:" << endl;
+
 	char info_str[MAX_INFO_STRING_LENGTH];
 	get_compiler_info(info_str);
-	log->info() << "Compiler: " << info_str << endl;
+	log->info() << "	Compiler:	" << info_str << endl;
 	get_compile_time(info_str);
-	log->info() << "Compiled: " << info_str << endl;
+	log->info() << "	Compiled on:	" << info_str << endl;
 	get_precision_info(info_str);
-	log->info() << "Compiled in " << info_str << " precision." << endl;
+	log->info() << "	Precision:	" << info_str << endl;
 	get_intrinsics_info(info_str);
-	log->info() << "Compiled with " << info_str << " intrinsics." << endl;
+	log->info() << "	Intrinsics:	" << info_str << endl;
 	get_rmm_normal_info(info_str);
-	log->info() << "RMM/normal: compiled in " << info_str << endl;
+	log->info() << "	RMM/normal:	" << info_str << endl;
 	get_openmp_info(info_str);
-	log->info() << "Compiled " << info_str << endl;
+	log->info() << "	OpenMP:		" << info_str << endl;
 	get_mpi_info(info_str);
-	log->info() << info_str << endl;
+	log->info() << "	MPI:		" << info_str << endl;
 }
 
 /**
  * @brief Helper function outputting program invocation information to given logger
  */
 void program_execution_info(int argc, char **argv, Log::Logger *log) {
+	log->info() << "Execution info:" << endl;
+
 	char info_str[MAX_INFO_STRING_LENGTH];
 	get_timestamp(info_str);
-	log->info() << "Started: " << info_str << endl;
+	log->info() << "	Started: " << info_str << endl;
 	get_host(info_str);
-	log->info() << "Execution host: " << info_str << endl;
+	log->info() << "	Execution host: " << info_str << endl;
 	std::stringstream arguments;
 	for (int i = 0; i < argc; i++) {
 		arguments << " " << argv[i];
 	}
-	log->info() << "Started with arguments: " << arguments.str() << endl;
+	log->info() << "	Started with arguments: " << arguments.str() << endl;
 
 #if defined(_OPENMP)
 	int num_threads = mardyn_get_max_threads();
-	global_log->info() << "Running with " << num_threads << " OpenMP threads." << endl;
+	global_log->info() << "	Running with " << num_threads << " OpenMP threads." << endl;
 	// print thread pinning info
 	PrintThreadPinningToCPU();
 #endif
@@ -98,7 +102,7 @@ void program_execution_info(int argc, char **argv, Log::Logger *log) {
 #ifdef ENABLE_MPI
 	int world_size = 1;
 	MPI_CHECK(MPI_Comm_size(MPI_COMM_WORLD, &world_size));
-	global_log->info() << "Running with " << world_size << " MPI processes." << endl;
+	global_log->info() << "	Running with " << world_size << " MPI processes." << endl;
 #endif
 }
 

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -61,20 +61,16 @@ void program_build_info(Log::Logger *log) {
 	log->info() << "Compiler: " << info_str << endl;
 	get_compile_time(info_str);
 	log->info() << "Compiled: " << info_str << endl;
-#ifdef ENABLE_MPI
+	get_precision_info(info_str);
+	log->info() << "Compiled in " << info_str << " precision." << endl;
+	get_intrinsics_info(info_str);
+	log->info() << "Compiled with " << info_str << " intrinsics." << endl;
+	get_rmm_normal_info(info_str);
+	log->info() << "RMM/normal: compiled in " << info_str << endl;
+	get_openmp_info(info_str);
+	log->info() << "Compiled " << info_str << endl;
 	get_mpi_info(info_str);
-	log->info() << "MPI library: " << info_str << endl;
-#endif
-#if defined(MARDYN_SPSP)
-	log->info() << "Precision: Single" << endl;
-#elif defined(MARDYN_SPDP)
-	log->info() << "Precision: Mixed" << endl;
-#else
-	log->info() << "Precision: Double" << endl;
-#endif
-#if defined(_OPENMP)
-	log->info() << "Compiled with OpenMP support" << endl;
-#endif
+	log->info() << info_str << endl;
 }
 
 /**
@@ -91,20 +87,18 @@ void program_execution_info(int argc, char **argv, Log::Logger *log) {
 		arguments << " " << argv[i];
 	}
 	log->info() << "Started with arguments: " << arguments.str() << endl;
+
+#if defined(_OPENMP)
+	int num_threads = mardyn_get_max_threads();
+	global_log->info() << "Running with " << num_threads << " OpenMP threads." << endl;
+	// print thread pinning info
+	PrintThreadPinningToCPU();
+#endif
+
 #ifdef ENABLE_MPI
 	int world_size = 1;
 	MPI_CHECK(MPI_Comm_size(MPI_COMM_WORLD, &world_size));
 	global_log->info() << "Running with " << world_size << " MPI processes." << endl;
-#endif
-#if defined(_OPENMP)
-	int num_threads = mardyn_get_max_threads();
-	global_log->info() << "Running with " << num_threads << " OpenMP threads." << endl;
-
-	#if defined(ENABLE_REDUCED_MEMORY_MODE)
-	global_log->warning() << "Running in reduced memory mode. Not all features work in this mode." << endl;
-		// print thread pinning info
-		PrintThreadPinningToCPU();
-	#endif
 #endif
 }
 

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -255,7 +255,7 @@ int main(int argc, char** argv) {
 	//!@todo is this correct w.r.t. starting from time > 0 ? We keep changing this...
 	const unsigned long numForceCalculations = simulation.getNumTimesteps();
 	const double speed = simulation.getTotalNumberOfMolecules() * numForceCalculations / runtime;
-	global_log->info() << "Simulation speed: " << scientific << speed << " Molecule-updates per second." << endl;
+	global_log->info() << "Simulation speed: " << scientific << setprecision(8) << speed << " Molecule-updates per second." << endl;
 
 	simulation.finalize();
 

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -247,13 +247,17 @@ int main(int argc, char** argv) {
 	sim_timer.stop();
 	double runtime = sim_timer.get_etime();
 	//!@todo time only for simulation.simulate not "main"!
-	global_log->info() << "main: used " << fixed << setprecision(2) << runtime << " seconds" << endl;
+	global_log->info() << "main: used " << fixed << setprecision(2) << runtime << " seconds" << endl << fixed << setprecision(5);
 
 	// print out total simulation speed
 	//!@todo is this correct w.r.t. starting from time > 0 ? We keep changing this...
 	const unsigned long numForceCalculations = simulation.getNumTimesteps();
 	const double speed = simulation.getTotalNumberOfMolecules() * numForceCalculations / runtime;
-	global_log->info() << "Simulation speed: " << scientific << setprecision(8) << speed << " Molecule-updates per second." << endl;
+	global_log->info() << "Simulation speed: " << scientific << setprecision(6) << speed << " Molecule-updates per second." << endl << fixed << setprecision(5);
+
+	const double iterationsPerSecond = simulation.getNumTimesteps() / runtime;
+	global_log->info() << "Iterations per second: " << fixed << setprecision(3) << iterationsPerSecond << endl << fixed << setprecision(5);
+	global_log->info() << "Time per iteration: " << fixed << setprecision(3) << 1.0 / iterationsPerSecond << " seconds." << endl << fixed << setprecision(5);
 
 	simulation.finalize();
 

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -248,6 +248,7 @@ int main(int argc, char** argv) {
 	double runtime = sim_timer.get_etime();
 	//!@todo time only for simulation.simulate not "main"!
 	global_log->info() << "main: used " << fixed << setprecision(2) << runtime << " seconds" << endl << fixed << setprecision(5);
+	//  FIXME: The statements "<< fixed << setprecision(5)" after endl are so that the next logger timestamp appears as expected. A better solution would be nice, of course.
 
 	// print out total simulation speed
 	//!@todo is this correct w.r.t. starting from time > 0 ? We keep changing this...

--- a/src/io/FlopRateWriter.cpp
+++ b/src/io/FlopRateWriter.cpp
@@ -139,20 +139,20 @@ void FlopRateWriter::measureFLOPS(ParticleContainer* particleContainer, unsigned
 
 void FlopRateWriter::setPrefix(double f_in, double& f_out, char& prefix) const {
 	// powers of two or powers of ten?
-//	double kilo = 1024.0;
-//	double mega = 1024.0 * 1024.0;
-//	double giga = 1024.0 * 1024.0 * 1024.0;
-//	double tera = 1024.0 * 1024.0 * 1024.0 * 1024.0;
-//	double peta = 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0;
-//	double exa  = 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0;
+	double kilo = 1024.0;
+	double mega = 1024.0 * 1024.0;
+	double giga = 1024.0 * 1024.0 * 1024.0;
+	double tera = 1024.0 * 1024.0 * 1024.0 * 1024.0;
+	double peta = 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0;
+	double exa  = 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0;
 
-	// use powers of ten for correct comparison to TrillionAtoms run. (10-12% difference at tera-peta scale)
-	double kilo = 1e+3;
-	double mega = 1e+6;
-	double giga = 1e+9;
-	double tera = 1e+12;
-	double peta = 1e+15;
-	double exa  = 1e+18;
+//	// use powers of ten for correct comparison to TrillionAtoms run.
+//	double kilo = 1e+3;
+//	double mega = 1e+6;
+//	double giga = 1e+9;
+//	double tera = 1e+12;
+//	double peta = 1e+15;
+//	double exa  = 1e+18;
 
 	if (f_in >= exa) {
 		f_out = f_in / exa;

--- a/src/io/FlopRateWriter.cpp
+++ b/src/io/FlopRateWriter.cpp
@@ -138,21 +138,15 @@ void FlopRateWriter::measureFLOPS(ParticleContainer* particleContainer, unsigned
 }
 
 void FlopRateWriter::setPrefix(double f_in, double& f_out, char& prefix) const {
-	// powers of two or powers of ten?
-	double kilo = 1024.0;
-	double mega = 1024.0 * 1024.0;
-	double giga = 1024.0 * 1024.0 * 1024.0;
-	double tera = 1024.0 * 1024.0 * 1024.0 * 1024.0;
-	double peta = 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0;
-	double exa  = 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0 * 1024.0;
+//	// powers of two or powers of ten? Update: resolved.
 
-//	// use powers of ten for correct comparison to TrillionAtoms run.
-//	double kilo = 1e+3;
-//	double mega = 1e+6;
-//	double giga = 1e+9;
-//	double tera = 1e+12;
-//	double peta = 1e+15;
-//	double exa  = 1e+18;
+	// Powers of ten, as stated by IEC, NIST and ISO, cf. Wikipedia on Binary_prefix
+	double kilo = 1e+3;
+	double mega = 1e+6;
+	double giga = 1e+9;
+	double tera = 1e+12;
+	double peta = 1e+15;
+	double exa  = 1e+18;
 
 	if (f_in >= exa) {
 		f_out = f_in / exa;

--- a/src/utils/PrintThreadPinningToCPU.cpp
+++ b/src/utils/PrintThreadPinningToCPU.cpp
@@ -52,7 +52,7 @@ void PrintThreadPinningToCPU() {
 using Log::global_log;
 
 void PrintThreadPinningToCPU() {
-	global_log->warning() << "Thread pinning information cannot be obtained for this system by ls1. Please use OpenMP runtime system capabilities, e.g. KMP_AFFINITY=verbose with the Intel Compiler." << endl;
+	global_log->warning() << "Thread pinning information cannot be obtained for this system/compiler by ls1. Please use OpenMP runtime system capabilities, i.e. KMP_AFFINITY=verbose with the Intel Compiler." << endl;
 }
 
 #endif

--- a/src/utils/PrintThreadPinningToCPU.cpp
+++ b/src/utils/PrintThreadPinningToCPU.cpp
@@ -18,8 +18,8 @@ using std::endl;
 void PrintThreadPinningToCPU() {
 	int mastercpu = sched_getcpu();
 
-	global_log->info() << "Thread pinning:" << std::endl;
-	global_log->info() << "Master thread running on " << mastercpu << std::endl;
+	global_log->info() << "	Thread pinning:" << std::endl;
+	global_log->info() << "	Master thread running on " << mastercpu << std::endl;
 
 	#if defined(_OPENMP)
 	#pragma omp parallel
@@ -39,7 +39,7 @@ void PrintThreadPinningToCPU() {
 
 		for (int i = 0; i < numThreads; ++i) {
 			if (i == myID) {
-				global_log->info() << "	Thread with id " << myID << " is running on " << cpu << "." << endl;
+				global_log->info() << "		Thread with id " << myID << " is running on " << cpu << "." << endl;
 			}
 
 			#if defined(_OPENMP)
@@ -52,7 +52,7 @@ void PrintThreadPinningToCPU() {
 using Log::global_log;
 
 void PrintThreadPinningToCPU() {
-	global_log->warning() << "Thread pinning information cannot be obtained for this system/compiler by ls1. Please use OpenMP runtime system capabilities, i.e. KMP_AFFINITY=verbose with the Intel Compiler." << endl;
+	global_log->warning() << "	Thread pinning information cannot be obtained for this system/compiler by ls1. Please use OpenMP runtime system capabilities, i.e. KMP_AFFINITY=verbose with the Intel Compiler." << endl;
 }
 
 #endif

--- a/src/utils/compile_info.h
+++ b/src/utils/compile_info.h
@@ -66,26 +66,37 @@ int get_compiler_info(char *info_str) {
 
 	return 0;
 }
-#if defined(MPI_VERSION) and defined(MPI_SUBVERSION)
 
 int get_mpi_info(char *info_str) {
 
-#if defined(MVAPICH2)
-	sprintf(info_str, "MVAPICH2 (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
-#elif defined(OPEN_MPI)
-	sprintf(info_str, "Open MPI %d.%d.%d (MPI %d.%d)", OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION, OMPI_RELEASE_VERSION, MPI_VERSION, MPI_SUBVERSION);
-#elif defined(CRAY_MPICH_VERSION)
-	sprintf(info_str, "Cray MPI (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
-#elif defined(I_MPI_VERSION)
-	sprintf(info_str, "Intel MPI %s (MPI %d.%d)", I_MPI_VERSION, MPI_VERSION, MPI_SUBVERSION);
-#else
-	// unknown
-	sprintf(info_str, "unknown (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
-#endif
+#ifdef ENABLE_MPI
+
+	#if defined(MPI_VERSION) and defined(MPI_SUBVERSION)
+
+		#if defined(MVAPICH2)
+			sprintf(info_str, "MPI library: MVAPICH2 (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
+		#elif defined(OPEN_MPI)
+			sprintf(info_str, "MPI library: Open MPI %d.%d.%d (MPI %d.%d)", OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION, OMPI_RELEASE_VERSION, MPI_VERSION, MPI_SUBVERSION);
+		#elif defined(CRAY_MPICH_VERSION)
+			sprintf(info_str, "MPI library: Cray MPI (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
+		#elif defined(I_MPI_VERSION)
+			sprintf(info_str, "MPI library: Intel MPI %s (MPI %d.%d)", I_MPI_VERSION, MPI_VERSION, MPI_SUBVERSION);
+		#else
+			// unknown
+			sprintf(info_str, "MPI library: unknown (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
+		#endif
+
+	#else /* MPI_VERSION and MPI_SUBVERSION */
+			// I guess this can never happen, as it will fail on #include "mpi.h"?
+	#endif /* MPI_VERSION and MPI_SUBVERSION */
+
+#else /* ENABLE_MPI */
+	sprintf(info_str, "%s", "Compiled without MPI support.");
+#endif /* ENABLE_MPI */
+
 	return 0;
 }
 
-#endif
 
 int get_compile_time(char *info_str) {
 	sprintf(info_str, "%s %s", __DATE__, __TIME__);
@@ -113,6 +124,53 @@ int get_host(char *info_str) {
 #endif
 	sprintf(info_str, "%s", hostname);
 	return 0;
+}
+
+void get_precision_info(char *info_str) {
+#if defined(MARDYN_SPSP)
+	sprintf(info_str, "%s", "Single (SPSP)");
+#elif defined(MARDYN_SPDP)
+	sprintf(info_str, "%s", "Mixed (SPDP)");
+#else
+	sprintf(info_str, "%s", "Double (DPDP)");
+#endif
+}
+
+void get_intrinsics_info(char *info_str) {
+#if VCP_VEC_TYPE==VCP_NOVEC
+	sprintf(info_str, "%s", "without");
+#elif VCP_VEC_TYPE==VCP_VEC_SSE3
+	sprintf(info_str, "%s", "SSE3");
+#elif VCP_VEC_TYPE==VCP_VEC_AVX
+	sprintf(info_str, "%s", "AVX");
+#elif VCP_VEC_TYPE==VCP_VEC_AVX2
+	sprintf(info_str, "%s", "AVX2");
+#elif VCP_VEC_TYPE==VCP_VEC_KNL
+	sprintf(info_str, "%s", "KNL masking");
+#elif VCP_VEC_TYPE==VCP_VEC_KNL_GATHER
+	sprintf(info_str, "%s", "KNL gather/scatter");
+#elif VCP_VEC_TYPE==VCP_VEC_AVX512F
+	sprintf(info_str, "%s", "SKX masking");
+#elif VCP_VEC_TYPE==VCP_VEC_AVX512F_GATHER
+	sprintf(info_str, "%s", "SKX gather/scatter");
+#endif
+}
+
+void get_rmm_normal_info(char *info_str) {
+#if defined(ENABLE_REDUCED_MEMORY_MODE)
+	sprintf(info_str, "%s", "reduced memory mode (RMM). Not all features work in this mode.");
+#else
+	sprintf(info_str, "%s", "normal mode. All features work in this mode.");
+#endif
+}
+
+void get_openmp_info(char *info_str) {
+#if defined(_OPENMP)
+	sprintf(info_str, "%s%d%s", "with OpenMP support, dated ", _OPENMP, ".");
+#else
+	sprintf(info_str, "%s", "without OpenMP support.");
+#endif
+
 }
 
 #endif /*COMPILE_INFO_H_*/

--- a/src/utils/compile_info.h
+++ b/src/utils/compile_info.h
@@ -74,16 +74,16 @@ int get_mpi_info(char *info_str) {
 	#if defined(MPI_VERSION) and defined(MPI_SUBVERSION)
 
 		#if defined(MVAPICH2)
-			sprintf(info_str, "MPI library: MVAPICH2 (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
+			sprintf(info_str, "with MVAPICH2 (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
 		#elif defined(OPEN_MPI)
-			sprintf(info_str, "MPI library: Open MPI %d.%d.%d (MPI %d.%d)", OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION, OMPI_RELEASE_VERSION, MPI_VERSION, MPI_SUBVERSION);
+			sprintf(info_str, "with Open MPI %d.%d.%d (MPI %d.%d)", OMPI_MAJOR_VERSION, OMPI_MINOR_VERSION, OMPI_RELEASE_VERSION, MPI_VERSION, MPI_SUBVERSION);
 		#elif defined(CRAY_MPICH_VERSION)
-			sprintf(info_str, "MPI library: Cray MPI (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
+			sprintf(info_str, "with Cray MPI (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
 		#elif defined(I_MPI_VERSION)
-			sprintf(info_str, "MPI library: Intel MPI %s (MPI %d.%d)", I_MPI_VERSION, MPI_VERSION, MPI_SUBVERSION);
+			sprintf(info_str, "with Intel MPI %s (MPI %d.%d)", I_MPI_VERSION, MPI_VERSION, MPI_SUBVERSION);
 		#else
 			// unknown
-			sprintf(info_str, "MPI library: unknown (MPI %d.%d)", MPI_VERSION, MPI_SUBVERSION);
+			sprintf(info_str, "with unknown MPI (version %d.%d)", MPI_VERSION, MPI_SUBVERSION);
 		#endif
 
 	#else /* MPI_VERSION and MPI_SUBVERSION */
@@ -91,7 +91,7 @@ int get_mpi_info(char *info_str) {
 	#endif /* MPI_VERSION and MPI_SUBVERSION */
 
 #else /* ENABLE_MPI */
-	sprintf(info_str, "%s", "Compiled without MPI support.");
+	sprintf(info_str, "%s", "without MPI support.");
 #endif /* ENABLE_MPI */
 
 	return 0;
@@ -138,7 +138,7 @@ void get_precision_info(char *info_str) {
 
 void get_intrinsics_info(char *info_str) {
 #if VCP_VEC_TYPE==VCP_NOVEC
-	sprintf(info_str, "%s", "without");
+	sprintf(info_str, "%s", "none");
 #elif VCP_VEC_TYPE==VCP_VEC_SSE3
 	sprintf(info_str, "%s", "SSE3");
 #elif VCP_VEC_TYPE==VCP_VEC_AVX


### PR DESCRIPTION
minor fixes in printed information for greater precision and convenience:

- more systematic compilation info and execution info at start of program
- print MUPS with more precision, 3 significant digits is too few
- print iterations/sec and sec/iteration at end of program as a more practical number than MUPS
- use powers of two for Giga, Tera, etc prefixes.