### PR TITLE
unique ID calculation fix in Spatial Profiles

### DIFF
--- a/src/plugins/SpatialProfile.cpp
+++ b/src/plugins/SpatialProfile.cpp
@@ -275,6 +275,15 @@ void SpatialProfile::endStep(ParticleContainer* particleContainer, DomainDecompB
 	}
 }
 
+/**
+ * @brief getCartesianUID samples the domain cartesian coordinate bins.
+ *
+ * The calculation of uID has to be the same as used in the actual sampling profiles.
+ * E.g. ProfileBase / Child classes of Profile Base.
+ *
+ * @param thismol
+ * @return
+ */
 unsigned long SpatialProfile::getCartesianUID(ParticleIterator& thismol) {
 	auto xun = (unsigned) floor(thismol->r(0) * samplInfo.universalInvProfileUnit[0]);
 	auto yun = (unsigned) floor(thismol->r(1) * samplInfo.universalInvProfileUnit[1]);

--- a/src/plugins/profiles/ProfileBase.cpp
+++ b/src/plugins/profiles/ProfileBase.cpp
@@ -29,6 +29,8 @@ void ProfileBase::writeKartMatrix (ofstream& outfile) {
 		// number density values
 		for (unsigned z = 0; z < _samplInfo.universalProfileUnit[2]; z++) {
 			for (unsigned x = 0; x < _samplInfo.universalProfileUnit[0]; x++) {
+				// CRUCIAL:
+				// Do not change unID calculation. Has to be the same as in SpatialProfile.cpp
 				auto unID = (unsigned long) (
 						x * _samplInfo.universalProfileUnit[1] * _samplInfo.universalProfileUnit[2] +
 						y * _samplInfo.universalProfileUnit[2] + z);
@@ -60,6 +62,8 @@ void ProfileBase::writeCylMatrix (ofstream& outfile) {
 		outfile << hval << "  \t";
 		for (unsigned phi = 0; phi < _samplInfo.universalProfileUnit[2]; phi++) {
 			for (unsigned r = 0; r < _samplInfo.universalProfileUnit[0]; r++) {
+				// CRUCIAL:
+				// Do not change unID calculation. Has to be the same as in SpatialProfile.cpp
 				auto unID = (long) (h * _samplInfo.universalProfileUnit[0] * _samplInfo.universalProfileUnit[2]
 									+ r * _samplInfo.universalProfileUnit[2] + phi);
 				this->writeDataEntry(unID, outfile);

--- a/src/plugins/profiles/ProfileBase.cpp
+++ b/src/plugins/profiles/ProfileBase.cpp
@@ -30,8 +30,8 @@ void ProfileBase::writeKartMatrix (ofstream& outfile) {
 		for (unsigned z = 0; z < _samplInfo.universalProfileUnit[2]; z++) {
 			for (unsigned x = 0; x < _samplInfo.universalProfileUnit[0]; x++) {
 				auto unID = (unsigned long) (
-						x * _samplInfo.universalProfileUnit[0] * _samplInfo.universalProfileUnit[2] +
-						y * _samplInfo.universalProfileUnit[1] + z);
+						x * _samplInfo.universalProfileUnit[1] * _samplInfo.universalProfileUnit[2] +
+						y * _samplInfo.universalProfileUnit[2] + z);
 				this->writeDataEntry(unID, outfile);
 			}
 		}

--- a/src/plugins/profiles/VirialProfile.cpp
+++ b/src/plugins/profiles/VirialProfile.cpp
@@ -57,9 +57,15 @@ void VirialProfile::output(string prefix, long unsigned accumulatedDatasets) {
 		for (unsigned a = 0; a < _samplInfo.universalProfileUnit[0]; a++) {
 			for (unsigned b = 0; b < _samplInfo.universalProfileUnit[2]; b++) {
 				if (_samplInfo.cylinder) {
+					// CRUCIAL:
+					// Do not change unID calculation. Has to be the same as in SpatialProfile.cpp
+					// VirialProfile overwrites the default output routine of ProfileBase, so has to calculate unID on its own
 					unID = (unsigned long) (y * _samplInfo.universalProfileUnit[0] * _samplInfo.universalProfileUnit[2]
 											+ a * _samplInfo.universalProfileUnit[2] + b);
 				} else {
+					// CRUCIAL:
+					// Do not change unID calculation. Has to be the same as in SpatialProfile.cpp
+					// VirialProfile overwrites the default output routine of ProfileBase, so has to calculate unID on its own
 					unID = (unsigned long) (
 							a * _samplInfo.universalProfileUnit[1] * _samplInfo.universalProfileUnit[2] +
 							y * _samplInfo.universalProfileUnit[2] + b);

--- a/src/plugins/profiles/VirialProfile.cpp
+++ b/src/plugins/profiles/VirialProfile.cpp
@@ -61,8 +61,8 @@ void VirialProfile::output(string prefix, long unsigned accumulatedDatasets) {
 											+ a * _samplInfo.universalProfileUnit[2] + b);
 				} else {
 					unID = (unsigned long) (
-							a * _samplInfo.universalProfileUnit[0] * _samplInfo.universalProfileUnit[2] +
-							y * _samplInfo.universalProfileUnit[1] + b);
+							a * _samplInfo.universalProfileUnit[1] * _samplInfo.universalProfileUnit[2] +
+							y * _samplInfo.universalProfileUnit[2] + b);
 				}
 				// Add pressures
 				Px += _global3dProfile[unID][0];


### PR DESCRIPTION
fixes a bug where the unique ID of a given sampling bin was calculated differently during recording and later printing, leading to a SegFault.

This fixes an issue where sampling with only 1 bin in a dimension was not possible.