### PR TITLE
Fix path parsing

### DIFF
--- a/src/io/ASCIIReader.cpp
+++ b/src/io/ASCIIReader.cpp
@@ -38,7 +38,11 @@ void ASCIIReader::setPhaseSpaceHeaderFile(string filename) {
 void ASCIIReader::readXML(XMLfileUnits& xmlconfig) {
 	string pspfile;
 	if(xmlconfig.getNodeValue(".", pspfile)) {
-		pspfile.insert(0, xmlconfig.getDir());
+        pspfile = string_utils::trim(pspfile);
+        // only prefix xml dir if path is not absolute
+        if (pspfile[0] != '/') {
+          pspfile.insert(0, xmlconfig.getDir());
+        }
 		global_log->info() << "phasespacepoint description file:\t" << pspfile << endl;
 	}
 	setPhaseSpaceFile(pspfile);

--- a/src/io/ASCIIReader.cpp
+++ b/src/io/ASCIIReader.cpp
@@ -38,11 +38,11 @@ void ASCIIReader::setPhaseSpaceHeaderFile(string filename) {
 void ASCIIReader::readXML(XMLfileUnits& xmlconfig) {
 	string pspfile;
 	if(xmlconfig.getNodeValue(".", pspfile)) {
-        pspfile = string_utils::trim(pspfile);
-        // only prefix xml dir if path is not absolute
-        if (pspfile[0] != '/') {
-          pspfile.insert(0, xmlconfig.getDir());
-        }
+		pspfile = string_utils::trim(pspfile);
+		// only prefix xml dir if path is not absolute
+		if (pspfile[0] != '/') {
+			pspfile.insert(0, xmlconfig.getDir());
+		}
 		global_log->info() << "phasespacepoint description file:\t" << pspfile << endl;
 	}
 	setPhaseSpaceFile(pspfile);

--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -52,11 +52,11 @@ void BinaryReader::readXML(XMLfileUnits& xmlconfig) {
 	pspheaderfile.insert(0, xmlconfig.getDir());
 	global_log->info() << "phase space header file: " << pspheaderfile << endl;
 	xmlconfig.getNodeValue("data", pspfile);
-    pspfile = string_utils::trim(pspfile);
-    // only prefix xml dir if path is not absolute
-    if (pspfile[0] != '/') {
-      pspfile.insert(0, xmlconfig.getDir());
-    }
+	pspfile = string_utils::trim(pspfile);
+	// only prefix xml dir if path is not absolute
+	if (pspfile[0] != '/') {
+	  pspfile.insert(0, xmlconfig.getDir());
+	}
 	global_log->info() << "phase space header file: " << pspfile << endl;
 	setPhaseSpaceHeaderFile(pspheaderfile);
 	setPhaseSpaceFile(pspfile);

--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -52,7 +52,11 @@ void BinaryReader::readXML(XMLfileUnits& xmlconfig) {
 	pspheaderfile.insert(0, xmlconfig.getDir());
 	global_log->info() << "phase space header file: " << pspheaderfile << endl;
 	xmlconfig.getNodeValue("data", pspfile);
-	pspfile.insert(0, xmlconfig.getDir());
+    pspfile = string_utils::trim(pspfile);
+    // only prefix xml dir if path is not absolute
+    if (pspfile[0] != '/') {
+      pspfile.insert(0, xmlconfig.getDir());
+    }
 	global_log->info() << "phase space header file: " << pspfile << endl;
 	setPhaseSpaceHeaderFile(pspheaderfile);
 	setPhaseSpaceFile(pspfile);

--- a/src/io/ReplicaGenerator.cpp
+++ b/src/io/ReplicaGenerator.cpp
@@ -50,13 +50,12 @@ ReplicaGenerator::ReplicaGenerator()
 	std::iota(std::begin(_vecChangeCompIDsLiq), std::end(_vecChangeCompIDsLiq), 0);
 }
 
-ReplicaGenerator::~ReplicaGenerator() {
-}
+ReplicaGenerator::~ReplicaGenerator() = default;
 
 void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	XMLfileUnits inp(subDomain.strFilePathHeader);
 
-	if(false == inp.changecurrentnode("/mardyn")) {
+	if(not inp.changecurrentnode("/mardyn")) {
 		global_log->error() << "Could not find root node /mardyn in XML input file." << endl;
 		global_log->fatal() << "Not a valid MarDyn XML input file." << endl;
 		Simulation::exit(1);
@@ -80,7 +79,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	}
 	subDomain.dDensity = subDomain.numParticles / subDomain.dVolume;
 
-	if(false == bInputOk) {
+	if(not bInputOk) {
 		global_log->error() << "Content of file: '" << subDomain.strFilePathHeader << "' corrupted! Program exit ..."
 							<< endl;
 		Simulation::exit(1);
@@ -102,6 +101,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceData(SubDomain& subDomain, DomainDec
 #ifdef ENABLE_MPI
 	if(domainDecomp->getRank() == 0) {
 #endif
+	subDomain.strFilePathData = string_utils::trim(subDomain.strFilePathData);
 	global_log->info() << "Opening phase space file " << subDomain.strFilePathData << endl;
 	std::ifstream ifs;
 	ifs.open(subDomain.strFilePathData.c_str(), ios::binary | ios::in);

--- a/src/utils/String_utils.h
+++ b/src/utils/String_utils.h
@@ -31,4 +31,22 @@ static std::string toLowercase(const std::string& s) {
 	return ret;
 }
 
+/**
+ * Removes all leading and trailing whitespaces from a std::string.
+ * @param str
+ * @param whitespace characters to be removed. Default is whitespaces and tabs
+ * @return trimmed string
+ */
+static std::string trim(const std::string& str,
+                        const std::string &whitespace = " \t") {
+  const auto strBegin = str.find_first_not_of(whitespace);
+  if (strBegin == std::string::npos)
+    return "";
+
+  const auto strEnd = str.find_last_not_of(whitespace);
+  const auto strRange = strEnd - strBegin + 1;
+
+  return str.substr(strBegin, strRange);
+}
+
 }  // namespace string_utils

--- a/src/utils/String_utils.h
+++ b/src/utils/String_utils.h
@@ -37,16 +37,15 @@ static std::string toLowercase(const std::string& s) {
  * @param whitespace characters to be removed. Default is whitespaces and tabs
  * @return trimmed string
  */
-static std::string trim(const std::string& str,
-                        const std::string &whitespace = " \t") {
-  const auto strBegin = str.find_first_not_of(whitespace);
-  if (strBegin == std::string::npos)
-    return "";
+static std::string trim(const std::string& str, const std::string &whitespace = " \t") {
+	const auto strBegin = str.find_first_not_of(whitespace);
+	if (strBegin == std::string::npos)
+		return "";
 
-  const auto strEnd = str.find_last_not_of(whitespace);
-  const auto strRange = strEnd - strBegin + 1;
+	const auto strEnd = str.find_last_not_of(whitespace);
+	const auto strRange = strEnd - strBegin + 1;
 
-  return str.substr(strBegin, strRange);
+	return str.substr(strBegin, strRange);
 }
 
 }  // namespace string_utils


### PR DESCRIPTION
This makes the parsing of paths more robust to typos which otherwise produce wired errors.

# Resolved Issues:
## 1. Trailing Whitespaces
(from `examples/Argon/200K_18mol_l/Argon_200K_18mol_l.inp`)
```
      <phasespacepoint>
        <file type="ASCII">Argon_200K_18mol_l.inp </file>
      </phasespacepoint>
```
would produce the following error:
```
Could not open phaseSpaceFile ../examples/Argon/200K_18mol_l/Argon_200K_18mol_l.inp
```
which is confusing because the trailing whitespace is obviously not printed. Otherwise the path is correct.

## 2. Prefixing Paths
The ASCII and BinaryParser both always prefix the xml path to the parsed paths. This makes passing absolute paths impossible.

# Question
Are there more parsing weirdnesses like these I overlooked?