### PR TITLE
More robust Xerces-c include

### DIFF
--- a/cmake/modules/vtk.cmake
+++ b/cmake/modules/vtk.cmake
@@ -5,13 +5,26 @@ if(ENABLE_VTK)
     find_library(VTK_LIB xerces-c
       HINTS $ENV{XERCES_LIBDIR}
       )
+
+    # /lrz/mnt/sys.x86_sles12/spack/18.2/opt/x86_avx2/xerces-c/3.2.1-gcc-jz3anmr/include/
     if(NOT VTK_LIB)
         message(FATAL_ERROR "xerces-c lib not found. Disable VTK support, if you do not need it.")
     endif()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVTK")
+
+    # if the environment variable pointing to the xerces-c include directory is missing try to deduce it
+    if(NOT DEFINED ENV{XERCES_INCDIR})
+        string(REGEX REPLACE "/lib/.+" "/include/" VTK_INCDIR ${VTK_LIB})
+        if(NOT EXISTS ${VTK_INCDIR})
+            message(FATAL_ERROR "Could not find include directory for xerces-c. Please set the environment variable XERCES_INCDIR to it.")
+        endif()
+    else()
+        set(VTK_INCDIR $ENV{XERCES_INCDIR})
+    endif()
+
     include_directories(SYSTEM
             "${PROJECT_SOURCE_DIR}/dependencies-external/libxsd"
-            $ENV{XERCES_INCDIR}
+            ${VTK_INCDIR}
             )
 else()
     message(STATUS "VTK Disabled")

--- a/cmake/modules/vtk.cmake
+++ b/cmake/modules/vtk.cmake
@@ -6,7 +6,6 @@ if(ENABLE_VTK)
       HINTS $ENV{XERCES_LIBDIR}
       )
 
-    # /lrz/mnt/sys.x86_sles12/spack/18.2/opt/x86_avx2/xerces-c/3.2.1-gcc-jz3anmr/include/
     if(NOT VTK_LIB)
         message(FATAL_ERROR "xerces-c lib not found. Disable VTK support, if you do not need it.")
     endif()


### PR DESCRIPTION
This covers the case that the XERCES_INCDIR environment variable is not set properly.

If this is the case, we 
1. try to naively guess it from the library path
2. Throw a meaningful error if 1. fails