### PR TITLE
Fixes multiple memory leaks in tests

### DIFF
--- a/src/parallel/tests/DomainDecompositionTest.cpp
+++ b/src/parallel/tests/DomainDecompositionTest.cpp
@@ -21,7 +21,7 @@ DomainDecompositionTest::~DomainDecompositionTest() = default;
 
 void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * filename, double cutoff) {
 	// original pointer will be deleted by tearDown() (delete global_simulation)
-	std::unique_ptr<DomainDecomposition> _domainDecomposition {new DomainDecomposition()};
+	_domainDecomposition = new DomainDecomposition();
 
 	std::unique_ptr<ParticleContainer> container{
 		initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff)};
@@ -45,6 +45,8 @@ void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * fil
 	_domainDecomposition->collCommFinalize();
 
 	ASSERT_EQUAL(numMols, newNumMols);
+
+	delete _domainDecomposition;
 }
 
 void DomainDecompositionTest::testNoDuplicatedParticles() {
@@ -52,8 +54,7 @@ void DomainDecompositionTest::testNoDuplicatedParticles() {
 }
 
 void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename, double cutoff) {
-	// original pointer will be deleted by tearDown() (delete global_simulation)
-	std::unique_ptr<DomainDecomposition> _domainDecomposition{new DomainDecomposition()};
+	_domainDecomposition = new DomainDecomposition();
 
 	std::unique_ptr<ParticleContainer> container{
 		initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff)};
@@ -123,6 +124,8 @@ void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename,
 			}
 		}
 	}
+
+	delete _domainDecomposition;
 }
 
 void DomainDecompositionTest::testNoLostParticles() {

--- a/src/parallel/tests/DomainDecompositionTest.cpp
+++ b/src/parallel/tests/DomainDecompositionTest.cpp
@@ -23,9 +23,10 @@ DomainDecompositionTest::~DomainDecompositionTest() {
 
 void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * filename, double cutoff) {
 	// original pointer will be deleted by tearDown() (delete global_simulation)
-	_domainDecomposition = new DomainDecomposition();
+	std::unique_ptr<DomainDecomposition> _domainDecomposition {new DomainDecomposition()};
 
-	ParticleContainer* container = initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff);
+	std::unique_ptr<ParticleContainer> container{
+		initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff)};
 	int numMols = container->getNumberOfParticles();
 
 	_domainDecomposition->collCommInit(1);
@@ -34,7 +35,7 @@ void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * fil
 	numMols = _domainDecomposition->collCommGetInt();
 	_domainDecomposition->collCommFinalize();
 
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
+	_domainDecomposition->balanceAndExchange(0., true, container.get(), _domain);
 	container->deleteOuterParticles();
 
 	int newNumMols = container->getNumberOfParticles();
@@ -46,8 +47,6 @@ void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * fil
 	_domainDecomposition->collCommFinalize();
 
 	ASSERT_EQUAL(numMols, newNumMols);
-
-	delete _domainDecomposition;
 }
 
 void DomainDecompositionTest::testNoDuplicatedParticles() {

--- a/src/parallel/tests/DomainDecompositionTest.cpp
+++ b/src/parallel/tests/DomainDecompositionTest.cpp
@@ -55,9 +55,10 @@ void DomainDecompositionTest::testNoDuplicatedParticles() {
 
 void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename, double cutoff) {
 	// original pointer will be deleted by tearDown() (delete global_simulation)
-	_domainDecomposition = new DomainDecomposition();
+	std::unique_ptr<DomainDecomposition> _domainDecomposition{new DomainDecomposition()};
 
-	ParticleContainer* container = initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff);
+	std::unique_ptr<ParticleContainer> container{
+		initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff)};
 	int numMols = container->getNumberOfParticles();
 
 	_domainDecomposition->collCommInit(1);
@@ -99,7 +100,7 @@ void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename,
 
 	container->update();
 
-	_domainDecomposition->balanceAndExchange(0., true, container, _domain);
+	_domainDecomposition->balanceAndExchange(0., true, container.get(), _domain);
 	container->deleteOuterParticles();
 
 	int newNumMols = container->getNumberOfParticles();
@@ -124,8 +125,6 @@ void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename,
 			}
 		}
 	}
-
-	delete _domainDecomposition;
 }
 
 void DomainDecompositionTest::testNoLostParticles() {

--- a/src/parallel/tests/DomainDecompositionTest.cpp
+++ b/src/parallel/tests/DomainDecompositionTest.cpp
@@ -15,11 +15,9 @@
 
 TEST_SUITE_REGISTRATION(DomainDecompositionTest);
 
-DomainDecompositionTest::DomainDecompositionTest() {
-}
+DomainDecompositionTest::DomainDecompositionTest() = default;
 
-DomainDecompositionTest::~DomainDecompositionTest() {
-}
+DomainDecompositionTest::~DomainDecompositionTest() = default;
 
 void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * filename, double cutoff) {
 	// original pointer will be deleted by tearDown() (delete global_simulation)
@@ -27,7 +25,7 @@ void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * fil
 
 	std::unique_ptr<ParticleContainer> container{
 		initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff)};
-	int numMols = container->getNumberOfParticles();
+	auto numMols = container->getNumberOfParticles();
 
 	_domainDecomposition->collCommInit(1);
 	_domainDecomposition->collCommAppendInt(numMols);
@@ -38,7 +36,7 @@ void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * fil
 	_domainDecomposition->balanceAndExchange(0., true, container.get(), _domain);
 	container->deleteOuterParticles();
 
-	int newNumMols = container->getNumberOfParticles();
+	auto newNumMols = container->getNumberOfParticles();
 
 	_domainDecomposition->collCommInit(1);
 	_domainDecomposition->collCommAppendInt(newNumMols);
@@ -59,7 +57,7 @@ void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename,
 
 	std::unique_ptr<ParticleContainer> container{
 		initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff)};
-	int numMols = container->getNumberOfParticles();
+	auto numMols = container->getNumberOfParticles();
 
 	_domainDecomposition->collCommInit(1);
 	_domainDecomposition->collCommAppendInt(numMols);
@@ -103,7 +101,7 @@ void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename,
 	_domainDecomposition->balanceAndExchange(0., true, container.get(), _domain);
 	container->deleteOuterParticles();
 
-	int newNumMols = container->getNumberOfParticles();
+	auto newNumMols = container->getNumberOfParticles();
 
 	_domainDecomposition->collCommInit(1);
 	_domainDecomposition->collCommAppendInt(newNumMols);

--- a/src/parallel/tests/DomainDecompositionTest.cpp
+++ b/src/parallel/tests/DomainDecompositionTest.cpp
@@ -28,9 +28,9 @@ void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * fil
 	auto numMols = container->getNumberOfParticles();
 
 	_domainDecomposition->collCommInit(1);
-	_domainDecomposition->collCommAppendInt(numMols);
+	_domainDecomposition->collCommAppendUnsLong(numMols);
 	_domainDecomposition->collCommAllreduceSum();
-	numMols = _domainDecomposition->collCommGetInt();
+	numMols = _domainDecomposition->collCommGetUnsLong();
 	_domainDecomposition->collCommFinalize();
 
 	_domainDecomposition->balanceAndExchange(0., true, container.get(), _domain);
@@ -39,9 +39,9 @@ void DomainDecompositionTest::testNoDuplicatedParticlesFilename(const char * fil
 	auto newNumMols = container->getNumberOfParticles();
 
 	_domainDecomposition->collCommInit(1);
-	_domainDecomposition->collCommAppendInt(newNumMols);
+	_domainDecomposition->collCommAppendUnsLong(newNumMols);
 	_domainDecomposition->collCommAllreduceSum();
-	newNumMols = _domainDecomposition->collCommGetInt();
+	newNumMols = _domainDecomposition->collCommGetUnsLong();
 	_domainDecomposition->collCommFinalize();
 
 	ASSERT_EQUAL(numMols, newNumMols);
@@ -61,9 +61,9 @@ void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename,
 	auto numMols = container->getNumberOfParticles();
 
 	_domainDecomposition->collCommInit(1);
-	_domainDecomposition->collCommAppendInt(numMols);
+	_domainDecomposition->collCommAppendUnsLong(numMols);
 	_domainDecomposition->collCommAllreduceSum();
-	numMols = _domainDecomposition->collCommGetInt();
+	numMols = _domainDecomposition->collCommGetUnsLong();
 	_domainDecomposition->collCommFinalize();
 
 
@@ -105,9 +105,9 @@ void DomainDecompositionTest::testNoLostParticlesFilename(const char * filename,
 	auto newNumMols = container->getNumberOfParticles();
 
 	_domainDecomposition->collCommInit(1);
-	_domainDecomposition->collCommAppendInt(newNumMols);
+	_domainDecomposition->collCommAppendUnsLong(newNumMols);
 	_domainDecomposition->collCommAllreduceSum();
-	newNumMols = _domainDecomposition->collCommGetInt();
+	newNumMols = _domainDecomposition->collCommGetUnsLong();
 	_domainDecomposition->collCommFinalize();
 
 	//_domain->writeCheckpoint("dump.txt", container, _domainDecomposition, false);

--- a/src/parallel/tests/DomainDecompositionTest.h
+++ b/src/parallel/tests/DomainDecompositionTest.h
@@ -22,7 +22,7 @@ public:
 
 	DomainDecompositionTest();
 
-	virtual ~DomainDecompositionTest();
+	~DomainDecompositionTest() override;
 
 	void testNoDuplicatedParticles();
 	void testNoLostParticles();

--- a/src/plugins/tests/COMalignerTest.cpp
+++ b/src/plugins/tests/COMalignerTest.cpp
@@ -19,13 +19,13 @@ void COMalignerTest::testCOMalign() {
 
     const char* filename = "1clj-regular-2x2x2-offset.inp";
     double cutoff = .5;
-    ParticleContainer* container = initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff);
+	std::unique_ptr<ParticleContainer> container{
+		initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff)};
 
+	std::unique_ptr<COMaligner> plugin {new COMaligner()};
 
-    COMaligner* plugin = new COMaligner();
-
-    plugin->init(container, _domainDecomposition, _domain);
-    plugin->beforeForces(container, _domainDecomposition, 1);
+    plugin->init(container.get(), _domainDecomposition, _domain);
+    plugin->beforeForces(container.get(), _domainDecomposition, 1);
 
     double m = plugin->_mass;
     if (_domainDecomposition->getNumProcs() != 1) {
@@ -43,8 +43,9 @@ void COMalignerTest::testCOMalign() {
     ASSERT_EQUAL_MSG("z motion is wrong", -.25, plugin->_motion[2]);
 
     // initialize oldContainer only now, to prevent it from interfering with anything relevant!
-    ParticleContainer* oldContainer = initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff);
-    // TEST IF MOTION WAS APPLIED
+	std::unique_ptr<ParticleContainer> oldContainer{
+		initializeFromFile(ParticleContainerFactory::LinkedCell, filename, cutoff)};
+	// TEST IF MOTION WAS APPLIED
     auto newPos = container->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY);
     auto oldPos = oldContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY);
     while(newPos.isValid()){


### PR DESCRIPTION
Fixes memory leaks in:
- [x] in COMalignerTest::testCOMalign()
- [x] in DomainDecompositionTest::testNoDuplicatedParticlesFilename()
- [x] in DomainDecompositionTest::testNoLostParticlesFilename()

mostly fixed using std::unique_ptr, so this will also work on failures