### PR TITLE
Adds TimerWriter output plugin

### DIFF
--- a/doc/Plugins_Summary.dox
+++ b/doc/Plugins_Summary.dox
@@ -11,7 +11,7 @@ CavityWriter | cavity, output, profile, grid | Sets up a grid of pseudo-molecule
 CheckpointWriter | checkpoint, legacy | (Legacy) Checkpoint writer. Hint: use <type>binary</type> to speed-up. See also MPICheckpointWriter and MPI_IOCheckpointWriter.
 COMaligner | alignment, particleContainer utility, visualization | Calculates Center of Mass (COM) of all particles and aligns it with center of simulation box. Dimension/frequency/speed of alignment can be controlled via XML.
 CommunicationPartnerWriter | mpi, communication, output, debugging | Prints the CommunicationPartners for each rank in a separate file.
-DecompWriter | todo | todo. Writes information on the MPI Domain Decomposition.
+DecompWriter | mpi, print | Writes information on the MPI Domain Decomposition. For each rank the boxmin and boxmax is printed.
 DensityProfileWriter | todo | todo
 EnergyLogWriter | print, file, thermodynamic macroscopic quantities | Write the global \f$N\f$, \f$U_\mathrm{pot}\f$, \f$U_\mathrm{kin}\f$, \f$U_\mathrm{kinTrans}\f$, \f$U_\mathrm{kinRot}\f$, \f$T\f$, \f$p\f$ to file. Duplication with ResultWriter?
 ExamplePlugin  | example, sample, illustrate, usage | Print user-specifed text at a user-specified position in the code.  
@@ -25,7 +25,7 @@ SP / VelocityAbsProfile | velocity magnitude profile output | Outputs average ma
 SP / Velocity3dProfile | velocity 3d vector profile output | Outputs average velocity 3d-components per bin. Requires/auto enables DensityProfile.
 SP / TemperatureProfile | temperature profile output | Outputs the average temperature per sampling bin. Requires/auto enables DOFProfile and KineticProfile which dont write to file (as of now).
 SP / VirialProfile | virial pressure profile output | Outputs the virial/partial pressures in a special 1D output in y-direction. Requires/auto enables DensityProfile.
-LoadbalanceWriter | todo | todo
+LoadbalanceWriter | print, mpi, load balance, timers | Writes load balance information. Averages, min, max and a load balance is written. For more detailed output use the TimerWriter.
 MaxCheck  | todo | todo
 MaxWriter  | todo | todo
 Mirror  | todo | todo
@@ -38,6 +38,7 @@ RDF | radial distribution function | Calculate and write the radial distribution
 ResultWriter | print, macroscopic thermodynamic quantities, file | Write macroscopic thermodynamic quantities to file, such as temperature, pressure, BetaTrans, BetaRot, cv, number of molecules and number of cavities (?).
 SysMonOutput | todo | todo
 TestPlugin  | test | Test correctness of plugin calls within Simulation. Simpler version without XML input of ExamplePlugin
+TimerWriter | Timers, mpi, print, load balance | Prints the average time for the specified timers as a transient. Separate output for each rank. Can be used to gather information of the load balance.
 VectorizationTuner | todo | todo
 VISWriter | visualization?, todo | todo
 VTKGridWriter | vtk, grid | Write MPI rank, number of molecules in each cell in a .vtu or .pvtu file. Requires compiling with VTK=1.

--- a/src/io/LoadBalanceWriter.h
+++ b/src/io/LoadBalanceWriter.h
@@ -29,9 +29,9 @@
 class LoadbalanceWriter : public PluginBase {
 public:
 	LoadbalanceWriter();
-	~LoadbalanceWriter() {}
+	~LoadbalanceWriter() override = default;
 
-	/** @brief Read in XML configuration for DecompWriter.
+	/** @brief Read in XML configuration for LoadbalanceWriter.
 	 *
 	 * The following xml object structure is handled by this method:
 	 * parameters:
@@ -52,22 +52,22 @@ public:
 	   </outputplugin>
 	   \endcode
 	 */
-	void readXML(XMLfileUnits& xmlconfig);
+	void readXML(XMLfileUnits& xmlconfig) override;
 
 	void init(ParticleContainer *particleContainer,
-              DomainDecompBase *domainDecomp, Domain *domain);
+              DomainDecompBase *domainDecomp, Domain *domain) override;
 
 	void endStep(
             ParticleContainer *particleContainer,
             DomainDecompBase *domainDecomp, Domain *domain,
             unsigned long simstep
-    );
+    ) override;
 
-	void finish(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain) {
+	void finish(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain) override {
 		/* nothing to do */
 	}
 
-	std::string getPluginName() {
+	std::string getPluginName() override {
 		return std::string("LoadbalanceWriter");
 	}
 	static PluginBase* createInstance() { return new LoadbalanceWriter(); }

--- a/src/io/TimerProfiler.cpp
+++ b/src/io/TimerProfiler.cpp
@@ -64,10 +64,10 @@ void TimerProfiler::registerTimer(string timerName, vector<string> parentTimerNa
 	}
 	_timers[timerName] = _Timer(timerName, timer);
 
-	if (parentTimerNames.size() == 0) {
+	if (parentTimerNames.empty()) {
 		parentTimerNames.push_back(_baseTimerName);
 	}
-	for (auto parentTimerName : parentTimerNames) {
+	for (const auto& parentTimerName : parentTimerNames) {
 		_timers[timerName]._parentTimerNames.push_back(parentTimerName);
 		_timers[parentTimerName]._childTimerNames.push_back(timerName);
 	}
@@ -93,8 +93,8 @@ void TimerProfiler::print(string timerName, string outputPrefix){
 		_debugMessage(timerName);
 		return;
 	}
-	if( (getDisplayMode() == Displaymode::ALL) |
-		(getDisplayMode() == Displaymode::ACTIVE && getTimer(timerName)->isActive()) |
+	if( (getDisplayMode() == Displaymode::ALL) ||
+		(getDisplayMode() == Displaymode::ACTIVE && getTimer(timerName)->isActive()) ||
 		(getDisplayMode() == Displaymode::NON_ZERO && getTimer(timerName)->get_etime() > 0)
 	) {
 		global_log->info() << outputPrefix << getOutputString(timerName) << getTime(timerName) << " sec" << endl;
@@ -107,7 +107,7 @@ void TimerProfiler::printTimers(string timerName, string outputPrefix){
 		print(timerName, outputPrefix);
 		outputPrefix += "\t";
 	}
-	for(auto childTimerName : _timers[timerName]._childTimerNames){
+	for(const auto& childTimerName : _timers[timerName]._childTimerNames){
 		printTimers(childTimerName, outputPrefix);
 	}
 }

--- a/src/io/TimerWriter.cpp
+++ b/src/io/TimerWriter.cpp
@@ -1,0 +1,98 @@
+//
+// Created by seckler on 10.10.19.
+//
+
+#include <chrono>
+
+#include "TimerWriter.h"
+
+#include "Simulation.h"
+#include "parallel/DomainDecompBase.h"
+
+void TimerWriter::readXML(XMLfileUnits& xmlconfig) {
+	xmlconfig.getNodeValue("writefrequency", _writeFrequency);
+	global_log->info() << "Write frequency: " << _writeFrequency << endl;
+	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
+	global_log->info() << "Output prefix: " << _outputPrefix << endl;
+
+	XMLfile::Query query = xmlconfig.query("timers/timer");
+	std::string oldpath = xmlconfig.getcurrentnodepath();
+	for (auto timerIter = query.begin(); timerIter; ++timerIter) {
+		xmlconfig.changecurrentnode(timerIter);
+		std::string timername;
+		xmlconfig.getNodeValue("name", timername);
+		_timerNames.push_back(timername);
+
+		bool incrementalTimer = false;  // if the timer is increasing in every time step, this should be true
+		xmlconfig.getNodeValue("incremental", incrementalTimer);
+		_incremental.push_back(incrementalTimer);
+
+		global_log->info() << "Added timer for LB monitoring: " << timername << ", incremental: " << incrementalTimer
+						   << std::endl;
+	}
+	if (_timerNames.empty()) {
+		global_log->error() << "TimerWriter: no timers given. make sure you specify them correctly." << std::endl;
+		Simulation::exit(242367);
+	}
+	xmlconfig.changecurrentnode(oldpath);
+}
+
+void TimerWriter::init(ParticleContainer* /*particleContainer*/, DomainDecompBase* domainDecomp, Domain* /*domain*/) {
+	auto rank = domainDecomp->getRank();
+	std::stringstream filename;
+
+	auto timeNow = chrono::system_clock::now();
+	auto time_tNow = std::chrono::system_clock::to_time_t(timeNow);
+
+	auto maxRank = domainDecomp->getNumProcs();
+	auto numDigitsMaxRank = std::to_string(maxRank).length();
+
+	filename << _outputPrefix << "-rank" << setfill('0') << setw(numDigitsMaxRank) << rank << "_"
+			 << std::put_time(std::localtime(&time_tNow), "%Y-%m-%d_%H-%M-%S") << ".dat";
+
+	_fileStream.open(filename.str(), std::ofstream::out);
+
+	_fileStream << "timestep";
+
+	for (const auto& timerName : _timerNames) {
+		_fileStream << ";" << timerName;
+	}
+	_fileStream << std::endl;
+
+	_times.resize(_timerNames.size(), 0.);  // initialize to 0.
+}
+void TimerWriter::endStep(ParticleContainer* /*particleContainer*/, DomainDecompBase* /*domainDecomp*/,
+						  Domain* /*domain*/, unsigned long simstep) {
+	for (size_t i = 0; i < _timerNames.size(); ++i) {
+		if (not _incremental[i]) {
+			// save times for each time step, so we can average it later.
+			_times[i] += global_simulation->timers()->getTimer(_timerNames[i])->get_etime();
+		}
+		// nothing to do for incremental timers, as they track their overall time themselves.
+	}
+	// increase amount of written steps
+	++_stepsSinceLastWrite;
+
+	if (simstep % _writeFrequency == 0 and simstep != 0) {
+		_fileStream << simstep;
+		for (size_t i = 0; i < _timerNames.size(); ++i) {
+			double timeOneStep;
+			if (_incremental[i]) {
+				double currentTime = global_simulation->timers()->getTimer(_timerNames[i])->get_etime();
+				timeOneStep = (currentTime - _times[i]) / static_cast<double>(_stepsSinceLastWrite);
+				// incremental timer, so set to current time!
+				_times[i] = currentTime;
+			} else {
+				// we have added _stepsSinceLastWrite individual timing values, so divide by this number!
+				timeOneStep = _times[i] / static_cast<double>(_stepsSinceLastWrite);
+				// reset time to 0, so we can add them again.
+				_times[i] = 0;
+			}
+			_fileStream << ";" << timeOneStep;
+		}
+		_fileStream << std::endl;
+
+		// reset write state
+		_stepsSinceLastWrite = 0ul;
+	}
+}

--- a/src/io/TimerWriter.h
+++ b/src/io/TimerWriter.h
@@ -1,0 +1,62 @@
+//
+// Created by seckler on 10.10.19.
+//
+#pragma once
+
+#include <fstream>
+#include <vector>
+
+#include "plugins/PluginBase.h"
+#include "utils/Timer.h"
+
+/**
+ * Output plugin to write the timing info of timers to files.
+ * Every rank writes the info to a separate file.
+ * The average time spent in one simulation step is printed for the provided timers.
+ * Hereby the average is taken for writefrequency steps (printed if (sim step % write frequency == 0), except for the
+ * zeroth time step).
+ */
+class TimerWriter : public PluginBase {
+public:
+	/** @brief Read in XML configuration for TimerWriter.
+	 *
+	 * The following xml object structure is handled by this method:
+	 * parameters:
+	 * 	name: name of the timer
+	 * 	incremental: specifies whether the timer is incremental or not, (default is false)
+	 * 		e.g., a timer just measuring the time for the current time step is not incremental,
+	 * 			but one measuring the time since the first time step is incremental.
+	 * \code{.xml}
+	   <outputplugin name="TimerWriter">
+		 <writefrequency>INTEGER</writefrequency>
+		 <outputprefix>STRING</outputprefix><!--default is mardyn-timers. -rankX_TIMESTAMP.dat will be appended. -->
+		 <timers> <!-- timers that should be printed -->
+			<timer> <name>STRING</name> <incremental>BOOL</incremental> </timer>
+			<!-- ... -->
+		 </timers>
+	   </outputplugin>
+	   \endcode
+	 */
+	void readXML(XMLfileUnits &xmlconfig) override;
+
+	void init(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain) override;
+
+	void endStep(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain,
+				 unsigned long simstep) override;
+
+	void finish(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain) override {
+		/* nothing to do */
+	}
+
+	std::string getPluginName() override { return std::string("TimerWriter"); }
+	static PluginBase *createInstance() { return new TimerWriter(); }
+
+private:
+	unsigned long _writeFrequency{0ul};
+	std::ofstream _fileStream{};
+	std::string _outputPrefix{""};
+	std::vector<std::string> _timerNames{};
+	std::vector<bool> _incremental{};
+	std::vector<double> _times{};
+	unsigned long _stepsSinceLastWrite{0ul};
+};

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -32,6 +32,7 @@
 #include "io/RDF.h"
 #include "io/ResultWriter.h"
 #include "io/SysMonOutput.h"
+#include "io/TimerWriter.h"
 #include "io/VISWriter.h"
 #include "io/XyzWriter.h"
 
@@ -88,6 +89,7 @@ void PluginFactory<PluginBase>::registerDefaultPlugins(){
     REGISTER_PLUGIN(ResultWriter);
     REGISTER_PLUGIN(SysMonOutput);
     REGISTER_PLUGIN(TestPlugin);
+	REGISTER_PLUGIN(TimerWriter);
     REGISTER_PLUGIN(VectorizationTuner);
     REGISTER_PLUGIN(VISWriter);
     REGISTER_PLUGIN(WallPotential);

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -55,49 +55,49 @@
 #endif
 
 /** @brief Register all default plugins with base PluginBase
-	 *
-	 * @param createInstance  pointer to a function returning an instance of the plugin object.
-	 */
+ *
+ * @param createInstance  pointer to a function returning an instance of the plugin object.
+ */
 template<>
-void PluginFactory<PluginBase>::registerDefaultPlugins(){
-    global_log -> debug() << "REGISTERING PLUGINS" << endl;
+void PluginFactory<PluginBase>::registerDefaultPlugins() {
+	global_log->debug() << "REGISTERING PLUGINS" << endl;
 
-    REGISTER_PLUGIN(COMaligner);
-    REGISTER_PLUGIN(CavityWriter);
-    REGISTER_PLUGIN(CheckpointWriter);
-    REGISTER_PLUGIN(CommunicationPartnerWriter);
-    REGISTER_PLUGIN(DecompWriter);
-    REGISTER_PLUGIN(EnergyLogWriter);
-    REGISTER_PLUGIN(ExamplePlugin);
-    REGISTER_PLUGIN(FlopRateWriter);
-    REGISTER_PLUGIN(GammaWriter);
-    REGISTER_PLUGIN(HaloParticleWriter);
-    REGISTER_PLUGIN(InMemoryCheckpointing);
-    REGISTER_PLUGIN(SpatialProfile);
-    REGISTER_PLUGIN(LoadbalanceWriter);
-    REGISTER_PLUGIN(MPICheckpointWriter);
-    REGISTER_PLUGIN(MaxCheck);
-    REGISTER_PLUGIN(MaxWriter);
-    REGISTER_PLUGIN(Mirror);
-    REGISTER_PLUGIN(MirrorSystem);
-    REGISTER_PLUGIN(MmpldWriter);
-    REGISTER_PLUGIN(MmspdBinWriter);
-    REGISTER_PLUGIN(MmspdWriter);
-    REGISTER_PLUGIN(PovWriter);
-    REGISTER_PLUGIN(RDF);
-    REGISTER_PLUGIN(RegionSampling);
-    REGISTER_PLUGIN(ResultWriter);
-    REGISTER_PLUGIN(SysMonOutput);
-    REGISTER_PLUGIN(TestPlugin);
+	REGISTER_PLUGIN(COMaligner);
+	REGISTER_PLUGIN(CavityWriter);
+	REGISTER_PLUGIN(CheckpointWriter);
+	REGISTER_PLUGIN(CommunicationPartnerWriter);
+	REGISTER_PLUGIN(DecompWriter);
+	REGISTER_PLUGIN(EnergyLogWriter);
+	REGISTER_PLUGIN(ExamplePlugin);
+	REGISTER_PLUGIN(FlopRateWriter);
+	REGISTER_PLUGIN(GammaWriter);
+	REGISTER_PLUGIN(HaloParticleWriter);
+	REGISTER_PLUGIN(InMemoryCheckpointing);
+	REGISTER_PLUGIN(SpatialProfile);
+	REGISTER_PLUGIN(LoadbalanceWriter);
+	REGISTER_PLUGIN(MPICheckpointWriter);
+	REGISTER_PLUGIN(MaxCheck);
+	REGISTER_PLUGIN(MaxWriter);
+	REGISTER_PLUGIN(Mirror);
+	REGISTER_PLUGIN(MirrorSystem);
+	REGISTER_PLUGIN(MmpldWriter);
+	REGISTER_PLUGIN(MmspdBinWriter);
+	REGISTER_PLUGIN(MmspdWriter);
+	REGISTER_PLUGIN(PovWriter);
+	REGISTER_PLUGIN(RDF);
+	REGISTER_PLUGIN(RegionSampling);
+	REGISTER_PLUGIN(ResultWriter);
+	REGISTER_PLUGIN(SysMonOutput);
+	REGISTER_PLUGIN(TestPlugin);
 	REGISTER_PLUGIN(TimerWriter);
-    REGISTER_PLUGIN(VectorizationTuner);
-    REGISTER_PLUGIN(VISWriter);
-    REGISTER_PLUGIN(WallPotential);
-    REGISTER_PLUGIN(XyzWriter);
+	REGISTER_PLUGIN(VectorizationTuner);
+	REGISTER_PLUGIN(VISWriter);
+	REGISTER_PLUGIN(WallPotential);
+	REGISTER_PLUGIN(XyzWriter);
 #ifdef VTK
-    REGISTER_PLUGIN(VTKMoleculeWriter);
+	REGISTER_PLUGIN(VTKMoleculeWriter);
 #ifndef MARDYN_AUTOPAS
-    REGISTER_PLUGIN(VTKGridWriter);
+	REGISTER_PLUGIN(VTKGridWriter);
 #endif
 #endif
 }


### PR DESCRIPTION
# Description

Adds the TimerWriter output plugin to write the timers to files.

From the doc:
```
/**
 * Output plugin to write the timing info of timers to files.
 * Every rank writes the info to a separate file.
 * The average time spent in one simulation step is printed for the provided timers.
 * Hereby the average is taken for writefrequency steps (printed if (sim step % write frequency == 0), except for the
 * zeroth time step).
 */
```
# How Has This Been Tested?

- [x] ran locally with 1 and 2 processes
