### PR TITLE
Allow nested ParticleIterator loops inside of openmp

### DIFF
--- a/src/particleContainer/ParticleIterator.h
+++ b/src/particleContainer/ParticleIterator.h
@@ -60,10 +60,10 @@ public:
 	typedef size_t MolIndex_T;
 
 	ParticleIterator ();
-	ParticleIterator (Type t_arg, CellContainer_T_ptr cells_arg, const CellIndex_T offset_arg, const CellIndex_T stride_arg, const bool initialize=true);
+	ParticleIterator (Type t_arg, CellContainer_T_ptr cells_arg, CellIndex_T offset_arg, CellIndex_T stride_arg, bool initialize=true);
 	ParticleIterator& operator=(const ParticleIterator& other);
 
-	virtual ~ParticleIterator(){}
+	virtual ~ParticleIterator()= default;
 
 	Molecule& operator *  () const;
 	Molecule* operator -> () const;

--- a/src/particleContainer/RegionParticleIterator.h
+++ b/src/particleContainer/RegionParticleIterator.h
@@ -33,7 +33,7 @@ public:
 class RegionParticleIterator : public ParticleIterator {
 	public:
 		RegionParticleIterator ();
-		RegionParticleIterator (Type t, CellContainer_T_ptr cells_arg, const CellIndex_T offset_arg, const CellIndex_T stride_arg, const int startCellIndex_arg, const int regionDimensions_arg[3], const int globalDimensions_arg[3], const double startRegion_arg[3], const double endRegion_arg[3]);
+		RegionParticleIterator (Type t, CellContainer_T_ptr cells_arg, CellIndex_T offset_arg, CellIndex_T stride_arg, int startCellIndex_arg, const int regionDimensions_arg[3], const int globalDimensions_arg[3], const double startRegion_arg[3], const double endRegion_arg[3]);
 		RegionParticleIterator& operator=(const RegionParticleIterator& other);
 
 		void operator++() override;


### PR DESCRIPTION
# Description

Allows for nested ParticleIterator loops inside of openmp. E.g.:
(only allowed for non-newton3)
```C++
#pragma omp parallel
for (auto it1 = pc->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); it1.isValid(); ++it1) {
  // set `lo` and `hi`
  for (auto it2 = container->regionIterator(lo, hi, ParticleIterator::ALL_CELLS); it2.isValid(); ++it2) {
    // do something
  }
}
```

## Related Pull Requests

- needed for OpenMP parallel implementation of #98 


# How Has This Been Tested?

