### PR TITLE
Allows arbitrary timer to be used as load for domain decomposition.

### DIFF
--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -179,6 +179,7 @@
     <algorithm>
       <parallelisation type="DomainDecomposition">
           <CommunicationScheme>direct</CommunicationScheme>
+          <timerForCalculation>SIMULATION_FORCE_CALCULATION</timerForCalculation><!-- Timer to use as load. requires valid timer name! -->
       </parallelisation>
       <datastructure type="LinkedCells">
           <cellsInCutoffRadius>1</cellsInCutoffRadius>

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -104,7 +104,9 @@ public:
 	         <epsilon>DOUBLE</epsilon>
 	       </electrostatic>
 	       <datastructure type=STRING><!-- see ParticleContainer class documentation --></datastructure>
-	       <parallelisation type=STRING><!-- see DomainDecompBase class documentation --></parallelisation>
+	       <parallelisation type=STRING><!-- see DomainDecompBase class documentation -->
+	         <timerForCalculation>STRING</timerForCalculation><!-- Timer to use as load. requires valid timer name! -->
+	       </parallelisation>
 	       <thermostats>
 	         <thermostat type='VelocityScaling' componentId=STRING><!-- componentId can be component id or 'global' -->
 	           <temperature>DOUBLE</temperature>
@@ -458,6 +460,9 @@ public:
 	bool keepRunning();
 
 private:
+
+	/// the timer used for the load calculation.
+	Timer* _timerForLoad{nullptr};
 
 	Timer _timeFromStart;
 	double _maxWallTime = -1;


### PR DESCRIPTION
# Description

This can be specified in the xml inside of the <parallelisation> tag using, e.g.,
```xml
<timerForCalculation>SIMULATION_FORCE_CALCULATION</timerForCalculation>
```
## Resolved Issues

- Allows different timers to be used as load for e.g. the GeneralDomainDecomposition.
- We might want to update the default from `SIMULATION_COMPUTATION` to `SIMULATION_FORCE_CALCULATION`, as `SIMULATION_COMPUTATION` (which was the same as the perStepTimer that was used before) include calls to global calculation and is thus not always useful...

# How Has This Been Tested?

- [x] locally, also for stupid input (aborts with error)
