### PR TITLE
AutoPas or RMM: fix binary checkpoints

### DIFF
--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -583,7 +583,7 @@ void Domain::writeCheckpointHeaderXML(string filename, ParticleContainer* partic
 	ofs << "\t\t</length>" << endl;
 	ofs.flags(f);  // restore default format flags
 	ofs << "\t\t<number>" << _globalNumMolecules << "</number>" << endl;
-	ofs << "\t\t<format type=\"ICRVQD\"/>" << endl;
+	ofs << "\t\t<format type=\"" << Molecule::getWriteFormat() << "\"/>" << endl;
 	ofs << "\t</headerinfo>" << endl;
 	ofs << "</mardyn>" << endl;
 }


### PR DESCRIPTION
Fixes restarting of checkpoint files written using the BinaryWriter and enabled AutoPas or RMM mode.

Cause:
* The WriteFormat was set to ICRVQD instead of using Molecule::getWriteFormat().

Fix:
* Correctly use Molecule::getWriteFormat().

