### PR TITLE
Fix neighbor acquirer (GDD, push-pull)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -200,7 +200,7 @@ pipeline {
                   unstash 'autopas_mpi_exec'
                   dir ("build-mpi"){
                     sh """
-                      mpirun -n 3 ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml --steps=20 | tee autopas_run_log.txt
+                      mpirun -n 2 ./src/MarDyn ../examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml --steps=20 | tee autopas_run_log.txt
                       grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
                       grep "T = 0.000633975" simstep20.txt
                       grep "U_pot = -2.14161" simstep20.txt

--- a/examples/Argon/200K_18mol_l/config.xml
+++ b/examples/Argon/200K_18mol_l/config.xml
@@ -30,7 +30,9 @@
       </phasespacepoint>
     </ensemble>
     <algorithm>
-      <parallelisation type="DomainDecomposition"/>
+      <parallelisation type="DomainDecomposition">
+	<timerForLoad>SIMULATION_FORCE_CALCULATION</timerForLoad>
+      </parallelisation>
       <datastructure type="LinkedCells">
         <cellsInCutoffRadius>1</cellsInCutoffRadius>
       </datastructure>

--- a/src/parallel/CommunicationPartner.h
+++ b/src/parallel/CommunicationPartner.h
@@ -138,6 +138,8 @@ private:
 	bool _msgSent, _countReceived, _msgReceived;
 
 	void collectLeavingMoleculesFromInvalidParticles(std::vector<Molecule>& invalidParticles, double lowCorner [3], double highCorner [3], double shift [3]);
+
+	friend class NeighborAcquirerTest;
 };
 
 #endif /* COMMUNICATIONPARTNER_H_ */

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -138,9 +138,10 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 	std::vector<HaloRegion> desiredDomain{newDomain};
 	std::vector<CommunicationPartner> sendNeighbors{}, recvNeighbors{};
 
+	std::array<double, 3> globalDomainLength {domain->getGlobalLength(0),domain->getGlobalLength(1), domain->getGlobalLength(2)};
 	// 0. skin, as it is not needed for the migration of particles!
 	std::tie(recvNeighbors, sendNeighbors) =
-		NeighborAcquirer::acquireNeighbors(domain, &ownDomain, desiredDomain, 0. /*skin*/);
+		NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownDomain, desiredDomain, 0. /*skin*/);
 
 	std::vector<Molecule> dummy;
 	for (auto& sender : sendNeighbors) {

--- a/src/parallel/NeighborAcquirer.cpp
+++ b/src/parallel/NeighborAcquirer.cpp
@@ -155,14 +155,14 @@ std::tuple<std::vector<CommunicationPartner>, std::vector<CommunicationPartner>>
 					for (int dimI = 0; dimI < 3; ++dimI) {
 						unshiftedOverlappedRegion.rmax[dimI] -= currentShift[dimI];
 						if (fabs(unshiftedOverlappedRegion.rmax[dimI]) < 1e-10 and currentShift[dimI] != 0.) {
-							std::cout << "shift corrected." << std::endl;
+							// std::cout << "shift corrected." << std::endl;
 							// we have to ensure that if we shifted, then the rmax, etc. are correct!
 							unshiftedOverlappedRegion.rmax[dimI] = 0.;
 						}
 						unshiftedOverlappedRegion.rmin[dimI] -= currentShift[dimI];
 						if (fabs(unshiftedOverlappedRegion.rmin[dimI] - globalDomainLength[dimI]) < 1e-10 and
 							currentShift[dimI] != 0.) {
-							std::cout << "shift corrected." << std::endl;
+							// std::cout << "shift corrected." << std::endl;
 							// we have to ensure that if we shifted, then the rmax, etc. are correct!
 							unshiftedOverlappedRegion.rmin[dimI] = globalDomainLength[dimI];
 						}

--- a/src/parallel/NeighborAcquirer.cpp
+++ b/src/parallel/NeighborAcquirer.cpp
@@ -310,38 +310,13 @@ bool NeighborAcquirer::isIncluded(HaloRegion *myRegion, HaloRegion *inQuestion) 
 
 void NeighborAcquirer::overlap(HaloRegion *myRegion, HaloRegion *inQuestion) {
 	/*
-	 * m = myRegion, q = inQuestion, o = overlap
-	 * i)  m.max < q.max ?
-	 * ii) m.min < q.min ?
-	 *
-	 * i) | ii) | Operation
-	 * -------------------------------------------
-	 *  0 |  0  | o.max = q.max and o.min = m.min
-	 *  0 |  1  | o.max = q.max and o.min = q.min
-	 *  1 |  0  | o.max = m.max and o.min = m.min
-	 *  1 |  1  | o.max = m.max and o.min = q.min
-	 *
+	 * Choose the overlap of myRegion and inQuestion.
 	 */
 	HaloRegion overlap{};
 
 	for (int i = 0; i < 3; i++) {
-		if (myRegion->rmax[i] < inQuestion->rmax[i]) {      // 1
-			if (myRegion->rmin[i] < inQuestion->rmin[i]) {  // 1 1
-				overlap.rmax[i] = myRegion->rmax[i];
-				overlap.rmin[i] = inQuestion->rmin[i];
-			} else {  // 1 0
-				overlap.rmax[i] = myRegion->rmax[i];
-				overlap.rmin[i] = myRegion->rmin[i];
-			}
-		} else {                                            // 0
-			if (myRegion->rmin[i] < inQuestion->rmin[i]) {  // 0 1
-				overlap.rmax[i] = inQuestion->rmax[i];
-				overlap.rmin[i] = inQuestion->rmin[i];
-			} else {  // 0 0
-				overlap.rmax[i] = inQuestion->rmax[i];
-				overlap.rmin[i] = myRegion->rmin[i];
-			}
-		}
+		overlap.rmax[i] = std::min(myRegion->rmax[i], inQuestion->rmax[i]);
+		overlap.rmin[i] = std::max(myRegion->rmin[i], inQuestion->rmin[i]);
 	}
 
 	// adjust width and offset?

--- a/src/parallel/NeighborAcquirer.cpp
+++ b/src/parallel/NeighborAcquirer.cpp
@@ -155,14 +155,12 @@ std::tuple<std::vector<CommunicationPartner>, std::vector<CommunicationPartner>>
 					for (int dimI = 0; dimI < 3; ++dimI) {
 						unshiftedOverlappedRegion.rmax[dimI] -= currentShift[dimI];
 						if (fabs(unshiftedOverlappedRegion.rmax[dimI]) < 1e-10 and currentShift[dimI] != 0.) {
-							// std::cout << "shift corrected." << std::endl;
 							// we have to ensure that if we shifted, then the rmax, etc. are correct!
 							unshiftedOverlappedRegion.rmax[dimI] = 0.;
 						}
 						unshiftedOverlappedRegion.rmin[dimI] -= currentShift[dimI];
 						if (fabs(unshiftedOverlappedRegion.rmin[dimI] - globalDomainLength[dimI]) < 1e-10 and
 							currentShift[dimI] != 0.) {
-							// std::cout << "shift corrected." << std::endl;
 							// we have to ensure that if we shifted, then the rmax, etc. are correct!
 							unshiftedOverlappedRegion.rmin[dimI] = globalDomainLength[dimI];
 						}

--- a/src/parallel/NeighborAcquirer.cpp
+++ b/src/parallel/NeighborAcquirer.cpp
@@ -18,7 +18,7 @@
  * saved in partners01.
  */
 std::tuple<std::vector<CommunicationPartner>, std::vector<CommunicationPartner>> NeighborAcquirer::acquireNeighbors(
-	Domain *domain, HaloRegion *ownRegion, std::vector<HaloRegion> &desiredRegions, double skin) {
+	const std::array<double,3>& globalDomainLength, HaloRegion *ownRegion, std::vector<HaloRegion> &desiredRegions, double skin) {
 
 	HaloRegion ownRegionEnlargedBySkin = *ownRegion;
 	for(unsigned int dim = 0; dim < 3; ++dim){
@@ -107,9 +107,7 @@ std::tuple<std::vector<CommunicationPartner>, std::vector<CommunicationPartner>>
 
 			// msg format one region: rmin | rmax | offset | width | shift
 			std::array<double, 3> shift{};
-			double domainLength[3] = {domain->getGlobalLength(0), domain->getGlobalLength(1),
-									  domain->getGlobalLength(2)};  // better for testing
-			auto shiftedRegion = getPotentiallyShiftedRegion(domainLength, unshiftedRegion, shift.data(), skin);
+			auto shiftedRegion = getPotentiallyShiftedRegion(globalDomainLength, unshiftedRegion, shift.data(), skin);
 
 			std::vector<HaloRegion> regionsToTest;
 			std::vector<std::array<double, 3>> shifts;
@@ -351,7 +349,7 @@ void NeighborAcquirer::overlap(HaloRegion *myRegion, HaloRegion *inQuestion) {
 	memcpy(inQuestion->rmin, overlap.rmin, sizeof(double) * 3);
 }
 
-HaloRegion NeighborAcquirer::getPotentiallyShiftedRegion(const double *domainLength, const HaloRegion &region,
+HaloRegion NeighborAcquirer::getPotentiallyShiftedRegion(const std::array<double,3>& domainLength, const HaloRegion &region,
 														 double *shiftArray, double skin) {
 	for (int i = 0; i < 3; i++) {  // calculating shift
 		if (region.rmin[i] >= domainLength[i] - skin) {

--- a/src/parallel/NeighborAcquirer.h
+++ b/src/parallel/NeighborAcquirer.h
@@ -26,14 +26,18 @@ public:
 	 * second vector will own the particles.
 	 */
 	static std::tuple<std::vector<CommunicationPartner>, std::vector<CommunicationPartner>> acquireNeighbors(
-		Domain* domain, HaloRegion* ownRegion, std::vector<HaloRegion>& desiredRegions, double skin);
+		const std::array<double,3>& globalDomainLength, HaloRegion* ownRegion, std::vector<HaloRegion>& desiredRegions, double skin);
+
 	static std::vector<CommunicationPartner> squeezePartners(const std::vector<CommunicationPartner>& partners);
 
 private:
 	static bool isIncluded(HaloRegion* myRegion, HaloRegion* inQuestion);
+
 	static void overlap(HaloRegion* myRegion, HaloRegion* inQuestion);
-	static HaloRegion getPotentiallyShiftedRegion(const double* domainLength, const HaloRegion& region,
+
+	static HaloRegion getPotentiallyShiftedRegion(const std::array<double,3>& domainLength, const HaloRegion& region,
 												  double* shiftArray, double skin);
+
 	/**
 	 * Get all possible combinations of halo regions and shifts, where the given halo region nonShiftedRegion can get
 	 * particles from.
@@ -52,6 +56,6 @@ private:
 	static std::tuple<std::vector<HaloRegion>, std::vector<std::array<double, 3>>>
 	getAllShiftedAndNonShiftedRegionsAndShifts(HaloRegion nonShiftedRegion, HaloRegion shiftedRegion,
 											  std::array<double, 3> shift);
-    friend class NeighbourCommunicationSchemeTest;
 
+    friend class NeighbourCommunicationSchemeTest;
 };

--- a/src/parallel/NeighborAcquirer.h
+++ b/src/parallel/NeighborAcquirer.h
@@ -57,5 +57,5 @@ private:
 	getAllShiftedAndNonShiftedRegionsAndShifts(HaloRegion nonShiftedRegion, HaloRegion shiftedRegion,
 											  std::array<double, 3> shift);
 
-    friend class NeighbourCommunicationSchemeTest;
+    friend class NeighborAcquirerTest;
 };

--- a/src/parallel/NeighborAcquirer.h
+++ b/src/parallel/NeighborAcquirer.h
@@ -33,7 +33,7 @@ public:
 private:
 	static bool isIncluded(HaloRegion* myRegion, HaloRegion* inQuestion);
 
-	static void overlap(HaloRegion* myRegion, HaloRegion* inQuestion);
+	static HaloRegion overlap(const HaloRegion& myRegion, const HaloRegion& inQuestion);
 
 	static HaloRegion getPotentiallyShiftedRegion(const std::array<double,3>& domainLength, const HaloRegion& region,
 												  double* shiftArray, double skin);

--- a/src/parallel/NeighbourCommunicationScheme.cpp
+++ b/src/parallel/NeighbourCommunicationScheme.cpp
@@ -238,6 +238,18 @@ void DirectNeighbourCommunicationScheme::initExchangeMoleculesMPI(ParticleContai
 		global_log->error_always_output() << "NeighbourCommunicationScheme: Invalid particles that should have been "
 											 "removed, are still existent. They would be lost. Aborting..."
 										  << std::endl;
+		global_log->error_always_output() << "The particles:" << std::endl;
+		for (auto& invalidParticle : invalidParticles) {
+			std::stringstream ss;
+			invalidParticle.write(ss);
+			global_log->error_always_output() << ss.str() << std::endl;
+		}
+		global_log->error_always_output() << "The leavingExportNeighbours:" << std::endl;
+		for (auto& neighbour : (*_leavingExportNeighbours)[0]) {
+			std::stringstream ss;
+			neighbour.print(ss);
+			global_log->error_always_output() << ss.str() << std::endl;
+		}
 		Simulation::exit(544);
 	}
 

--- a/src/parallel/NeighbourCommunicationScheme.cpp
+++ b/src/parallel/NeighbourCommunicationScheme.cpp
@@ -456,12 +456,13 @@ void DirectNeighbourCommunicationScheme::initCommunicationPartners(double cutoff
 				_zonalMethod->getLeavingExportRegions(ownRegion, cutoffRadius,
 						_coversWholeDomain);
 
+		std::array<double, 3> globalDomainLength {domain->getGlobalLength(0),domain->getGlobalLength(1), domain->getGlobalLength(2)};
 		// assuming p1 sends regions to p2
 		std::tie((*_haloImportForceExportNeighbours)[0], (*_haloExportForceImportNeighbours)[0]) =
-			NeighborAcquirer::acquireNeighbors(domain, &ownRegion, haloOrForceRegions, skin);
+			NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownRegion, haloOrForceRegions, skin);
 		// p1 notes reply, p2 notes owned as haloExportForceImport
 		std::tie((*_leavingExportNeighbours)[0], (*_leavingImportNeighbours)[0]) =
-			NeighborAcquirer::acquireNeighbors(domain, &ownRegion, leavingRegions, 0.);
+			NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownRegion, leavingRegions, 0.);
 		// p1 notes reply, p2 notes owned as leaving import
 
 

--- a/src/parallel/tests/NeighborAcquirerTest.cpp
+++ b/src/parallel/tests/NeighborAcquirerTest.cpp
@@ -198,6 +198,7 @@ void NeighborAcquirerTest::testCorrectNeighborAcquisition() {
 	MPI_Comm_size(MPI_COMM_WORLD, &numRanks);
 
 	if (numRanks != 2) {
+		std::cout << "SKIPPED: requires two processes, but run with "<< numRanks <<"." << std::endl;
 		// test is only meant for two processes!
 		return;
 	}

--- a/src/parallel/tests/NeighborAcquirerTest.cpp
+++ b/src/parallel/tests/NeighborAcquirerTest.cpp
@@ -4,26 +4,25 @@
  * and open the template in the editor.
  */
 
-#include "NeighbourCommunicationSchemeTest.h"
+#include "NeighborAcquirerTest.h"
 #include "parallel/NeighborAcquirer.h"
 
 using namespace std;
 
-TEST_SUITE_REGISTRATION(NeighbourCommunicationSchemeTest);
+TEST_SUITE_REGISTRATION(NeighborAcquirerTest);
 
-
-NeighbourCommunicationSchemeTest::NeighbourCommunicationSchemeTest() {
+NeighborAcquirerTest::NeighborAcquirerTest() {
 	_fullShell = new FullShell();
 	_directScheme = new DirectNeighbourCommunicationScheme(_fullShell, true);
 }
 
-NeighbourCommunicationSchemeTest::~NeighbourCommunicationSchemeTest() {
+NeighborAcquirerTest::~NeighborAcquirerTest() {
 	//delete _fullShell;
 	delete _directScheme;
 }
 
 
-void NeighbourCommunicationSchemeTest::testShiftIfNecessary() {
+void NeighborAcquirerTest::testShiftIfNecessary() {
 	HaloRegion region; // rmin, rmax, offset, width
 	std::array<double,3> domainLength = {10.0, 10.0, 10.0};
 	double shift[3] = {0.0};
@@ -53,7 +52,7 @@ void NeighbourCommunicationSchemeTest::testShiftIfNecessary() {
 	
 }
 
-void NeighbourCommunicationSchemeTest::testOverlap() { // assume this one works for now, because you thought about it long and hard.
+void NeighborAcquirerTest::testOverlap() { // assume this one works for now, because you thought about it long and hard.
 	HaloRegion region01;
 	HaloRegion region02;
 	
@@ -128,7 +127,7 @@ void NeighbourCommunicationSchemeTest::testOverlap() { // assume this one works 
 	}
 }
 
-void NeighbourCommunicationSchemeTest::testIOwnThis() { // i own a part of this
+void NeighborAcquirerTest::testIOwnThis() { // i own a part of this
 	HaloRegion region01;
 	HaloRegion region02;
 	

--- a/src/parallel/tests/NeighborAcquirerTest.cpp
+++ b/src/parallel/tests/NeighborAcquirerTest.cpp
@@ -1,7 +1,8 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * File:   NeighborAcquirerTest.h
+ * Author: bierth, seckler
+ *
+ * Created on February 27, 2018, 5:01 PM
  */
 
 #include "NeighborAcquirerTest.h"
@@ -13,14 +14,9 @@ TEST_SUITE_REGISTRATION(NeighborAcquirerTest);
 
 NeighborAcquirerTest::NeighborAcquirerTest() {
 	_fullShell = new FullShell();
-	_directScheme = new DirectNeighbourCommunicationScheme(_fullShell, true);
 }
 
-NeighborAcquirerTest::~NeighborAcquirerTest() {
-	//delete _fullShell;
-	delete _directScheme;
-}
-
+NeighborAcquirerTest::~NeighborAcquirerTest() { delete _fullShell; }
 
 void NeighborAcquirerTest::testShiftIfNecessary() {
 	HaloRegion region; // rmin, rmax, offset, width

--- a/src/parallel/tests/NeighborAcquirerTest.cpp
+++ b/src/parallel/tests/NeighborAcquirerTest.cpp
@@ -59,12 +59,12 @@ void NeighborAcquirerTest::testOverlap() { // assume this one works for now, bec
 		region02.rmax[i] = 6.0;
 		region02.rmin[i] = 3.0;
 	}
-	
-	NeighborAcquirer::overlap(&region01, &region02);
+
+	auto overlap = NeighborAcquirer::overlap(region01, region02);
 	
 	for(int i = 0; i < 3; i++) {
-		ASSERT_EQUAL(region02.rmax[i], 4.0);
-		ASSERT_EQUAL(region02.rmin[i], 3.0);
+		ASSERT_EQUAL(overlap.rmax[i], 4.0);
+		ASSERT_EQUAL(overlap.rmin[i], 3.0);
 	}
 	
 	for(int i = 0; i < 3; i++) {
@@ -73,12 +73,12 @@ void NeighborAcquirerTest::testOverlap() { // assume this one works for now, bec
 		region02.rmax[i] = 5.0;
 		region02.rmin[i] = 3.0;
 	}
-	
-	NeighborAcquirer::overlap(&region01, &region02);
+
+	overlap = NeighborAcquirer::overlap(region01, region02);
 	
 	for(int i = 0; i < 3; i++) {
-		ASSERT_EQUAL(region02.rmax[i], 5.0);
-		ASSERT_EQUAL(region02.rmin[i], 3.0);
+		ASSERT_EQUAL(overlap.rmax[i], 5.0);
+		ASSERT_EQUAL(overlap.rmin[i], 3.0);
 	}
 	
 	for(int i = 0; i < 3; i++) {
@@ -88,11 +88,11 @@ void NeighborAcquirerTest::testOverlap() { // assume this one works for now, bec
 		region02.rmin[i] = 1.0;
 	}
 	
-	NeighborAcquirer::overlap(&region01, &region02);
+	overlap = NeighborAcquirer::overlap(region01, region02);
 	
 	for(int i = 0; i < 3; i++) {
-		ASSERT_EQUAL(region02.rmax[i], 3.0);
-		ASSERT_EQUAL(region02.rmin[i], 2.0);
+		ASSERT_EQUAL(overlap.rmax[i], 3.0);
+		ASSERT_EQUAL(overlap.rmin[i], 2.0);
 	}
 	
 	for(int i = 0; i < 3; i++) {
@@ -102,11 +102,11 @@ void NeighborAcquirerTest::testOverlap() { // assume this one works for now, bec
 		region02.rmin[i] = 1.0;
 	}
 	
-	NeighborAcquirer::overlap(&region01, &region02);
+	overlap = NeighborAcquirer::overlap(region01, region02);
 	
 	for(int i = 0; i < 3; i++) {
-		ASSERT_EQUAL(region02.rmax[i], 4.0);
-		ASSERT_EQUAL(region02.rmin[i], 2.0);
+		ASSERT_EQUAL(overlap.rmax[i], 4.0);
+		ASSERT_EQUAL(overlap.rmin[i], 2.0);
 	}
 	
 	for(int i = 0; i < 3; i++) {
@@ -116,11 +116,11 @@ void NeighborAcquirerTest::testOverlap() { // assume this one works for now, bec
 		region02.rmin[i] = 2.0;
 	}
 	
-	NeighborAcquirer::overlap(&region01, &region02);
+	overlap = NeighborAcquirer::overlap(region01, region02);
 	
 	for(int i = 0; i < 3; i++) {
-		ASSERT_EQUAL(region02.rmax[i], 6.0);
-		ASSERT_EQUAL(region02.rmin[i], 2.0);
+		ASSERT_EQUAL(overlap.rmax[i], 6.0);
+		ASSERT_EQUAL(overlap.rmin[i], 2.0);
 	}
 }
 
@@ -226,6 +226,7 @@ void NeighborAcquirerTest::testCorrectNeighborAcquisition() {
 		for (auto& haloRegion : neighbor._haloInfo) {
 			for (auto i = 0; i < 3; ++i) {
 				std::stringstream ss;
+				ss << "in leavingExport: " << std::endl;
 				neighbor.print(ss);
 				ASSERT_TRUE_MSG(ss.str(),haloRegion._leavingLow[i] >= otherRegion.rmin[i]);
 				ASSERT_TRUE_MSG(ss.str(),haloRegion._leavingHigh[i] <= otherRegion.rmax[i]);
@@ -236,6 +237,7 @@ void NeighborAcquirerTest::testCorrectNeighborAcquisition() {
 		for (auto& haloRegion : neighbor._haloInfo) {
 			for (auto i = 0; i < 3; ++i) {
 				std::stringstream ss;
+				ss << "in leavingImport: " << std::endl;
 				neighbor.print(ss);
 				ASSERT_TRUE_MSG(ss.str(),haloRegion._leavingLow[i] >= ownRegion.rmin[i]);
 				ASSERT_TRUE_MSG(ss.str(),haloRegion._leavingHigh[i] <= ownRegion.rmax[i]);

--- a/src/parallel/tests/NeighborAcquirerTest.cpp
+++ b/src/parallel/tests/NeighborAcquirerTest.cpp
@@ -222,15 +222,23 @@ void NeighborAcquirerTest::testCorrectNeighborAcquisition() {
 		NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownRegion, leavingRegions, 0.);
 	// p1 notes reply, p2 notes owned as leaving import
 
-	if (not rank) {
-		for (auto& neighbor : leavingExportNeighbours) {
-			for (auto& haloRegion : neighbor._haloInfo) {
-				for (auto i = 0; i < 3; ++i) {
-					std::stringstream ss;
-					neighbor.print(ss);
-					ASSERT_TRUE_MSG(ss.str(),haloRegion._leavingLow[i] >= otherRegion.rmin[i]);
-					ASSERT_TRUE_MSG(ss.str(),haloRegion._leavingHigh[i] >= otherRegion.rmax[i]);
-				}
+	for (auto& neighbor : leavingExportNeighbours) {
+		for (auto& haloRegion : neighbor._haloInfo) {
+			for (auto i = 0; i < 3; ++i) {
+				std::stringstream ss;
+				neighbor.print(ss);
+				ASSERT_TRUE_MSG(ss.str(),haloRegion._leavingLow[i] >= otherRegion.rmin[i]);
+				ASSERT_TRUE_MSG(ss.str(),haloRegion._leavingHigh[i] <= otherRegion.rmax[i]);
+			}
+		}
+	}
+	for (auto& neighbor : leavingImportNeighbours) {
+		for (auto& haloRegion : neighbor._haloInfo) {
+			for (auto i = 0; i < 3; ++i) {
+				std::stringstream ss;
+				neighbor.print(ss);
+				ASSERT_TRUE_MSG(ss.str(),haloRegion._leavingLow[i] >= ownRegion.rmin[i]);
+				ASSERT_TRUE_MSG(ss.str(),haloRegion._leavingHigh[i] <= ownRegion.rmax[i]);
 			}
 		}
 	}

--- a/src/parallel/tests/NeighborAcquirerTest.h
+++ b/src/parallel/tests/NeighborAcquirerTest.h
@@ -1,12 +1,6 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
-/* 
  * File:   NeighborAcquirerTest.h
- * Author: bierth
+ * Author: bierth, seckler
  *
  * Created on February 27, 2018, 5:01 PM
  */
@@ -35,8 +29,6 @@ class NeighborAcquirerTest : public utils::TestWithSimulationSetup {
 		void testIOwnThis();		
 	private:
 		FullShell* _fullShell;
-		DirectNeighbourCommunicationScheme* _directScheme;
-	
 };
 
 

--- a/src/parallel/tests/NeighborAcquirerTest.h
+++ b/src/parallel/tests/NeighborAcquirerTest.h
@@ -19,6 +19,7 @@ class NeighborAcquirerTest : public utils::TestWithSimulationSetup {
 	TEST_METHOD(testShiftIfNecessary);
 	TEST_METHOD(testOverlap);
 	TEST_METHOD(testIOwnThis);
+	TEST_METHOD(testCorrectNeighborAcquisition);
 	TEST_SUITE_END();
 	
 	public:
@@ -26,7 +27,8 @@ class NeighborAcquirerTest : public utils::TestWithSimulationSetup {
 		~NeighborAcquirerTest();
 		void testShiftIfNecessary();
 		void testOverlap();
-		void testIOwnThis();		
+		void testIOwnThis();
+		void testCorrectNeighborAcquisition();
 	private:
 		FullShell* _fullShell;
 };

--- a/src/parallel/tests/NeighborAcquirerTest.h
+++ b/src/parallel/tests/NeighborAcquirerTest.h
@@ -5,7 +5,7 @@
  */
 
 /* 
- * File:   NeighbourCommunicationSchemeTest.h
+ * File:   NeighborAcquirerTest.h
  * Author: bierth
  *
  * Created on February 27, 2018, 5:01 PM
@@ -19,17 +19,17 @@
 #include "parallel/NeighbourCommunicationScheme.h"
 
 
-class NeighbourCommunicationSchemeTest : public utils::TestWithSimulationSetup {
+class NeighborAcquirerTest : public utils::TestWithSimulationSetup {
 	
-	TEST_SUITE(NeighbourCommunicationSchemeTest);
+	TEST_SUITE(NeighborAcquirerTest);
 	TEST_METHOD(testShiftIfNecessary);
 	TEST_METHOD(testOverlap);
 	TEST_METHOD(testIOwnThis);
 	TEST_SUITE_END();
 	
 	public:
-		NeighbourCommunicationSchemeTest();
-		~NeighbourCommunicationSchemeTest();
+		NeighborAcquirerTest();
+		~NeighborAcquirerTest();
 		void testShiftIfNecessary();
 		void testOverlap();
 		void testIOwnThis();		

--- a/src/parallel/tests/NeighbourCommunicationSchemeTest.cpp
+++ b/src/parallel/tests/NeighbourCommunicationSchemeTest.cpp
@@ -25,7 +25,7 @@ NeighbourCommunicationSchemeTest::~NeighbourCommunicationSchemeTest() {
 
 void NeighbourCommunicationSchemeTest::testShiftIfNecessary() {
 	HaloRegion region; // rmin, rmax, offset, width
-	double domainLength[3] = {10.0, 10.0, 10.0};
+	std::array<double,3> domainLength = {10.0, 10.0, 10.0};
 	double shift[3] = {0.0};
 	
 	// region does not need to be shifted


### PR DESCRIPTION
# Description

Fixes Neighbor acquirer.

## Related Pull Requests

- bug introduced in #82 

## Resolved Issues

- NeighborAcquirer did not return overlapped domains to the sending process, so particles could be sent to processes they shouldn't be sent to and thus lost. Applicable when using the direct-push-pull scheme.

# How Has This Been Tested?

- [x] New test `NeighborAcquirerTest::testCorrectNeighborAcquisition()` -- that fails without the fix and works with the fix :)
