### PR TITLE
RDF resolved in Angular direction (ARDF) is now available as an addit…

### DIFF
--- a/doc/Plugins_Summary.dox
+++ b/doc/Plugins_Summary.dox
@@ -34,7 +34,7 @@ MmspdBinWriter  | visualization, todo | todo
 MPI_IOCheckpointWriter  | todo | todo
 MPICheckpointWriter | todo | todo
 PovWriter | visualization?, todo | todo
-RDF | radial distribution function | Calculate and write the radial distribution function to file. Slows down visibly, set sampling frequency > 1.
+RDF | radial distribution function | Calculate and write the radial distribution function to file. Slows down visibly, set sampling frequency > 1. Optional angular resolution of the RDF possible by choosing angular bins > 1
 ResultWriter | print, macroscopic thermodynamic quantities, file | Write macroscopic thermodynamic quantities to file, such as temperature, pressure, BetaTrans, BetaRot, cv, number of molecules and number of cavities (?).
 SysMonOutput | todo | todo
 TestPlugin  | test | Test correctness of plugin calls within Simulation. Simpler version without XML input of ExamplePlugin

--- a/src/io/RDF.cpp
+++ b/src/io/RDF.cpp
@@ -46,6 +46,15 @@ void RDF::init() {
 	_accumulatedNumberOfRDFTimesteps = 0;
 	_maxDistanceSquare = _intervalLength*_intervalLength*_bins*_bins;
 
+	if (_angularBins > 1) {
+		_ARDFBins = _bins * _angularBins;
+		_doARDF = true;
+		_angularIntervalLength = 2. / _angularBins;
+	}
+	else {
+		_doARDF = false;
+	}
+
 
 	{
 		const unsigned int nC = _numberOfComponents;
@@ -55,7 +64,11 @@ void RDF::init() {
 		resizeExactly(_distribution.local, nC);
 		resizeExactly(_distribution.global, nC);
 		resizeExactly(_globalAccumulatedDistribution, nC);
-
+		if(_doARDF == true) {
+			resizeExactly(_ARDFdistribution.local, nC);
+			resizeExactly(_ARDFdistribution.global, nC);
+			resizeExactly(_globalAccumulatedARDFDistribution, nC);
+		}
 		resizeExactly(_siteDistribution.local, nC);
 		resizeExactly(_siteDistribution.global, nC);
 		resizeExactly(_globalAccumulatedSiteDistribution, nC);
@@ -72,7 +85,11 @@ void RDF::init() {
 			resizeExactly(_distribution.local[i], nCmi);
 			resizeExactly(_distribution.global[i], nCmi);
 			resizeExactly(_globalAccumulatedDistribution[i], nCmi);
-
+			if(_doARDF == true) {
+				resizeExactly(_ARDFdistribution.local[i], nCmi + i); //the ARDF is not symmetrical in the same way as the RDF (i.e. ARDF12 is not the same as ARDF21, therefore the size of the matrix is different
+				resizeExactly(_ARDFdistribution.global[i], nCmi + i);
+				resizeExactly(_globalAccumulatedARDFDistribution[i], nCmi + i);
+			}
 			resizeExactly(_siteDistribution.local[i], nCmi);
 			resizeExactly(_siteDistribution.global[i], nCmi);
 			resizeExactly(_globalAccumulatedSiteDistribution[i], nCmi);
@@ -117,6 +134,18 @@ void RDF::init() {
 				}
 			}
 		}
+		if(_doARDF == true) {
+			for (unsigned k = 0; k < _numberOfComponents; k++){
+				resizeExactly(_ARDFdistribution.local[i][k], _ARDFBins);
+				resizeExactly(_ARDFdistribution.global[i][k], _ARDFBins);
+				resizeExactly(_globalAccumulatedARDFDistribution[i][k], _ARDFBins);
+				for(unsigned long l=0; l < _ARDFBins; l++) {
+					_ARDFdistribution.local[i][k][l] = 0;
+					_ARDFdistribution.global[i][k][l] = 0;
+					_globalAccumulatedARDFDistribution[i][k][l] = 0;
+				}
+			}
+		}
 	}
 	_initialized=true;
 }
@@ -138,6 +167,10 @@ void RDF::readXML(XMLfileUnits& xmlconfig) {
 	_bins = 1;
 	xmlconfig.getNodeValue("bins", _bins);
 	global_log->info() << "Number of bins: " << _bins << endl;
+	
+	_angularBins = 1;
+	xmlconfig.getNodeValue("angularbins", _angularBins);
+	global_log->info() << "Number of angular bins: " << _angularBins << endl;
 
 	_intervalLength = 1;
 	xmlconfig.getNodeValueReduced("intervallength", _intervalLength);
@@ -185,6 +218,13 @@ void RDF::accumulateRDF() {
 				}
 			}
 		}
+		if(_doARDF == true) {
+			for (unsigned k = 0; k < _numberOfComponents; k++){
+				for(unsigned long l=0; l < _ARDFBins; l++) {
+					_globalAccumulatedARDFDistribution[i][k][l] += _ARDFdistribution.global[i][k][l];
+				}
+			}
+		}
 	}
 }
 
@@ -210,6 +250,30 @@ void RDF::collectRDF(DomainDecompBase* dode) {
 	}
 	dode->collCommFinalize();
 
+	// communicate component-component ARDFs
+	
+	if(_doARDF == true) {
+		dode->collCommInit(_ARDFBins * _numberOfComponents * _numberOfComponents);
+	
+		for(unsigned i=0; i < _numberOfComponents; i++) {
+			for(unsigned k=0; k < _numberOfComponents; k++) {
+				for(unsigned long l=0; l < _ARDFBins; l++) {
+					dode->collCommAppendUnsLong(_ARDFdistribution.local[i][k][l]);
+				}
+			}
+		}
+
+		dode->collCommAllreduceSum();
+		for(unsigned i=0; i < _numberOfComponents; i++) {
+			for(unsigned k=0; k < _numberOfComponents; k++) {
+				for(unsigned long l=0; l < _ARDFBins; l++) {
+					_ARDFdistribution.global[i][k][l] = dode->collCommGetUnsLong();
+				}
+			}
+		}
+		dode->collCommFinalize();
+	}
+	
 	// communicate site-site RDFs
 	for(unsigned i=0; i < _numberOfComponents; i++) {
 		unsigned ni = (*_components)[i].numSites();
@@ -264,6 +328,14 @@ void RDF::reset() {
 				}
 			}
 		}
+		if(_doARDF == true) {
+			for (unsigned k = 0; k < _numberOfComponents; k++){
+				for(unsigned long l=0; l < _ARDFBins; l++) {
+					_ARDFdistribution.local[i][k][l] = 0;
+					_ARDFdistribution.global[i][k][l] = 0;
+				}
+			}
+		}
 	}
 }
 
@@ -286,10 +358,102 @@ void RDF::endStep(ParticleContainer * /*particleContainer*/, DomainDecompBase *d
 					osstrm << std::right << simStep << ".rdf";
 					writeToFile(domain, osstrm.str(), i, j);
 				}
+				if( _doARDF == true) {
+					for (unsigned j = 0; j < _numberOfComponents; j++){
+						ostringstream osstrm2;
+						osstrm2 << _outputPrefix << "_" << i << "-" << j << ".";
+						osstrm2.fill('0');
+						osstrm2.width(9);
+						osstrm2 << std::right << simStep << ".ardf";
+						writeToFileARDF(domain, osstrm2.str(), i, j);
+					}
+				}
 			}
 		}
 		reset();
 	}
+}
+
+void RDF::writeToFileARDF(const Domain* domain, const std::string& filename, unsigned i, unsigned j) const {
+	ofstream ardfout(filename);
+	if( ardfout.fail() ) {
+		global_log->error() << "[ARDF] Failed opening output file '" << filename << "'" << endl;
+		return;
+	}
+	double V = domain->getGlobalVolume();
+	double N_i = _globalCtr[i] / (double)_numberOfRDFTimesteps;
+	double N_Ai = _globalAccumulatedCtr[i] / (double)_accumulatedNumberOfRDFTimesteps;
+	double N_j = _globalCtr[j] / (double)_numberOfRDFTimesteps;
+	double N_Aj = _globalAccumulatedCtr[j] / (double)_accumulatedNumberOfRDFTimesteps;
+	double rho_i = N_i / V;
+	double rho_Ai = N_Ai / V;
+	double rho_j = N_j / V;
+	double rho_Aj = N_Aj / V;
+	unsigned int angularID = 0;
+	unsigned int radialID = 0;
+	
+	ardfout << "\n";
+	ardfout << "# \n# ctr_i: " << _globalCtr[i] << "\n# ctr_j: " << _globalCtr[j]
+	       << "\n# V: " << V << "\n# _universalRDFTimesteps: " << _numberOfRDFTimesteps
+	       << "\n# _universalAccumulatedTimesteps: " << _accumulatedNumberOfRDFTimesteps
+		   << "\n# _samplingFrequency: " << _samplingFrequency
+	       << "\n# rho_i: " << rho_i << " (acc. " << rho_Ai << ")"
+	       << "\n# rho_j: " << rho_j << " (acc. " << rho_Aj << ")"
+	       << "\n# \n";
+
+	// new or alternative heading
+	ardfout << "#r\tcos(phi)\tcounter\tardf\tardf_{integral}\tacc_rdf acc_rdf_{integral}\t\tdV\tNpair(curr.)\tNpair(accu.)\t\tnormalization(curr.)\tnormalization(accu.)";
+	ardfout << "\n";
+	double N_pair_int = 0.0;
+	double N_Apair_int = 0.0;
+	for(unsigned long l = 0; l < numARDFBins(); ++l) {
+		
+		if (l % _angularBins == 0 && l != 0) {
+			radialID++;
+		}
+		angularID = l - radialID * _angularBins;
+		
+		
+		double rmin = radialID * binwidth();
+		double rmid = (radialID+0.5) * binwidth();
+		double rmax = (radialID+1.0) * binwidth();
+		/*double phimin = acos(angularID * angularbinwidth() - 1.);
+		double phimid = phimin + 0.5 * angularbinwidth();
+		double phimax = phimin + 1.0 * angularbinwidth();*/
+		double cosPhiMin = 1. - angularID * angularbinwidth();
+		double cosPhiMid = 1. -(angularID + 0.5) * angularbinwidth();
+		double cosPhiMax = 1. -(angularID + 1.0) * angularbinwidth();
+		double dV = 2./3. * M_PI * ((rmax * rmax * rmax - rmin * rmin * rmin) * (1. - cosPhiMax) + (rmin * rmin * rmin - rmax * rmax * rmax) * (1. - cosPhiMin));
+		
+		double N_pair = _ARDFdistribution.global[i][j][l] / (double)_numberOfRDFTimesteps;
+		N_pair_int += N_pair;
+		double N_Apair = _globalAccumulatedARDFDistribution[i][j][l] / (double)_accumulatedNumberOfRDFTimesteps;
+		N_Apair_int += N_Apair;
+		double N_pair_norm = 0.0;
+		double N_Apair_norm = 0.0;
+		double N_pair_int_norm = 0.0;
+		double N_Apair_int_norm = 0.0;
+
+		if(i == j) {
+			N_pair_norm = N_i*(N_i-1.0) * dV/V;
+			N_Apair_norm = N_Ai*(N_Ai-1.0) * dV/V;
+			N_pair_int_norm = N_i*(N_i-1.0) * 4.1887902*(rmin*rmin*rmin + 0.5 * ((rmax*rmax*rmax - rmin*rmin*rmin)*(1-cosPhiMax)))/V;
+			N_Apair_int_norm = N_Ai*(N_Ai-1.0) * 4.1887902*(rmin*rmin*rmin + 0.5 * ((rmax*rmax*rmax - rmin*rmin*rmin)*(1-cosPhiMax)))/V;
+		}
+		else {
+			N_pair_norm = N_i*N_j * dV/V;
+			N_Apair_norm = N_Ai*N_Aj * dV/V;
+			N_pair_int_norm = N_i*N_j * 4.1887902*(rmin*rmin*rmin + 0.5 * ((rmax*rmax*rmax - rmin*rmin*rmin)*(1-cosPhiMax)))/V;
+			N_Apair_int_norm = N_Ai*N_Aj * 4.1887902*(rmin*rmin*rmin + 0.5 * ((rmax*rmax*rmax - rmin*rmin*rmin)*(1-cosPhiMax)))/V;
+		}
+
+		ardfout << rmid << "\t" << cosPhiMid << "\t" << _ARDFdistribution.global[i][j][l] <<"\t" << N_pair/N_pair_norm << " " << N_pair_int/N_pair_int_norm
+				<< "\t" << N_Apair/N_Apair_norm << " " << N_Apair_int/N_Apair_int_norm
+				<< "\t\t" << dV << "\t" << N_pair << "\t" << N_Apair
+				<< "\t\t" << N_pair_norm << "\t" << N_Apair_norm;
+		ardfout << "\n";
+	}
+	ardfout.close();
 }
 
 

--- a/src/io/RDF.cpp
+++ b/src/io/RDF.cpp
@@ -389,7 +389,7 @@ void RDF::writeToFileARDF(const Domain* domain, const std::string& filename, uns
 	double rho_Ai = N_Ai / V;
 	double rho_j = N_j / V;
 	double rho_Aj = N_Aj / V;
-	unsigned int angularID = 0;
+	unsigned long angularID = 0;
 	unsigned int radialID = 0;
 	
 	ardfout << "\n";
@@ -417,9 +417,6 @@ void RDF::writeToFileARDF(const Domain* domain, const std::string& filename, uns
 		double rmin = radialID * binwidth();
 		double rmid = (radialID+0.5) * binwidth();
 		double rmax = (radialID+1.0) * binwidth();
-		/*double phimin = acos(angularID * angularbinwidth() - 1.);
-		double phimid = phimin + 0.5 * angularbinwidth();
-		double phimax = phimin + 1.0 * angularbinwidth();*/
 		double cosPhiMin = 1. - angularID * angularbinwidth();
 		double cosPhiMid = 1. -(angularID + 0.5) * angularbinwidth();
 		double cosPhiMax = 1. -(angularID + 1.0) * angularbinwidth();

--- a/src/io/RDF.cpp
+++ b/src/io/RDF.cpp
@@ -64,7 +64,7 @@ void RDF::init() {
 		resizeExactly(_distribution.local, nC);
 		resizeExactly(_distribution.global, nC);
 		resizeExactly(_globalAccumulatedDistribution, nC);
-		if(_doARDF == true) {
+		if(_doARDF) {
 			resizeExactly(_ARDFdistribution.local, nC);
 			resizeExactly(_ARDFdistribution.global, nC);
 			resizeExactly(_globalAccumulatedARDFDistribution, nC);
@@ -85,7 +85,7 @@ void RDF::init() {
 			resizeExactly(_distribution.local[i], nCmi);
 			resizeExactly(_distribution.global[i], nCmi);
 			resizeExactly(_globalAccumulatedDistribution[i], nCmi);
-			if(_doARDF == true) {
+			if(_doARDF) {
 				resizeExactly(_ARDFdistribution.local[i], nCmi + i); //the ARDF is not symmetrical in the same way as the RDF (i.e. ARDF12 is not the same as ARDF21, therefore the size of the matrix is different
 				resizeExactly(_ARDFdistribution.global[i], nCmi + i);
 				resizeExactly(_globalAccumulatedARDFDistribution[i], nCmi + i);
@@ -134,7 +134,7 @@ void RDF::init() {
 				}
 			}
 		}
-		if(_doARDF == true) {
+		if(_doARDF) {
 			for (unsigned k = 0; k < _numberOfComponents; k++){
 				resizeExactly(_ARDFdistribution.local[i][k], _ARDFBins);
 				resizeExactly(_ARDFdistribution.global[i][k], _ARDFBins);
@@ -218,7 +218,7 @@ void RDF::accumulateRDF() {
 				}
 			}
 		}
-		if(_doARDF == true) {
+		if(_doARDF) {
 			for (unsigned k = 0; k < _numberOfComponents; k++){
 				for(unsigned long l=0; l < _ARDFBins; l++) {
 					_globalAccumulatedARDFDistribution[i][k][l] += _ARDFdistribution.global[i][k][l];
@@ -252,7 +252,7 @@ void RDF::collectRDF(DomainDecompBase* dode) {
 
 	// communicate component-component ARDFs
 	
-	if(_doARDF == true) {
+	if(_doARDF) {
 		dode->collCommInit(_ARDFBins * _numberOfComponents * _numberOfComponents);
 	
 		for(unsigned i=0; i < _numberOfComponents; i++) {
@@ -328,7 +328,7 @@ void RDF::reset() {
 				}
 			}
 		}
-		if(_doARDF == true) {
+		if(_doARDF) {
 			for (unsigned k = 0; k < _numberOfComponents; k++){
 				for(unsigned long l=0; l < _ARDFBins; l++) {
 					_ARDFdistribution.local[i][k][l] = 0;
@@ -358,7 +358,7 @@ void RDF::endStep(ParticleContainer * /*particleContainer*/, DomainDecompBase *d
 					osstrm << std::right << simStep << ".rdf";
 					writeToFile(domain, osstrm.str(), i, j);
 				}
-				if( _doARDF == true) {
+				if( _doARDF) {
 					for (unsigned j = 0; j < _numberOfComponents; j++){
 						ostringstream osstrm2;
 						osstrm2 << _outputPrefix << "_" << i << "-" << j << ".";

--- a/src/io/RDF.h
+++ b/src/io/RDF.h
@@ -102,6 +102,9 @@ public:
 		#pragma omp atomic
 		#endif
 		_ARDFdistribution.local[cid1][cid2][binID]++;
+		#if defined _OPENMP
+		#pragma omp atomic
+		#endif
 		_ARDFdistribution.local[cid2][cid1][binIDReverse]++;
 	}
 

--- a/src/io/RDF.h
+++ b/src/io/RDF.h
@@ -202,11 +202,11 @@ private:
 
 	//! The number of bins, i.e. the number of intervals in which the cutoff
 	//! radius will be subdivided.
-	unsigned int _bins;
+	unsigned long _bins;
 	
 	//! The number of bins in angular direction in case the angular RDF is
 	//! being calculated
-	unsigned int _angularBins;
+	unsigned long _angularBins;
 	
 	
 	//! The total number of bins for the ARDF is the product of the radial bins and

--- a/src/molecules/FullMolecule.h
+++ b/src/molecules/FullMolecule.h
@@ -261,32 +261,6 @@ public:
 		}
 		return d2;
 	}
-	//calculates orientation angle for ARDF
-	double orientationAngle(const FullMolecule& molecule2, double dr[3], double d2) const {
-		
-		double cosPhi = 0.;
-		double orientationVector[3];
-		double orientationVectorSquared = 0.;
-		double roundingThreshold = 0.0001;
-		
-		orientationVector[0] = 2. * (q().qx() * q().qz() + q().qw() * q().qy());
-		orientationVector[1] = 2. * (q().qy() * q().qz() - q().qw() * q().qx());
-		orientationVector[2] = 1. - 2. * (q().qx() * q().qx() + q().qy() * q().qy());
-
-	
-		
-		for (unsigned short d = 0; d < 3; d++) {
-			dr[d] = molecule2._r[d] - _r[d];
-			orientationVectorSquared += orientationVector[d] * orientationVector[d];
-		}
-		
-		for (unsigned short d = 0; d < 3; d++) {
-			cosPhi += orientationVector[d] * dr[d] / sqrt(orientationVectorSquared) / sqrt(d2);
-		}
-		return cosPhi;
-		
-	}
-	
 	
 	/** set force acting on molecule
 	 * @param[out] F force vector (x,y,z)

--- a/src/molecules/FullMolecule.h
+++ b/src/molecules/FullMolecule.h
@@ -261,8 +261,33 @@ public:
 		}
 		return d2;
 	}
-	
+	//calculates orientation angle for ARDF
+	double orientationAngle(const FullMolecule& molecule2, double dr[3], double d2) const {
+		
+		double cosPhi = 0.;
+		double orientationVector[3];
+		double orientationVectorSquared = 0.;
+		double roundingThreshold = 0.0001;
+		
+		orientationVector[0] = 2. * (q().qx() * q().qz() + q().qw() * q().qy());
+		orientationVector[1] = 2. * (q().qy() * q().qz() - q().qw() * q().qx());
+		orientationVector[2] = 1. - 2. * (q().qx() * q().qx() + q().qy() * q().qy());
 
+	
+		
+		for (unsigned short d = 0; d < 3; d++) {
+			dr[d] = molecule2._r[d] - _r[d];
+			orientationVectorSquared += orientationVector[d] * orientationVector[d];
+		}
+		
+		for (unsigned short d = 0; d < 3; d++) {
+			cosPhi += orientationVector[d] * dr[d] / sqrt(orientationVectorSquared) / sqrt(d2);
+		}
+		return cosPhi;
+		
+	}
+	
+	
 	/** set force acting on molecule
 	 * @param[out] F force vector (x,y,z)
 	 */

--- a/src/molecules/MoleculeInterface.h
+++ b/src/molecules/MoleculeInterface.h
@@ -87,7 +87,7 @@ public:
 	virtual void setD(unsigned short d, double D) = 0;
 
 	inline virtual void move(int d, double dr) = 0;
-
+	
 	//by Stefan Becker
 	virtual double getI(unsigned short d) const = 0;
 
@@ -163,7 +163,32 @@ public:
 		return d2;
 	}
 
+	//calculates orientation angle for ARDF
+	double orientationAngle(const MoleculeInterface& molecule2, double dr[3], double d2) const {
+		
+		double cosPhi = 0.;
+		double orientationVector[3];
+		double orientationVectorSquared = 0.;
+		double roundingThreshold = 0.0001;
+		
+		orientationVector[0] = 2. * (q().qx() * q().qz() + q().qw() * q().qy());
+		orientationVector[1] = 2. * (q().qy() * q().qz() - q().qw() * q().qx());
+		orientationVector[2] = 1. - 2. * (q().qx() * q().qx() + q().qy() * q().qy());
 
+	
+		
+		for (unsigned short d = 0; d < 3; d++) {
+			dr[d] = molecule2.r(d) - r(d);
+			orientationVectorSquared += orientationVector[d] * orientationVector[d];
+		}
+		
+		for (unsigned short d = 0; d < 3; d++) {
+			cosPhi += orientationVector[d] * dr[d] / sqrt(orientationVectorSquared) / sqrt(d2);
+		}
+		return cosPhi;
+		
+	}
+	
 	virtual void setF(double F[3]) = 0;
 	virtual void setM(double M[3]) = 0;
 	virtual void setVi(double Vi[3]) = 0;

--- a/src/particleContainer/adapter/RDFCellProcessor.cpp
+++ b/src/particleContainer/adapter/RDFCellProcessor.cpp
@@ -33,6 +33,13 @@ void RDFCellProcessor::processCell(ParticleCell& cell) {
 
 				if (dd < _cutoffRadiusSquare) {
 					_rdf->observeRDF(molecule1, molecule2, dd);
+					if (_rdf->doARDF() == true) {
+						double dummy2[3], dummy3[3];
+						double cosPhi = molecule1.orientationAngle(molecule2, dummy2, dd);
+						double cosPhiReverse = molecule2.orientationAngle(molecule1, dummy3, dd);
+						_rdf->observeARDFMolecule(dd, cosPhi, cosPhiReverse, molecule1.componentid(), molecule2.componentid());
+						
+					}
 				}
 			}
 		}
@@ -55,6 +62,13 @@ void RDFCellProcessor::processCellPair(ParticleCell& cell1, ParticleCell& cell2,
 				double dd = molecule2.dist2(molecule1, dummy);
 				if (dd < _cutoffRadiusSquare) {
                     _rdf->observeRDF(molecule1, molecule2, dd);
+					if (_rdf->doARDF() == true) {
+						double dummy2[3], dummy3[3];
+						double cosPhi = molecule1.orientationAngle(molecule2, dummy2, dd);
+						double cosPhiReverse = molecule2.orientationAngle(molecule1, dummy3, dd);
+						_rdf->observeARDFMolecule(dd, cosPhi, cosPhiReverse, molecule1.componentid(), molecule2.componentid());
+						
+					}
 				}
 			}
 
@@ -74,6 +88,13 @@ void RDFCellProcessor::processCellPair(ParticleCell& cell1, ParticleCell& cell2,
 					double dd = molecule2.dist2(molecule1, dummy);
 					if (dd < _cutoffRadiusSquare) {
 	                    _rdf->observeRDF(molecule1, molecule2, dd);
+						if (_rdf->doARDF() == true) {
+							double dummy2[3], dummy3[3];
+							double cosPhi = molecule1.orientationAngle(molecule2, dummy2, dd);
+							double cosPhiReverse = molecule2.orientationAngle(molecule1, dummy3, dd);
+							_rdf->observeARDFMolecule(dd, cosPhi, cosPhiReverse, molecule1.componentid(), molecule2.componentid());
+						
+						}
 					}
 				}
 
@@ -97,6 +118,13 @@ void RDFCellProcessor::processCellPair(ParticleCell& cell1, ParticleCell& cell2,
 
 					if (dd < _cutoffRadiusSquare) {
 	                    _rdf->observeRDF(molecule1, molecule2, dd);
+						if (_rdf->doARDF() == true) {
+							double dummy2[3], dummy3[3];
+							double cosPhi = molecule1.orientationAngle(molecule2, dummy2, dd);
+							double cosPhiReverse = molecule2.orientationAngle(molecule1, dummy3, dd);
+							_rdf->observeARDFMolecule(dd, cosPhi, cosPhiReverse, molecule1.componentid(), molecule2.componentid());
+						
+						}
 					}
 				}
 			}

--- a/src/particleContainer/adapter/RDFCellProcessor.cpp
+++ b/src/particleContainer/adapter/RDFCellProcessor.cpp
@@ -33,7 +33,7 @@ void RDFCellProcessor::processCell(ParticleCell& cell) {
 
 				if (dd < _cutoffRadiusSquare) {
 					_rdf->observeRDF(molecule1, molecule2, dd);
-					if (_rdf->doARDF() == true) {
+					if (_rdf->doARDF()) {
 						double dummy2[3], dummy3[3];
 						double cosPhi = molecule1.orientationAngle(molecule2, dummy2, dd);
 						double cosPhiReverse = molecule2.orientationAngle(molecule1, dummy3, dd);
@@ -62,7 +62,7 @@ void RDFCellProcessor::processCellPair(ParticleCell& cell1, ParticleCell& cell2,
 				double dd = molecule2.dist2(molecule1, dummy);
 				if (dd < _cutoffRadiusSquare) {
                     _rdf->observeRDF(molecule1, molecule2, dd);
-					if (_rdf->doARDF() == true) {
+					if (_rdf->doARDF()) {
 						double dummy2[3], dummy3[3];
 						double cosPhi = molecule1.orientationAngle(molecule2, dummy2, dd);
 						double cosPhiReverse = molecule2.orientationAngle(molecule1, dummy3, dd);
@@ -88,7 +88,7 @@ void RDFCellProcessor::processCellPair(ParticleCell& cell1, ParticleCell& cell2,
 					double dd = molecule2.dist2(molecule1, dummy);
 					if (dd < _cutoffRadiusSquare) {
 	                    _rdf->observeRDF(molecule1, molecule2, dd);
-						if (_rdf->doARDF() == true) {
+						if (_rdf->doARDF()) {
 							double dummy2[3], dummy3[3];
 							double cosPhi = molecule1.orientationAngle(molecule2, dummy2, dd);
 							double cosPhiReverse = molecule2.orientationAngle(molecule1, dummy3, dd);
@@ -118,7 +118,7 @@ void RDFCellProcessor::processCellPair(ParticleCell& cell1, ParticleCell& cell2,
 
 					if (dd < _cutoffRadiusSquare) {
 	                    _rdf->observeRDF(molecule1, molecule2, dd);
-						if (_rdf->doARDF() == true) {
+						if (_rdf->doARDF()) {
 							double dummy2[3], dummy3[3];
 							double cosPhi = molecule1.orientationAngle(molecule2, dummy2, dd);
 							double cosPhiReverse = molecule2.orientationAngle(molecule1, dummy3, dd);


### PR DESCRIPTION

# Description

Additional optional output for the RDF plugin. RDF can now be resolved in angular direction, here called ARDF, by simply choosing angularbins > 1 in the input. 


# How Has This Been Tested?
I have tested this for mixtures of Lennard-Jones and Stockmayer fluids. The results make intuitive sense and fit well together with the already implemented normal RDF.
![ARDF](https://user-images.githubusercontent.com/54402420/67373343-c1a55380-f57f-11e9-8b45-de0ca8f9f426.png)

