### PR TITLE
fix AutoPas version

### DIFF
--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -17,7 +17,7 @@ if(ENABLE_AUTOPAS)
     ExternalProject_Add(
             autopas
             GIT_REPOSITORY ${autopasRepoPath}
-            GIT_TAG origin/master
+            GIT_TAG f639d8b77eb62b84ffb3717ca4a3e25f1caaea86
             #GIT_TAG origin/feature/regionParticleIteratorIncrease
             #URL https://github.com/AutoPas/AutoPas/archive/0c3d8b07a2e38940057fafd21b98645cb074e729.zip # zip option
             #${CMAKE_SOURCE_DIR}/libs/googletest-master.zip # bundled option

--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -19,9 +19,6 @@ if(ENABLE_AUTOPAS)
             GIT_REPOSITORY ${autopasRepoPath}
             GIT_TAG f639d8b77eb62b84ffb3717ca4a3e25f1caaea86
             #GIT_TAG origin/feature/regionParticleIteratorIncrease
-            #URL https://github.com/AutoPas/AutoPas/archive/0c3d8b07a2e38940057fafd21b98645cb074e729.zip # zip option
-            #${CMAKE_SOURCE_DIR}/libs/googletest-master.zip # bundled option
-            #URL_HASH MD5=6e70656897167140c1221eecc6ad872d
             BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/autopas/build
             BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/autopas/build/src/autopas/libautopas.a
             PREFIX ${CMAKE_CURRENT_BINARY_DIR}/autopas


### PR DESCRIPTION
# Description

Fixes the used AutoPas version to git id:
https://github.com/AutoPas/AutoPas/commit/f639d8b77eb62b84ffb3717ca4a3e25f1caaea86


## Resolved Issues

- Ensures compatibility.
