### PR TITLE
add Zoltan2 library for load balancing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ include(cppunit)
 include(bhfmm)
 # include ALL load balanding library
 include(ALL)
+# include Zoltan2 library (used for load balancing)
+include(Zoltan2)
 
 # ----- third: include autopas
 include(autopas)

--- a/cmake/modules/Zoltan2.cmake
+++ b/cmake/modules/Zoltan2.cmake
@@ -6,7 +6,8 @@ if(ENABLE_ZOLTAN2)
     FIND_PACKAGE(Zoltan2 REQUIRED)
     MESSAGE("   Trilinos_INCLUDE_DIRS = ${Trilinos_INCLUDE_DIRS}")
     target_include_directories(trilinos_zoltan2 SYSTEM INTERFACE
-            "/usr/include/trilinos"
+            "/usr/include/trilinos/"
+            "/usr/include/scotch/"
             )
     message(STATUS "link with \${Zoltan2_LIBRARIES}: ${Zoltan2_LIBRARIES} ")
     message(STATUS "Zoltan2 support enabled")

--- a/cmake/modules/Zoltan2.cmake
+++ b/cmake/modules/Zoltan2.cmake
@@ -6,6 +6,12 @@
 #    -D TPL_ENABLE_MPI:BOOL=ON \
 #    -D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF \
 #    ..
+# on clusters you might also need the following options when using MKL:
+# -DBLAS_LIBRARY_NAMES="mkl_intel_lp64;mkl_sequential;mkl_core"
+# -DBLAS_LIBRARY_DIRS="$MKL_LIBDIR"
+# -DLAPACK_LIBRARY_NAMES=""
+# -DLAPACK_LIBRARY_DIRS="$MKL_LIBDIR"
+#
 # and potentially also add a hint for find_package, by specifying Zoltan2_DIR=/path/to/install/dir
 
 function(check_defined configFile name_of_define RESULT_NAME)

--- a/cmake/modules/Zoltan2.cmake
+++ b/cmake/modules/Zoltan2.cmake
@@ -1,4 +1,12 @@
 # cmake module for adding Zoltan2
+# please build trilinos using:
+# build cmake -D CMAKE_INSTALL_PREFIX:PATH=/path/to/install/dir \
+#    -D Trilinos_ENABLE_Zoltan2:BOOL=ON \
+#    -D Trilinos_ENABLE_Fortran:BOOL=OFF \
+#    -D TPL_ENABLE_MPI:BOOL=ON \
+#    -D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF \
+#    ..
+# and potentially also add a hint for find_package, by specifying Zoltan2_DIR=/path/to/install/dir
 
 function(check_defined configFile name_of_define RESULT_NAME)
     execute_process(
@@ -12,7 +20,13 @@ endfunction()
 option(ENABLE_ZOLTAN2 "Enable Zoltan2 as load balancing library" OFF)
 if(ENABLE_ZOLTAN2)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_ZOLTAN2")
-    FIND_PACKAGE(Zoltan2 REQUIRED)
+    FIND_PACKAGE(Zoltan2)
+    if(Zoltan2_FOUND)
+        message(STATUS "zoltan2 found.")
+    else(Zoltan2_FOUND)
+        message(FATAL_ERROR "Zoltan2 not found but requested!\nIf you have installed zoltan2 at a non-default location, please provide a hint using Zoltan2_DIR=/path/to/install/dir.")
+    endif(Zoltan2_FOUND)
+
     MESSAGE(STATUS "Zoltan2_INCLUDE_DIRS = ${Zoltan2_INCLUDE_DIRS}")
 
     list (GET Zoltan2_LIBRARIES 0 Zoltan2LibraryTarget)

--- a/cmake/modules/Zoltan2.cmake
+++ b/cmake/modules/Zoltan2.cmake
@@ -1,0 +1,15 @@
+# cmake module for adding Zoltan2
+
+option(ENABLE_ZOLTAN2 "Enable Zoltan2 as load balancing library" OFF)
+if(ENABLE_ZOLTAN2)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_ZOLTAN2")
+    FIND_PACKAGE(Zoltan2 REQUIRED)
+    MESSAGE("   Trilinos_INCLUDE_DIRS = ${Trilinos_INCLUDE_DIRS}")
+    target_include_directories(trilinos_zoltan2 SYSTEM INTERFACE
+            "/usr/include/trilinos"
+            )
+    message(STATUS "link with \${Zoltan2_LIBRARIES}: ${Zoltan2_LIBRARIES} ")
+    message(STATUS "Zoltan2 support enabled")
+else()
+    message(STATUS "Zoltan2 support disabled")
+endif()

--- a/cmake/modules/Zoltan2.cmake
+++ b/cmake/modules/Zoltan2.cmake
@@ -1,14 +1,60 @@
 # cmake module for adding Zoltan2
 
+function(check_defined configFile name_of_define RESULT_NAME)
+    execute_process(
+         COMMAND grep -q -i "#define ${name_of_define}" ${configFile}
+         RESULT_VARIABLE define_found
+         OUTPUT_QUIET
+         )
+    set (${RESULT_NAME} ${define_found} PARENT_SCOPE)
+endfunction()
+
 option(ENABLE_ZOLTAN2 "Enable Zoltan2 as load balancing library" OFF)
 if(ENABLE_ZOLTAN2)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_ZOLTAN2")
     FIND_PACKAGE(Zoltan2 REQUIRED)
-    MESSAGE("   Trilinos_INCLUDE_DIRS = ${Trilinos_INCLUDE_DIRS}")
-    target_include_directories(trilinos_zoltan2 SYSTEM INTERFACE
-            "/usr/include/trilinos/"
-            "/usr/include/scotch/"
+    MESSAGE(STATUS "Zoltan2_INCLUDE_DIRS = ${Zoltan2_INCLUDE_DIRS}")
+
+    list (GET Zoltan2_LIBRARIES 0 Zoltan2LibraryTarget)
+
+    MESSAGE(STATUS "using Zoltan2_INCLUDE_DIRS")
+    target_include_directories(${Zoltan2LibraryTarget} SYSTEM INTERFACE
+            "${Zoltan2_INCLUDE_DIRS}"
             )
+
+    # check if we need to include scotch
+    check_defined(${Zoltan2_INCLUDE_DIRS}/Zoltan2_config.h HAVE_ZOLTAN2_SCOTCH NEEDS_SCOTCH)
+    if(NOT ${NEEDS_SCOTCH})
+        message(STATUS "we need scotch")
+        target_include_directories(${Zoltan2LibraryTarget} SYSTEM INTERFACE
+            "/usr/include/scotch"
+        )
+    else()
+        message(STATUS "skipping scotch, as zoltan2 doesn't need it.")
+    endif()
+
+    # check if we need to include parmetis
+    check_defined(${Zoltan2_INCLUDE_DIRS}/Zoltan2_config.h HAVE_ZOLTAN2_PARMETIS NEEDS_PARMETIS)
+    if(NOT ${NEEDS_PARMETIS})
+        message(STATUS "we need parmetis")
+        target_include_directories(${Zoltan2LibraryTarget} SYSTEM INTERFACE
+                "$ENV{PARMETIS_INC}"
+                )
+    else()
+        message(STATUS "skipping parmetis, as zoltan2 doesn't need it.")
+    endif()
+
+    # check if we need to include metis
+    check_defined(${Zoltan2_INCLUDE_DIRS}/Zoltan2_config.h HAVE_ZOLTAN2_METIS NEEDS_METIS)
+    if(NOT ${NEEDS_METIS})
+        message(STATUS "we need metis")
+        target_include_directories(${Zoltan2LibraryTarget} SYSTEM INTERFACE
+                "$ENV{METIS_INC}"
+                )
+    else()
+        message(STATUS "skipping metis, as zoltan2 doesn't need it.")
+    endif()
+
     message(STATUS "link with \${Zoltan2_LIBRARIES}: ${Zoltan2_LIBRARIES} ")
     message(STATUS "Zoltan2 support enabled")
 else()

--- a/examples/Argon/200K_18mol_l/config_autopas_allOptions.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_allOptions.xml
@@ -31,12 +31,17 @@
     </ensemble>
     <algorithm>
       <parallelisation type="DomainDecomposition"/>
-      <!--<parallelisation type="GeneralDomainDecomposition">
+      <!--
+      <parallelisation type="GeneralDomainDecomposition">
 		  <updateFrequency>1000</updateFrequency><comment>updateFrequency specifies how often a rebalancing will occur.</comment>
 		  <initialPhaseTime>10000</initialPhaseTime>
 		  <comment>initialPhaseTime specifies for how many time steps the initial rebalancing phase should last, in which initialPhaseFrequency is applied instead of updateFrequency.</comment>
           <initialPhaseFrequency>500</initialPhaseFrequency><comment>initialPhaseFrequency specifies how often a rebalancing will occur within the initial rebalancing phase.</comment>
-      </parallelisation>-->
+          <comment>choose one of the following:</comment>
+          <loadBalancer type="ALL"></loadBalancer>
+          <loadBalancer type="Zoltan2"></loadBalancer>
+      </parallelisation>
+      -->
       <datastructure type="AutoPas">
         <allowedTraversals>c01, c08, c04, c18, sli, verlet-lists, slicedVerlet, v01, v18, directsum, varVerlet</allowedTraversals>
         <allowedContainers>linkedCells, verletLists, directsum, verletListsCells, varVerletListsAsBuild</allowedContainers>

--- a/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
@@ -31,7 +31,9 @@
     </ensemble>
     <algorithm>
 	    <parallelisation type="GeneralDomainDecomposition">
-		    <updateFrequency>1000</updateFrequency>
+		  <updateFrequency>1000</updateFrequency>
+          <!--<loadBalancer type="ALL"></loadBalancer>-->
+          <loadBalancer type="zoltan"></loadBalancer>
 	    </parallelisation>
       <datastructure type="AutoPas">
         <allowedTraversals>c01, c08, c18, sli</allowedTraversals>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,9 @@ else()
     if(NOT ENABLE_ALLLBL)
         list(FILTER MY_SRC EXCLUDE REGEX "ALLLoadBalancer")
     endif()
+    if(NOT ENABLE_ZOLTAN2)
+        list(FILTER MY_SRC EXCLUDE REGEX "Zoltan2")
+    endif()
 endif()
 
 # if fmm fft is disabled, remove everything in an fft directory

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,13 +57,14 @@ endif()
 
 # we just add all libraries here. If a library is not set, it will simply be ignored.
 TARGET_LINK_LIBRARIES(MarDyn
-        ${BLAS_LIB}    # for armadillo
-        ${LAPACK_LIB}  # for armadillo
-        ${VTK_LIB}     # for VTK/xerces
-        ${CPPUNIT_LIB} # for unit tests
-        ${AUTOPAS_LIB} # for autopas
-        ${LZ4_LIB}     # for LZ4 compression
-        ${ALL_LIB}     # for ALL
+        ${BLAS_LIB}          # for armadillo
+        ${LAPACK_LIB}        # for armadillo
+        ${VTK_LIB}           # for VTK/xerces
+        ${CPPUNIT_LIB}       # for unit tests
+        ${AUTOPAS_LIB}       # for autopas
+        ${LZ4_LIB}           # for LZ4 compression
+        ${ALL_LIB}           # for ALL
+        ${Zoltan2_LIBRARIES} # for zoltan2
         )
 
 ADD_TEST(

--- a/src/parallel/ALLLoadBalancer.cpp
+++ b/src/parallel/ALLLoadBalancer.cpp
@@ -20,6 +20,8 @@ ALLLoadBalancer::ALLLoadBalancer(std::array<double, 3> boxMin, std::array<double
 	_all.set_proc_grid_params(coords.data(), global_size.data());
 	_all.set_communicator(comm);
 
+	_coversWholeDomain = {globalSize[0] == 1, global_size[1] == 1, global_size[2] == 1};
+
 	_minimalPartitionSize = minimalPartitionSize;
 }
 std::tuple<std::array<double, 3>, std::array<double, 3>> ALLLoadBalancer::rebalance(double work) {

--- a/src/parallel/ALLLoadBalancer.h
+++ b/src/parallel/ALLLoadBalancer.h
@@ -17,12 +17,16 @@ public:
 
 	~ALLLoadBalancer() override = default;
 	std::tuple<std::array<double, 3>, std::array<double, 3>> rebalance(double work) override;
-	void readXML(XMLfileUnits& xmlconfig) override{
+	void readXML(XMLfileUnits& xmlconfig) override {
 		// nothing yet.
 	}
+
+	std::array<bool, 3> getCoversWholeDomain() override { return _coversWholeDomain; }
+
 private:
 	ALL<double, double> _all;
 	using Point = ALL_Point<double>;
 	double _minimalPartitionSize{};
+	std::array<bool, 3> _coversWholeDomain{};
 };
 #endif

--- a/src/parallel/ALLLoadBalancer.h
+++ b/src/parallel/ALLLoadBalancer.h
@@ -17,7 +17,9 @@ public:
 
 	~ALLLoadBalancer() override = default;
 	std::tuple<std::array<double, 3>, std::array<double, 3>> rebalance(double work) override;
-
+	void readXML(XMLfileUnits& xmlconfig) override{
+		// nothing yet.
+	}
 private:
 	ALL<double, double> _all;
 	using Point = ALL_Point<double>;

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -261,22 +261,28 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 	global_log->info() << "GeneralDomainDecomposition frequency for initial rebalancing phase: " << _initFrequency
 					   << endl;
 
-	std::string loadBalancerString = "ALL";
-	xmlconfig.getNodeValue("Load Balancer", loadBalancerString);
-	global_log->info() << "Chosen Load Balancer: " << loadBalancerString << std::endl;
+	if(xmlconfig.changecurrentnode("loadBalancer")) {
+		std::string loadBalancerString = "None";
+		xmlconfig.getNodeValue("@type", loadBalancerString);
+		global_log->info() << "Chosen Load Balancer: " << loadBalancerString << std::endl;
 
-	std::transform(loadBalancerString.begin(), loadBalancerString.end(), loadBalancerString.begin(), ::tolower);
+		std::transform(loadBalancerString.begin(), loadBalancerString.end(), loadBalancerString.begin(), ::tolower);
 
-	if (loadBalancerString.find("all") != std::string::npos) {
-		initializeALL();
-	} else if (loadBalancerString.find("zoltan") != std::string::npos) {
-		initializeZoltan2();
-	} else {
-		global_log->error() << "GeneralDomainDecomposition: Unknown load balancer " << loadBalancerString
-							<< ". Aborting!";
-		Simulation::exit(1);
+		if (loadBalancerString.find("all") != std::string::npos) {
+			initializeALL();
+		} else if (loadBalancerString.find("zoltan") != std::string::npos) {
+			initializeZoltan2();
+		} else {
+			global_log->error() << "GeneralDomainDecomposition: Unknown load balancer " << loadBalancerString
+			                    << ". Aborting!";
+			Simulation::exit(1);
+		}
+		_loadBalancer->readXML(xmlconfig);
+	} else{
+		global_log->error() << "loadBalancer section missing! Aborting!" << std::endl;
 	}
-	_loadBalancer->readXML(xmlconfig);
+	xmlconfig.changecurrentnode("..");
+
 }
 
 /**

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -30,8 +30,7 @@ GeneralDomainDecomposition::GeneralDomainDecomposition(double interactionLength,
 	global_log->error() << "ALL load balancing library not enabled. Aborting." << std::endl;
 	Simulation::exit(24235);
 #endif
-	///@todo: change minimal domain size to include skin! -- this is not so trivial here!
-
+	
 	global_log->info() << "GeneralDomainDecomposition initial box: [" << _boxMin[0] << ", " << _boxMax[0] << "] x ["
 					   << _boxMin[1] << ", " << _boxMax[1] << "] x [" << _boxMin[2] << ", " << _boxMax[2] << "]"
 					   << std::endl;

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -25,7 +25,6 @@ void GeneralDomainDecomposition::initializeALL() {
 	global_log->info() << "initializing ALL load balancer..." << std::endl;
 	auto gridSize = getOptimalGrid(_domainLength, this->getNumProcs());
 	auto gridCoords = getCoordsFromRank(gridSize, _rank);
-	_coversWholeDomain = {gridSize[0] == 1, gridSize[1] == 1, gridSize[2] == 1};
 	global_log->info() << "gridSize:" << gridSize[0] << ", " << gridSize[1] << ", " << gridSize[2] << std::endl;
 	global_log->info() << "gridCoords:" << gridCoords[0] << ", " << gridCoords[1] << ", " << gridCoords[2] << std::endl;
 	std::tie(_boxMin, _boxMax) = initializeRegularGrid(_domainLength, gridSize, gridCoords);
@@ -46,7 +45,6 @@ void GeneralDomainDecomposition::initializeZoltan2() {
 
 	auto gridSize = getOptimalGrid(_domainLength, this->getNumProcs());
 	auto gridCoords = getCoordsFromRank(gridSize, _rank);
-	_coversWholeDomain = {gridSize[0] == 1, gridSize[1] == 1, gridSize[2] == 1};
 	global_log->info() << "gridSize:" << gridSize[0] << ", " << gridSize[1] << ", " << gridSize[2] << std::endl;
 	global_log->info() << "gridCoords:" << gridCoords[0] << ", " << gridCoords[1] << ", " << gridCoords[2] << std::endl;
 	std::tie(_boxMin, _boxMax) = initializeRegularGrid(_domainLength, gridSize, gridCoords);
@@ -236,9 +234,10 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 
 void GeneralDomainDecomposition::initCommPartners(ParticleContainer* moleculeContainer,
 												  Domain* domain) {  // init communication partners
+	auto coversWholeDomain = _loadBalancer->getCoversWholeDomain();
 	for (int d = 0; d < DIMgeom; ++d) {
 		// this needs to be updated for proper initialization of the neighbours
-		_neighbourCommunicationScheme->setCoverWholeDomain(d, _coversWholeDomain[d]);
+		_neighbourCommunicationScheme->setCoverWholeDomain(d, coversWholeDomain[d]);
 	}
 	_neighbourCommunicationScheme->initCommunicationPartners(moleculeContainer->getCutoff(), domain, this,
 															 moleculeContainer);

--- a/src/parallel/GeneralDomainDecomposition.h
+++ b/src/parallel/GeneralDomainDecomposition.h
@@ -32,6 +32,10 @@ public:
 		  <updateFrequency>INTEGER</updateFrequency>
 		  <initialPhaseTime>INTEGER</initialPhaseTime><!--time for initial rebalancing phase-->
 		  <initialPhaseFrequency>INTEGER</initialPhaseFrequency><!--frequency for initial rebalancing phase-->
+		  <loadBalancer type="STRING"> <!--STRING...type of the load balancer, currently supported: ALL, zoltan2-->
+		    <!--options for the load balancer-->
+			<!--for detailed information see the readXML functions from ALLLoadBalancer and Zoltan2LoadBalancer.-->
+		  </loadBalancer>
 	   </parallelisation>
 	   \endcode
 	 */
@@ -86,7 +90,6 @@ public:
 	}
 
 private:
-
 	/**
 	 * Method that initializes the ALLLoadBalancer
 	 */

--- a/src/parallel/GeneralDomainDecomposition.h
+++ b/src/parallel/GeneralDomainDecomposition.h
@@ -86,6 +86,17 @@ public:
 	}
 
 private:
+
+	/**
+	 * Method that initializes the ALLLoadBalancer
+	 */
+	void initializeALL();
+
+	/**
+	 * Method that initializes the Zontal2LoadBalancer
+	 */
+	void initializeZoltan2();
+
 	/**
 	 * Get the optimal grid for the given dimensions of the box and the number of processes.
 	 * The grid is produced, s.t., the number of grid[0] * grid[1] * grid[2] == numProcs
@@ -151,6 +162,9 @@ private:
 	// variables
 	std::array<double, 3> _boxMin;
 	std::array<double, 3> _boxMax;
+
+	std::array<double, 3> _domainLength;
+	double _interactionLength;
 
 	std::array<bool, 3> _coversWholeDomain{};
 

--- a/src/parallel/GeneralDomainDecomposition.h
+++ b/src/parallel/GeneralDomainDecomposition.h
@@ -169,8 +169,6 @@ private:
 	std::array<double, 3> _domainLength;
 	double _interactionLength;
 
-	std::array<bool, 3> _coversWholeDomain{};
-
 	size_t _steps{0};
 	size_t _rebuildFrequency{10000};
 

--- a/src/parallel/LoadBalancer.h
+++ b/src/parallel/LoadBalancer.h
@@ -35,4 +35,11 @@ public:
 	 * @param xmlconfig
 	 */
 	virtual void readXML(XMLfileUnits& xmlconfig) = 0;
+
+	/**
+	 * Get the information in which direction this process covers the entire domain.
+	 * @return array of bools, for each dimension one value: true, iff the domain is filled only be the current process,
+	 * i.e, the process spans the entire domain.
+	 */
+	virtual std::array<bool, 3> getCoversWholeDomain() = 0;
 };

--- a/src/parallel/LoadBalancer.h
+++ b/src/parallel/LoadBalancer.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <array>
 #include <tuple>
+#include "utils/xmlfileUnits.h"
 
 /**
  * LoadBalancer class for the usage of arbitrary load balancing classes that are handled by GeneralDomainDecomposition.
@@ -20,12 +21,18 @@ public:
 
 	/**
 	 * The rebalancing call.
-	 * Based on the current domain and the work for that domain this function determines a new 
+	 * Based on the current domain and the work for that domain this function determines a new
 	 * domain decomposition that provides a better load balancing.
 	 * This call will normally include communication and exchange of information with other processes.
 	 * @param work Arbitrary unit of work, e.g., time for the current process
-	 * @return New domain boundaries for the current process. First entry is the new boxMin, 
+	 * @return New domain boundaries for the current process. First entry is the new boxMin,
 	 * second the new boxMax.
 	 */
 	virtual std::tuple<std::array<double, 3>, std::array<double, 3>> rebalance(double work) = 0;
+
+	/**
+	 * Read Config file
+	 * @param xmlconfig
+	 */
+	virtual void readXML(XMLfileUnits& xmlconfig) = 0;
 };

--- a/src/parallel/Zoltan2LoadBalancer.cpp
+++ b/src/parallel/Zoltan2LoadBalancer.cpp
@@ -1,0 +1,16 @@
+/**
+ * @file Zoltan2LoadBalancer.cpp
+ * @author seckler
+ * @date 14.11.19
+ */
+
+#include "Zoltan2LoadBalancer.h"
+
+#include <Zoltan2_Adapter.hpp>
+#include <Zoltan2_MultiJagged_ReductionOps.hpp>
+
+Zoltan2LoadBalancer::Zoltan2LoadBalancer() = default;
+
+std::tuple<std::array<double, 3>, std::array<double, 3>> Zoltan2LoadBalancer::rebalance(double work) {
+	return std::tuple<std::array<double, 3>, std::array<double, 3>>();
+}

--- a/src/parallel/Zoltan2LoadBalancer.cpp
+++ b/src/parallel/Zoltan2LoadBalancer.cpp
@@ -7,10 +7,134 @@
 #include "Zoltan2LoadBalancer.h"
 
 #include <Zoltan2_Adapter.hpp>
+#include <Zoltan2_BasicVectorAdapter.hpp>
 #include <Zoltan2_MultiJagged_ReductionOps.hpp>
+#include <Zoltan2_PartitioningProblem.hpp>
+#include "utils/Logger.h"
 
-Zoltan2LoadBalancer::Zoltan2LoadBalancer() = default;
+Zoltan2LoadBalancer::Zoltan2LoadBalancer(std::array<double, 3> boxMin, std::array<double, 3> boxMax, MPI_Comm comm,
+										 double /*minimalDomainSize*/, std::array<double, 3> domainLength)
+	: _comm{comm}, _boxMin{boxMin}, _boxMax{boxMax}, _domainLength{domainLength} {
+	MPI_Comm_size(comm, &_numRanks);
+	MPI_Comm_rank(comm, &_rank);
+	Log::global_log->warning() << "Zoltan2LoadBalancer: minimalDomainSize currently ignored!" << std::endl;
+	// TODO: don't ignore minimal domain size
+}
+
+typedef Tpetra::Map<> Map_t;
+typedef Map_t::local_ordinal_type localId_t;
+typedef Map_t::global_ordinal_type globalId_t;
+typedef double scalar_t;
+typedef Zoltan2::BasicUserTypes<scalar_t, localId_t, globalId_t> myTypes;
+typedef Zoltan2::BasicVectorAdapter<myTypes> inputAdapter_t;
 
 std::tuple<std::array<double, 3>, std::array<double, 3>> Zoltan2LoadBalancer::rebalance(double work) {
-	return std::tuple<std::array<double, 3>, std::array<double, 3>>();
+	// Number of local samples.
+	size_t localCount = 3;
+	int dim = 3;
+	if (_rank == 0) {
+		localCount = localCount + 2;  // min and max of domain, s.t., it will remain
+	}
+
+	std::vector<scalar_t> coords(dim * localCount);
+
+	std::vector<scalar_t> x(localCount);
+	std::vector<scalar_t> y(localCount);
+	std::vector<scalar_t> z(localCount);
+
+	// Create coordinates that range from 0 to 10.0
+
+	srand(_rank);
+	scalar_t scalingFactorX = (_boxMax[0] - _boxMin[0]) / RAND_MAX;
+	scalar_t scalingFactorY = (_boxMax[1] - _boxMin[1]) / RAND_MAX;
+	scalar_t scalingFactorZ = (_boxMax[2] - _boxMin[2]) / RAND_MAX;
+
+	for (size_t i = 0; i < localCount; i++) {
+		x[i] = scalar_t(rand()) * scalingFactorX + _boxMin[0];
+		y[i] = scalar_t(rand()) * scalingFactorY + _boxMin[1];
+		z[i] = scalar_t(rand()) * scalingFactorZ + _boxMin[2];
+	}
+	std::vector<scalar_t> weights(localCount);
+	for (size_t i = 0; i < localCount; i++) {
+		weights[i] = work;
+	}
+
+	if (_rank == 0) {
+		x[0] = y[0] = z[0] = 0;
+		x[1] = _domainLength[0];
+		y[1] = _domainLength[1];
+		z[1] = _domainLength[2];
+		weights[0] = 0.;
+		weights[1] = 0.;
+	}
+
+	// Create global ids for the coordinates.
+
+	std::vector<globalId_t> globalIds(localCount);
+	globalId_t offset = _rank * localCount + (_rank ? 2 : 0);
+
+	for (size_t i = 0; i < localCount; i++) {
+		globalIds[i] = offset++;
+	}
+
+	// Create a Zoltan2 input adapter for this geometry. TODO explain
+
+	std::vector<const scalar_t *> coordVec(3);
+	std::vector<int> coordStrides(3);
+
+	coordVec[0] = x.data();
+	coordStrides[0] = 1;
+	coordVec[1] = y.data();
+	coordStrides[1] = 1;
+	coordVec[2] = z.data();
+	coordStrides[2] = 1;
+
+	// 1-d array as multiple weights are supported
+	std::vector<const scalar_t *> weightVec(1);
+	// 1-d array as multiple weights are supported
+	std::vector<int> weightStrides(1);
+
+	// point to weights vector
+	weightVec[0] = weights.data();
+	weightStrides[0] = 1;
+
+	inputAdapter_t ia(localCount, globalIds.data(), coordVec, coordStrides, weightVec, weightStrides);
+
+	Zoltan2::PartitioningProblem<inputAdapter_t> problem(&ia, &_params, _comm);
+
+	problem.solve();
+
+	auto view = problem.getSolution().getPartBoxesView();
+
+	auto lmins = view[_rank].getlmins();
+	auto lmaxs = view[_rank].getlmaxs();
+
+	return {{lmins[0], lmins[1], lmins[2]}, {lmaxs[0], lmaxs[1], lmaxs[2]}};
+}
+void Zoltan2LoadBalancer::readXML(XMLfileUnits &xmlconfig) {
+	// set the algorithm
+	_params.set("algorithm", "multijagged");
+
+	// don't allow particles on one line to belong to different partitions
+	_params.set("rectilinear", true);
+
+	// needed to be able to get the boundary boxes.
+	_params.set("mj_keep_part_boxes", true);
+
+	// set the tolerance of imbalance, should be > 1.
+	_params.set("imbalance_tolerance", 1.1);
+
+	// option does not exist in trilinos 12.12.1
+	// params->set("mj_premigration_option", mj_premigration_option);
+
+	// predefined partitioning grid, e.g., 2x2x4 or so.
+	// if (pqParts != "") params->set("mj_parts", pqParts);
+
+	// set the number of ranks as the number of partitions.
+	_params.set("num_global_parts", _numRanks);
+
+	// if (migration_check_option >= 0) params->set("mj_migration_option", migration_check_option);
+
+	// if (migration_imbalance_cut_off >= 0)
+	//	params->set("mj_minimum_migration_imbalance", double(migration_imbalance_cut_off));
 }

--- a/src/parallel/Zoltan2LoadBalancer.cpp
+++ b/src/parallel/Zoltan2LoadBalancer.cpp
@@ -30,7 +30,7 @@ typedef Zoltan2::BasicVectorAdapter<myTypes> inputAdapter_t;
 
 std::tuple<std::array<double, 3>, std::array<double, 3>> Zoltan2LoadBalancer::rebalance(double work) {
 	// Number of local samples.
-	size_t localCount = 10;
+	size_t localCount = 40;
 	if (_rank == 0) {
 		localCount = localCount + 2;  // min and max of domain, s.t., it will remain
 	}

--- a/src/parallel/Zoltan2LoadBalancer.cpp
+++ b/src/parallel/Zoltan2LoadBalancer.cpp
@@ -30,8 +30,7 @@ typedef Zoltan2::BasicVectorAdapter<myTypes> inputAdapter_t;
 
 std::tuple<std::array<double, 3>, std::array<double, 3>> Zoltan2LoadBalancer::rebalance(double work) {
 	// Number of local samples.
-	size_t localCount = 3;
-	int dim = 3;
+	size_t localCount = 10;
 	if (_rank == 0) {
 		localCount = localCount + 2;  // min and max of domain, s.t., it will remain
 	}
@@ -107,8 +106,11 @@ std::tuple<std::array<double, 3>, std::array<double, 3>> Zoltan2LoadBalancer::re
 	auto lmins = view[_rank].getlmins();
 	auto lmaxs = view[_rank].getlmaxs();
 
-	return {{lmins[0], lmins[1], lmins[2]}, {lmaxs[0], lmaxs[1], lmaxs[2]}};
+	_boxMin = {lmins[0], lmins[1], lmins[2]};
+	_boxMax = {lmaxs[0], lmaxs[1], lmaxs[2]};
+	return {_boxMin, _boxMax};
 }
+
 void Zoltan2LoadBalancer::readXML(XMLfileUnits &xmlconfig) {
 	// set the algorithm
 	_params.set("algorithm", "multijagged");

--- a/src/parallel/Zoltan2LoadBalancer.cpp
+++ b/src/parallel/Zoltan2LoadBalancer.cpp
@@ -36,8 +36,6 @@ std::tuple<std::array<double, 3>, std::array<double, 3>> Zoltan2LoadBalancer::re
 		localCount = localCount + 2;  // min and max of domain, s.t., it will remain
 	}
 
-	std::vector<scalar_t> coords(dim * localCount);
-
 	std::vector<scalar_t> x(localCount);
 	std::vector<scalar_t> y(localCount);
 	std::vector<scalar_t> z(localCount);

--- a/src/parallel/Zoltan2LoadBalancer.h
+++ b/src/parallel/Zoltan2LoadBalancer.h
@@ -31,6 +31,14 @@ public:
 
 	void readXML(XMLfileUnits& xmlconfig) override;
 
+	std::array<bool, 3> getCoversWholeDomain() override {
+		std::array<bool, 3> coversWholeDomain{};
+		for(size_t dim = 0; dim < 3 ; ++dim){
+			coversWholeDomain[dim] = _boxMax[dim] == _domainLength[dim] and _boxMin[dim] == 0;
+		}
+		return coversWholeDomain;
+	}
+
 private:
 	Teuchos::ParameterList _params;
 

--- a/src/parallel/Zoltan2LoadBalancer.h
+++ b/src/parallel/Zoltan2LoadBalancer.h
@@ -1,0 +1,28 @@
+/**
+ * @file Zoltan2LoadBalancer.h
+ * @author seckler
+ * @date 14.11.19
+ */
+#include "LoadBalancer.h"
+
+#pragma once
+
+/**
+ * Load balancer to interface the Zoltan2 package.
+ * Uses the MultiJagged algorithm provided by Zoltan2, which is similar to the multisection method.
+ */
+class Zoltan2LoadBalancer : public LoadBalancer {
+public:
+	/**
+	 * Constructor
+	 */
+	Zoltan2LoadBalancer();
+
+	/**
+	 * default destructor.
+	 */
+	~Zoltan2LoadBalancer() override = default;
+
+	// doc see base class.
+	std::tuple<std::array<double, 3>, std::array<double, 3>> rebalance(double work) override;
+};

--- a/src/parallel/Zoltan2LoadBalancer.h
+++ b/src/parallel/Zoltan2LoadBalancer.h
@@ -3,6 +3,8 @@
  * @author seckler
  * @date 14.11.19
  */
+#include <mpi.h>
+#include <Teuchos_ParameterList.hpp>
 #include "LoadBalancer.h"
 
 #pragma once
@@ -16,7 +18,8 @@ public:
 	/**
 	 * Constructor
 	 */
-	Zoltan2LoadBalancer();
+	Zoltan2LoadBalancer(std::array<double, 3> boxMin, std::array<double, 3> boxMax, MPI_Comm comm,
+						double minimalDomainSize, std::array<double, 3> domainLength);
 
 	/**
 	 * default destructor.
@@ -25,4 +28,17 @@ public:
 
 	// doc see base class.
 	std::tuple<std::array<double, 3>, std::array<double, 3>> rebalance(double work) override;
+
+	void readXML(XMLfileUnits& xmlconfig) override;
+
+private:
+	Teuchos::ParameterList _params;
+
+private:
+	MPI_Comm _comm;
+	std::array<double, 3> _boxMin;
+	std::array<double, 3> _boxMax;
+	std::array<double, 3> _domainLength;
+	int _numRanks{1};
+	int _rank{0};
 };

--- a/src/parallel/tests/Zoltan2NoMardynTest.cpp
+++ b/src/parallel/tests/Zoltan2NoMardynTest.cpp
@@ -6,16 +6,15 @@
 
 #include "Zoltan2NoMardynTest.h"
 
-#include <Zoltan2_PartitioningSolution.hpp>
-#include <Zoltan2_PartitioningProblem.hpp>
+#include <Tpetra_Map.hpp>
 #include <Zoltan2_BasicVectorAdapter.hpp>
 #include <Zoltan2_InputTraits.hpp>
-#include <Tpetra_Map.hpp>
-#include <vector>
+#include <Zoltan2_PartitioningProblem.hpp>
+#include <Zoltan2_PartitioningSolution.hpp>
 #include <cstdlib>
+#include <vector>
 
 TEST_SUITE_REGISTRATION(Zoltan2NoMardynTest);
-
 
 void Zoltan2NoMardynTest::multiJaggedTest() {
 #ifdef HAVE_ZOLTAN2_MPI
@@ -23,7 +22,7 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 	MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
 	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #else
-	int rank=0, nprocs=1;
+	int rank = 0, nprocs = 1;
 #endif
 
 	// For convenience, we'll use the Tpetra defaults for local/global ID types
@@ -46,7 +45,7 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 	size_t localCount = 40;
 	int dim = 3;
 
-	std::vector<scalar_t> coords (dim * localCount);
+	std::vector<scalar_t> coords(dim * localCount);
 
 	scalar_t *x = coords.data();
 	scalar_t *y = x + localCount;
@@ -57,10 +56,10 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 	srand(rank);
 	scalar_t scalingFactor = 10.0 / RAND_MAX;
 
-	for (size_t i=0; i < localCount*dim; i++){
+	for (size_t i = 0; i < localCount * dim; i++) {
 		coords[i] = scalar_t(rand()) * scalingFactor;
 	}
-	if(rank==0) {
+	if (rank == 0) {
 		x[0] = y[0] = z[0] = 0;
 		x[1] = y[1] = z[1] = 10.;
 	}
@@ -69,19 +68,17 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 
 	// Create global ids for the coordinates.
 
-	std::vector<globalId_t> globalIds (localCount);
+	std::vector<globalId_t> globalIds(localCount);
 	globalId_t offset = rank * localCount;
 
-	for (size_t i=0; i < localCount; i++)
-		globalIds[i] = offset++;
+	for (size_t i = 0; i < localCount; i++) globalIds[i] = offset++;
 
 	///////////////////////////////////////////////////////////////////////
-	// Create parameters for an RCB problem
+	// Create parameters for an MJ problem
 
 	double tolerance = 1.1;
 
-	if (rank == 0)
-		std::cout << "Imbalance tolerance is " << tolerance << std::endl;
+	if (rank == 0) std::cout << "Imbalance tolerance is " << tolerance << std::endl;
 
 	Teuchos::ParameterList params("test params");
 	params.set("debug_level", "basic_status");
@@ -89,9 +86,9 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 	params.set("error_check_level", "debug_mode_assertions");
 
 	params.set("algorithm", "multijagged");
-	params.set("imbalance_tolerance", tolerance );
+	params.set("imbalance_tolerance", tolerance);
 	params.set("num_global_parts", nprocs);
-	params.set("mj_keep_part_boxes",true);
+	params.set("mj_keep_part_boxes", true);
 
 	///////////////////////////////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////
@@ -101,7 +98,7 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 
 	// Create a Zoltan2 input adapter for this geometry. TODO explain
 
-	inputAdapter_t ia1 (localCount,globalIds.data(),x,y,z,1,1,1);
+	inputAdapter_t ia1(localCount, globalIds.data(), x, y, z, 1, 1, 1);
 
 	// Create a Zoltan2 partitioning problem
 
@@ -121,8 +118,8 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 	///////////////////////////////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////
 
-	std::vector<scalar_t> weights (localCount);
-	for (size_t i=0; i < localCount; i++){
+	std::vector<scalar_t> weights(localCount);
+	for (size_t i = 0; i < localCount; i++) {
 		weights[i] = 1.0 + scalar_t(rank) / scalar_t(nprocs);
 	}
 
@@ -130,19 +127,21 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 
 	// Create a Zoltan2 input adapter that includes weights.
 
-	std::vector<const scalar_t *>coordVec(2);
+	std::vector<const scalar_t *> coordVec(2);
 	std::vector<int> coordStrides(2);
 
-	coordVec[0] = x; coordStrides[0] = 1;
-	coordVec[1] = y; coordStrides[1] = 1;
+	coordVec[0] = x;
+	coordStrides[0] = 1;
+	coordVec[1] = y;
+	coordStrides[1] = 1;
 
-	std::vector<const scalar_t *>weightVec(1);
+	std::vector<const scalar_t *> weightVec(1);
 	std::vector<int> weightStrides(1);
 
-	weightVec[0] = weights.data(); weightStrides[0] = 1;
+	weightVec[0] = weights.data();
+	weightStrides[0] = 1;
 
-	inputAdapter_t ia2(localCount, globalIds.data(), coordVec,
-	                                       coordStrides,weightVec,weightStrides);
+	inputAdapter_t ia2(localCount, globalIds.data(), coordVec, coordStrides, weightVec, weightStrides);
 
 	// Create a Zoltan2 partitioning problem
 
@@ -169,13 +168,13 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 
 	// Create the new weights.
 
-	std::vector<scalar_t>weights3 (localCount*3);
+	std::vector<scalar_t> weights3(localCount * 3);
 	srand(rank);
 
-	for (size_t i=0; i < localCount*3; i+=3){
-		weights3[i] = 1.0 + scalar_t(rank) / nprocs;      // weight idx 1
-		weights3[i+1] = rank<nprocs/2 ? 1 : 2;  // weight idx 2
-		weights3[i+2] = scalar_t(rand())/RAND_MAX +.5;    // weight idx 3
+	for (size_t i = 0; i < localCount * 3; i += 3) {
+		weights3[i] = 1.0 + scalar_t(rank) / nprocs;         // weight idx 1
+		weights3[i + 1] = rank < nprocs / 2 ? 1 : 2;         // weight idx 2
+		weights3[i + 2] = scalar_t(rand()) / RAND_MAX + .5;  // weight idx 3
 	}
 
 	// Create a Zoltan2 input adapter with these weights.
@@ -183,16 +182,18 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 	weightVec.resize(3);
 	weightStrides.resize(3);
 
-	weightVec[0] = weights3.data();   weightStrides[0] = 3;
-	weightVec[1] = weights3.data()+1; weightStrides[1] = 3;
-	weightVec[2] = weights3.data()+2; weightStrides[2] = 3;
+	weightVec[0] = weights3.data();
+	weightStrides[0] = 3;
+	weightVec[1] = weights3.data() + 1;
+	weightStrides[1] = 3;
+	weightVec[2] = weights3.data() + 2;
+	weightStrides[2] = 3;
 
-	inputAdapter_t ia3(localCount, globalIds.data(), coordVec,
-	                                       coordStrides,weightVec,weightStrides);
+	inputAdapter_t ia3(localCount, globalIds.data(), coordVec, coordStrides, weightVec, weightStrides);
 
 	// Create a Zoltan2 partitioning problem.
 
-	Zoltan2::PartitioningProblem<inputAdapter_t> problem3 (&ia3, &params);
+	Zoltan2::PartitioningProblem<inputAdapter_t> problem3(&ia3, &params);
 
 	// Solve the problem
 
@@ -205,7 +206,7 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 	///////////////////////////////////////////////////////////////////////
 	// Try the other multicriteria objectives.
 
-	bool dataHasChanged = false;    // default is true
+	bool dataHasChanged = false;  // default is true
 
 	params.set("partitioning_objective", "multicriteria_minimize_maximum_weight");
 	problem3.resetParameters(&params);
@@ -222,10 +223,8 @@ void Zoltan2NoMardynTest::multiJaggedTest() {
 	// Solution changed!
 	checkMetric(rank, tolerance, params, ia3, problem3);
 
-	if (rank == 0)
-		std::cout << "PASS" << std::endl;
+	if (rank == 0) std::cout << "PASS" << std::endl;
 }
-
 
 void Zoltan2NoMardynTest::multiJaggedTest2() {
 #ifdef HAVE_ZOLTAN2_MPI
@@ -233,7 +232,7 @@ void Zoltan2NoMardynTest::multiJaggedTest2() {
 	MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
 	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #else
-	int rank=0, nprocs=1;
+	int rank = 0, nprocs = 1;
 #endif
 
 	// For convenience, we'll use the Tpetra defaults for local/global ID types
@@ -267,19 +266,19 @@ void Zoltan2NoMardynTest::multiJaggedTest2() {
 	srand(rank);
 	scalar_t scalingFactor = 10.0 / RAND_MAX;
 
-	for (size_t i=0; i < localCount*dim; i++){
+	for (size_t i = 0; i < localCount * dim; i++) {
 		coords[i] = scalar_t(rand()) * scalingFactor;
 	}
-	std::vector<scalar_t> weights (localCount);
+	std::vector<scalar_t> weights(localCount);
 	for (size_t i = 0; i < localCount; i++) {
 		weights[i] = 1.0 + scalar_t(rank) / scalar_t(nprocs);
 	}
 
-	if(rank==0) {
+	if (rank == 0) {
 		x[0] = y[0] = z[0] = 0;
 		x[1] = y[1] = z[1] = 10.;
-		//weights[0] = 0.;
-		//weights[1] = 0.;
+		// weights[0] = 0.;
+		// weights[1] = 0.;
 	}
 
 	printArray("x coords: ", x, localCount, rank);
@@ -287,14 +286,13 @@ void Zoltan2NoMardynTest::multiJaggedTest2() {
 
 	// Create global ids for the coordinates.
 
-	std::vector<globalId_t> globalIds (localCount);
+	std::vector<globalId_t> globalIds(localCount);
 	globalId_t offset = rank * localCount;
 
-	for (size_t i=0; i < localCount; i++)
-		globalIds[i] = offset++;
+	for (size_t i = 0; i < localCount; i++) globalIds[i] = offset++;
 
 	///////////////////////////////////////////////////////////////////////
-	// Create parameters for an RCB problem
+	// Create parameters for an MJ problem
 
 	double tolerance = 1.1;
 
@@ -308,10 +306,10 @@ void Zoltan2NoMardynTest::multiJaggedTest2() {
 	params.set("error_check_level", "debug_mode_assertions");
 
 	params.set("algorithm", "multijagged");
-	params.set("imbalance_tolerance", tolerance );
+	params.set("imbalance_tolerance", tolerance);
 	params.set("num_global_parts", nprocs);
-	params.set("mj_keep_part_boxes",true);
-	params.set("rectilinear",true);
+	params.set("mj_keep_part_boxes", true);
+	params.set("rectilinear", true);
 
 	///////////////////////////////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////
@@ -321,27 +319,30 @@ void Zoltan2NoMardynTest::multiJaggedTest2() {
 
 	// Create a Zoltan2 input adapter for this geometry. TODO explain
 
-	std::vector<const scalar_t *>coordVec(3);
+	std::vector<const scalar_t *> coordVec(3);
 	std::vector<int> coordStrides(3);
 
-	coordVec[0] = x; coordStrides[0] = 1;
-	coordVec[1] = y; coordStrides[1] = 1;
-	coordVec[2] = z; coordStrides[2] = 1;
+	coordVec[0] = x;
+	coordStrides[0] = 1;
+	coordVec[1] = y;
+	coordStrides[1] = 1;
+	coordVec[2] = z;
+	coordStrides[2] = 1;
 
 	// 1-d array as multiple weights are supported
-	std::vector<const scalar_t *>weightVec(1);
+	std::vector<const scalar_t *> weightVec(1);
 	// 1-d array as multiple weights are supported
 	std::vector<int> weightStrides(1);
 
 	// point to weights vector
-	weightVec[0] = weights.data(); weightStrides[0] = 1;
+	weightVec[0] = weights.data();
+	weightStrides[0] = 1;
 
-	inputAdapter_t ia1 (localCount, globalIds.data(), coordVec,
-	                                       coordStrides,weightVec,weightStrides);
+	inputAdapter_t ia1(localCount, globalIds.data(), coordVec, coordStrides, weightVec, weightStrides);
 
 	// Create a Zoltan2 partitioning problem
 
-	Zoltan2::PartitioningProblem<inputAdapter_t> problem1 (&ia1, &params);
+	Zoltan2::PartitioningProblem<inputAdapter_t> problem1(&ia1, &params);
 
 	// Solve the problem
 

--- a/src/parallel/tests/Zoltan2NoMardynTest.cpp
+++ b/src/parallel/tests/Zoltan2NoMardynTest.cpp
@@ -1,0 +1,336 @@
+/**
+ * @file Zoltan2NoMardynTest.cpp
+ * @author seckler
+ * @date 18.11.19
+ */
+
+#include "Zoltan2NoMardynTest.h"
+
+#include <Zoltan2_PartitioningSolution.hpp>
+#include <Zoltan2_PartitioningProblem.hpp>
+#include <Zoltan2_BasicVectorAdapter.hpp>
+#include <Zoltan2_InputTraits.hpp>
+#include <Tpetra_Map.hpp>
+#include <vector>
+#include <cstdlib>
+
+TEST_SUITE_REGISTRATION(Zoltan2NoMardynTest);
+
+
+void Zoltan2NoMardynTest::multiJaggedTest() {
+#ifdef HAVE_ZOLTAN2_MPI
+	int rank, nprocs;
+	MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#else
+	int rank=0, nprocs=1;
+#endif
+
+	// For convenience, we'll use the Tpetra defaults for local/global ID types
+	// Users can substitute their preferred local/global ID types
+	typedef Tpetra::Map<> Map_t;
+	typedef Map_t::local_ordinal_type localId_t;
+	typedef Map_t::global_ordinal_type globalId_t;
+
+	typedef double scalar_t;
+	typedef Zoltan2::BasicUserTypes<scalar_t, localId_t, globalId_t> myTypes;
+
+	// TODO explain
+	typedef Zoltan2::BasicVectorAdapter<myTypes> inputAdapter_t;
+	typedef Zoltan2::EvaluatePartition<inputAdapter_t> quality_t;
+	typedef inputAdapter_t::part_t part_t;
+
+	///////////////////////////////////////////////////////////////////////
+	// Create input data.
+
+	size_t localCount = 40;
+	int dim = 3;
+
+	scalar_t *coords = new scalar_t [dim * localCount];
+
+	scalar_t *x = coords;
+	scalar_t *y = x + localCount;
+	scalar_t *z = y + localCount;
+
+	// Create coordinates that range from 0 to 10.0
+
+	srand(rank);
+	scalar_t scalingFactor = 10.0 / RAND_MAX;
+
+	for (size_t i=0; i < localCount*dim; i++){
+		coords[i] = scalar_t(rand()) * scalingFactor;
+	}
+	if(rank==0) {
+		x[0] = y[0] = z[0] = 0;
+		x[1] = y[1] = z[1] = 10.;
+	}
+
+	// Create global ids for the coordinates.
+
+	globalId_t *globalIds = new globalId_t [localCount];
+	globalId_t offset = rank * localCount;
+
+	for (size_t i=0; i < localCount; i++)
+		globalIds[i] = offset++;
+
+	///////////////////////////////////////////////////////////////////////
+	// Create parameters for an RCB problem
+
+	double tolerance = 1.1;
+
+	if (rank == 0)
+		std::cout << "Imbalance tolerance is " << tolerance << std::endl;
+
+	Teuchos::ParameterList params("test params");
+	params.set("debug_level", "basic_status");
+	params.set("debug_procs", "0");
+	params.set("error_check_level", "debug_mode_assertions");
+
+	params.set("algorithm", "multijagged");
+	params.set("imbalance_tolerance", tolerance );
+	params.set("num_global_parts", nprocs);
+	params.set("mj_keep_part_boxes",true);
+
+	///////////////////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////
+	// A simple problem with no weights.
+	///////////////////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////
+
+	// Create a Zoltan2 input adapter for this geometry. TODO explain
+
+	inputAdapter_t *ia1 = new inputAdapter_t(localCount,globalIds,x,y,z,1,1,1);
+
+	// Create a Zoltan2 partitioning problem
+
+	Zoltan2::PartitioningProblem<inputAdapter_t> *problem1 =
+		new Zoltan2::PartitioningProblem<inputAdapter_t>(ia1, &params);
+
+	// Solve the problem
+
+	problem1->solve();
+
+	auto view = problem1->getSolution().getPartBoxesView();
+
+	if(rank == 0) {
+		for (int rankid = 0; rankid< nprocs; ++rankid) {
+			auto lmins = view[rankid].getlmins();
+			auto lmaxs = view[rankid].getlmaxs();
+			std::cout << "rank " << rankid << ": ";
+			for (int i = 0; i < dim; ++i) {
+				std::cout << "[" << lmins[i] << ", " << lmaxs[i] << (i < dim - 1 ? "] x " : "]");
+			}
+			std::cout << std::endl;
+		}
+	}
+	// create metric object where communicator is Teuchos default
+
+	quality_t *metricObject1 = new quality_t(ia1, &params, //problem1->getComm(),
+	                                         &problem1->getSolution());
+	// Check the solution.
+
+	if (rank == 0) {
+		metricObject1->printMetrics(std::cout);
+	}
+
+	if (rank == 0){
+		scalar_t imb = metricObject1->getObjectCountImbalance();
+		if (imb <= tolerance)
+			std::cout << "pass: " << imb << std::endl;
+		else
+			std::cout << "fail: " << imb << std::endl;
+		std::cout << std::endl;
+	}
+	delete metricObject1;
+
+	///////////////////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////
+	// Try a problem with weights
+	///////////////////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////
+
+	scalar_t *weights = new scalar_t [localCount];
+	for (size_t i=0; i < localCount; i++){
+		weights[i] = 1.0 + scalar_t(rank) / scalar_t(nprocs);
+	}
+	weights[0] = 0;
+
+	// Create a Zoltan2 input adapter that includes weights.
+
+	std::vector<const scalar_t *>coordVec(2);
+	std::vector<int> coordStrides(2);
+
+	coordVec[0] = x; coordStrides[0] = 1;
+	coordVec[1] = y; coordStrides[1] = 1;
+
+	std::vector<const scalar_t *>weightVec(1);
+	std::vector<int> weightStrides(1);
+
+	weightVec[0] = weights; weightStrides[0] = 1;
+
+	inputAdapter_t *ia2=new inputAdapter_t(localCount, globalIds, coordVec,
+	                                       coordStrides,weightVec,weightStrides);
+
+	// Create a Zoltan2 partitioning problem
+
+	Zoltan2::PartitioningProblem<inputAdapter_t> *problem2 =
+		new Zoltan2::PartitioningProblem<inputAdapter_t>(ia2, &params);
+
+	// Solve the problem
+
+	problem2->solve();
+
+	// create metric object for MPI builds
+
+#ifdef HAVE_ZOLTAN2_MPI
+	quality_t *metricObject2 = new quality_t(ia2, &params, //problem2->getComm()
+					   MPI_COMM_WORLD,
+					   &problem2->getSolution());
+#else
+	quality_t *metricObject2 = new quality_t(ia2, &params, problem2->getComm(),
+	                                         &problem2->getSolution());
+#endif
+	// Check the solution.
+
+	if (rank == 0) {
+		metricObject2->printMetrics(std::cout);
+	}
+
+	if (rank == 0){
+		scalar_t imb = metricObject2->getWeightImbalance(0);
+		if (imb <= tolerance)
+			std::cout << "pass: " << imb << std::endl;
+		else
+			std::cout << "fail: " << imb << std::endl;
+		std::cout << std::endl;
+	}
+	delete metricObject2;
+
+	if (localCount > 0){
+		delete [] weights;
+		weights = NULL;
+	}
+
+	///////////////////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////
+	// Try a problem with multiple weights.
+	///////////////////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////
+
+	// Add to the parameters the multicriteria objective.
+
+	params.set("partitioning_objective", "multicriteria_minimize_total_weight");
+
+	// Create the new weights.
+
+	weights = new scalar_t [localCount*3];
+	srand(rank);
+
+	for (size_t i=0; i < localCount*3; i+=3){
+		weights[i] = 1.0 + rank / nprocs;      // weight idx 1
+		weights[i+1] = rank<nprocs/2 ? 1 : 2;  // weight idx 2
+		weights[i+2] = rand()/RAND_MAX +.5;    // weight idx 3
+	}
+
+	// Create a Zoltan2 input adapter with these weights.
+
+	weightVec.resize(3);
+	weightStrides.resize(3);
+
+	weightVec[0] = weights;   weightStrides[0] = 3;
+	weightVec[1] = weights+1; weightStrides[1] = 3;
+	weightVec[2] = weights+2; weightStrides[2] = 3;
+
+	inputAdapter_t *ia3=new inputAdapter_t(localCount, globalIds, coordVec,
+	                                       coordStrides,weightVec,weightStrides);
+
+	// Create a Zoltan2 partitioning problem.
+
+	Zoltan2::PartitioningProblem<inputAdapter_t> *problem3 =
+		new Zoltan2::PartitioningProblem<inputAdapter_t>(ia3, &params);
+
+	// Solve the problem
+
+	problem3->solve();
+
+	// create metric object where Teuchos communicator is specified
+
+	quality_t *metricObject3 = new quality_t(ia3, &params, problem3->getComm(),
+	                                         &problem3->getSolution());
+	// Check the solution.
+
+	if (rank == 0) {
+		metricObject3->printMetrics(std::cout);
+	}
+
+	if (rank == 0){
+		scalar_t imb = metricObject3->getWeightImbalance(0);
+		if (imb <= tolerance)
+			std::cout << "pass: " << imb << std::endl;
+		else
+			std::cout << "fail: " << imb << std::endl;
+		std::cout << std::endl;
+	}
+	delete metricObject3;
+
+	///////////////////////////////////////////////////////////////////////
+	// Try the other multicriteria objectives.
+
+	bool dataHasChanged = false;    // default is true
+
+	params.set("partitioning_objective", "multicriteria_minimize_maximum_weight");
+	problem3->resetParameters(&params);
+	problem3->solve(dataHasChanged);
+
+	// Solution changed!
+
+	metricObject3 = new quality_t(ia3, &params, problem3->getComm(),
+	                              &problem3->getSolution());
+	if (rank == 0){
+		metricObject3->printMetrics(std::cout);
+		scalar_t imb = metricObject3->getWeightImbalance(0);
+		if (imb <= tolerance)
+			std::cout << "pass: " << imb << std::endl;
+		else
+			std::cout << "fail: " << imb << std::endl;
+		std::cout << std::endl;
+	}
+	delete metricObject3;
+
+	params.set("partitioning_objective", "multicriteria_balance_total_maximum");
+	problem3->resetParameters(&params);
+	problem3->solve(dataHasChanged);
+
+	// Solution changed!
+
+	metricObject3 = new quality_t(ia3, &params, problem3->getComm(),
+	                              &problem3->getSolution());
+	if (rank == 0){
+		metricObject3->printMetrics(std::cout);
+		scalar_t imb = metricObject3->getWeightImbalance(0);
+		if (imb <= tolerance)
+			std::cout << "pass: " << imb << std::endl;
+		else
+			std::cout << "fail: " << imb << std::endl;
+		std::cout << std::endl;
+	}
+	delete metricObject3;
+
+	if (localCount > 0){
+		delete [] weights;
+		weights = nullptr;
+	}
+
+	delete [] coords;
+	delete [] globalIds;
+
+	delete problem1;
+	delete ia1;
+	delete problem2;
+	delete ia2;
+	delete problem3;
+	delete ia3;
+
+	if (rank == 0)
+		std::cout << "PASS" << std::endl;
+}

--- a/src/parallel/tests/Zoltan2NoMardynTest.h
+++ b/src/parallel/tests/Zoltan2NoMardynTest.h
@@ -1,0 +1,24 @@
+/**
+ * @file Zoltan2NoMardynTest.h
+ * @author seckler
+ * @date 18.11.19
+ */
+
+#pragma once
+
+#include <utils/Testing.h>
+
+class Zoltan2NoMardynTest : public utils::Test {
+	TEST_SUITE(Zoltan2NoMardynTest);
+	TEST_METHOD(multiJaggedTest);
+	TEST_SUITE_END();
+public:
+	Zoltan2NoMardynTest() = default;
+	~Zoltan2NoMardynTest() override = default;
+
+	void multiJaggedTest();
+};
+
+
+
+

--- a/src/parallel/tests/Zoltan2NoMardynTest.h
+++ b/src/parallel/tests/Zoltan2NoMardynTest.h
@@ -7,18 +7,57 @@
 #pragma once
 
 #include <utils/Testing.h>
+#include <Zoltan2_BasicVectorAdapter.hpp>
+#include <Zoltan2_PartitioningProblem.hpp>
 
 class Zoltan2NoMardynTest : public utils::Test {
 	TEST_SUITE(Zoltan2NoMardynTest);
 	TEST_METHOD(multiJaggedTest);
+	TEST_METHOD(multiJaggedTest2);
 	TEST_SUITE_END();
+
 public:
 	Zoltan2NoMardynTest() = default;
 	~Zoltan2NoMardynTest() override = default;
 
-	void multiJaggedTest();
+	static void multiJaggedTest();
+
+	static void multiJaggedTest2();
+private:
+	static void printArray(const std::string& info, double* array, size_t count, int rank);
+
+	template<typename inputAdapter_t>
+	static void printDecomposition(int rank, int nprocs, int dim,
+								   Zoltan2::PartitioningProblem<inputAdapter_t>* problem){
+		auto view = problem->getSolution().getPartBoxesView();
+
+		if (rank == 0) {
+			for (int rankid = 0; rankid < nprocs; ++rankid) {
+				auto lmins = view[rankid].getlmins();
+				auto lmaxs = view[rankid].getlmaxs();
+				std::cout << "rank " << rankid << ": ";
+				for (int i = 0; i < dim; ++i) {
+					std::cout << "[" << lmins[i] << ", " << lmaxs[i] << (i < dim - 1 ? "] x " : "]");
+				}
+				std::cout << std::endl;
+			}
+		}
+	}
+
+	template<typename inputAdapter_t>
+	static void checkMetric(int rank, double tolerance, Teuchos::ParameterList& params,
+	                        inputAdapter_t& ia,
+							Zoltan2::PartitioningProblem<inputAdapter_t>& problem){
+		Zoltan2::EvaluatePartition<inputAdapter_t> metricObject (&ia, &params, problem.getComm(),
+		                                                           &problem.getSolution());
+		if (rank == 0){
+			metricObject.printMetrics(std::cout);
+			double imb = metricObject.getWeightImbalance(0);
+			if (imb <= tolerance)
+				std::cout << "pass: " << imb << std::endl;
+			else
+				std::cout << "fail: " << imb << std::endl;
+			std::cout << std::endl;
+		}
+	}
 };
-
-
-
-


### PR DESCRIPTION
# Description

- [x] Adds the zoltan2 library as a load balancer.
- [x] The GeneralDomainDecomposition now requires (mandatory!) the additional field as xml input:
  `<loadBalancer type="STRING"/>`, where the STRING can be one of `ALL` and `Zoltan2`.
  This change was necessary to be able to pass additional options to the two load balancers (e.g. samples, ...).
- [ ] Add additional options for number of samples for Zoltan2LoadBalancer


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Test A
- [ ] Test B
