### PR TITLE
Checkpoint refactoring

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ pipeline {
                 dir ("build"){
                   sh """
                     cmake -DENABLE_AUTOPAS=ON -DOPENMP=ON -DENABLE_UNIT_TESTS=1 ..
-                    make -j8
+                    make -j4
                   """
                 }
                 stash includes: "build/src/MarDyn", name: "autopas_exec"
@@ -101,7 +101,7 @@ pipeline {
                 dir ("build-mpi"){
                   sh """
                     CC=mpicc CXX=mpicxx cmake -DENABLE_ALLLBL=ON -DENABLE_MPI=ON -DENABLE_AUTOPAS=ON -DOPENMP=ON -DENABLE_UNIT_TESTS=1 ..
-                    make -j8
+                    make -j4
                   """
                 }
                 stash includes: "build-mpi/src/MarDyn", name: "autopas_mpi_exec"

--- a/src/io/CheckpointWriter.cpp
+++ b/src/io/CheckpointWriter.cpp
@@ -1,9 +1,5 @@
 #include "io/CheckpointWriter.h"
 
-#ifdef ENABLE_MPI
-#include <mpi.h>
-#include "utils/MPI_Info_object.h"
-#endif
 
 #include <sstream>
 #include <string>
@@ -85,93 +81,8 @@ void CheckpointWriter::endStep(ParticleContainer *particleContainer, DomainDecom
 			filenamestream << ".restart.dat";
 		}
 
-		if(_useBinaryFormat) {
-#ifdef ENABLE_MPI
-			domainDecomp->assertDisjunctivity(particleContainer);
-			// update global number of particles
-			domain->updateglobalNumMolecules(particleContainer, domainDecomp);
-
-			int rank = domainDecomp->getRank();
-			std::string fileprefix = filenamestream.str();
-			std::string filename = fileprefix + ".dat";
-
-			MPI_File mpifh;
-			MPI_Info_object mpiinfo;
-			MPI_File_open(MPI_COMM_WORLD, const_cast<char*>(filename.c_str()), MPI_MODE_WRONLY|MPI_MODE_CREATE, mpiinfo, &mpifh);
-
-			uint64_t numParticles_local = 0;
-			uint64_t numParticles_exscan = 0;
-			auto begin = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY);
-			for(auto it = begin; it.isValid(); ++it)
-				numParticles_local++;
-
-			MPI_Exscan(&numParticles_local, &numParticles_exscan, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
-
-			uint16_t particle_data_size = 116;
-			uint64_t buffer_size = 32768;
-			char* write_buffer = new char[buffer_size];
-			uint64_t offset = numParticles_exscan * particle_data_size;
-			MPI_File_seek(mpifh, offset, MPI_SEEK_SET);
-			uint64_t buffer_pos = 0;
-
-			for(auto it = begin; it.isValid(); ++it) {
-				uint64_t pid = it->getID();
-				uint32_t cid_ub = it->componentid()+1;
-				double r[3];
-				double v[3];
-				double D[3];
-				Quaternion Q = it->q();
-				double q[4];
-				for(auto d=0; d<3; ++d) {
-					r[d] = it->r(d);
-					v[d] = it->v(d);
-					D[d] = it->D(d);
-				}
-				q[0] = Q.qw();
-				q[1] = Q.qx();
-				q[2] = Q.qy();
-				q[3] = Q.qz();
-				memcpy(&write_buffer[buffer_pos], (char*)&pid, sizeof(uint64_t)); buffer_pos += sizeof(uint64_t);
-				memcpy(&write_buffer[buffer_pos], (char*)&cid_ub, sizeof(uint32_t)); buffer_pos += sizeof(uint32_t);
-				memcpy(&write_buffer[buffer_pos], (char*)&r[0], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&r[1], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&r[2], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&v[0], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&v[1], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&v[2], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&q[0], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&q[1], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&q[2], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&q[3], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&D[0], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&D[1], sizeof(double)); buffer_pos += sizeof(double);
-				memcpy(&write_buffer[buffer_pos], (char*)&D[2], sizeof(double)); buffer_pos += sizeof(double);
-
-				if(buffer_pos > buffer_size - particle_data_size) {
-					MPI_Status status;
-					MPI_File_write(mpifh, write_buffer, buffer_pos, MPI_BYTE, &status);
-					buffer_pos = 0;
-				}
-			}
-			MPI_Status status;
-			MPI_File_write(mpifh, write_buffer, buffer_pos, MPI_BYTE, &status);
-
-			delete[] write_buffer;
-			MPI_File_close(&mpifh);
-
-			// writer Header
-			double currentTime = global_simulation->getSimulationTime();
-			filename = fileprefix + ".header.xml";
-			domain->writeCheckpointHeaderXML(filename, particleContainer, domainDecomp, currentTime);
-#else
-			string filename = filenamestream.str();
-			domain->writeCheckpoint(filename, particleContainer, domainDecomp, _simulation.getSimulationTime(), _useBinaryFormat);
-#endif
-		}
-		else { /* ASCII mode */
-			string filename = filenamestream.str();
-			domain->writeCheckpoint(filename, particleContainer, domainDecomp, _simulation.getSimulationTime(), _useBinaryFormat);
-		}
+		string filename = filenamestream.str();
+		domain->writeCheckpoint(filename, particleContainer, domainDecomp, _simulation.getSimulationTime(), _useBinaryFormat);
 	}
 }
 

--- a/src/io/tests/CheckpointRestartTest.cpp
+++ b/src/io/tests/CheckpointRestartTest.cpp
@@ -38,7 +38,7 @@ void CheckpointRestartTest::testCheckpointRestartBinary() {
 }
 
 /*
- * This tests if a written checkpoint can successfully be read again using binary.
+ * Actual test if a written checkpoint can successfully be read again.
  */
 void CheckpointRestartTest::testCheckpointRestart(bool binary) {
 	ParticleContainer* particleContainer

--- a/src/io/tests/CheckpointRestartTest.cpp
+++ b/src/io/tests/CheckpointRestartTest.cpp
@@ -1,51 +1,69 @@
 /*
- * inputFileTest.cpp
+ * CheckpointRestartTest.cpp
  *
- * There are two problems
- * - How to derive components.
- * - error with the use of molecule
+ * Check whether a checkpoint can be successfully read again.
  *
- *  Created on: 01.05.2012
- *      Author: yutaka
+ *  Created on: 11.08.2016
+ *      Author: seckler
  */
 
 #include "Domain.h"
 #include "particleContainer/ParticleContainer.h"
+#include "parallel/DomainDecompBase.h"
 #include <iostream>
-#include <sstream>
 
 #include "io/tests/CheckpointRestartTest.h"
 
 using namespace std;
 
-class MDGenerator;
 
-#if !defined(ENABLE_REDUCED_MEMORY_MODE) && !defined(MARDYN_AUTOPAS)
+#if !defined(ENABLE_REDUCED_MEMORY_MODE)
 TEST_SUITE_REGISTRATION(CheckpointRestartTest);
 #else
-#pragma message "Compilation Info: CheckpointRestartTest disabled in reduced memory mode and autopas mode."
+#pragma message "Compilation Info: CheckpointRestartTest disabled in reduced memory mode."
 #endif
 
-
-CheckpointRestartTest::CheckpointRestartTest() {
-}
-
-CheckpointRestartTest::~CheckpointRestartTest() {
+/*
+ * This tests if a written checkpoint can successfully be read again using the ascii writer.
+ */
+void CheckpointRestartTest::testCheckpointRestartASCII() {
+	testCheckpointRestart(false);
 }
 
 /*
- * testRemoveMomentum tests if removeMomentum in MDGenerator works properly or not.
+ * This tests if a written checkpoint can successfully be read again using binary.
  */
-void CheckpointRestartTest::testCheckpointRestart() {
+void CheckpointRestartTest::testCheckpointRestartBinary() {
+	testCheckpointRestart(true);
+}
+
+/*
+ * This tests if a written checkpoint can successfully be read again using binary.
+ */
+void CheckpointRestartTest::testCheckpointRestart(bool binary) {
 	ParticleContainer* particleContainer
 		= initializeFromFile(ParticleContainerFactory::LinkedCell, "VectorizationMultiComponentMultiPotentials_50_molecules.inp", 10.5);
+	auto initialParticleCount = getGlobalParticleNumber(particleContainer);
 
-	_domain->writeCheckpoint(getTestDataFilename("restart.test.dat", false), particleContainer, _domainDecomposition, 0.);
+	_domain->writeCheckpoint(getTestDataFilename("restart.test.dat", false), particleContainer, _domainDecomposition,
+	                         0., binary);
 
 	delete particleContainer;
 
 	ParticleContainer* particleContainer2
-			= initializeFromFile(ParticleContainerFactory::LinkedCell, "restart.test.dat", 1.5);
+		= initializeFromFile(ParticleContainerFactory::LinkedCell, "restart.test.dat", 10.5, binary);
 
+	auto restartedParticleCount = getGlobalParticleNumber(particleContainer2);
+	ASSERT_EQUAL(initialParticleCount, restartedParticleCount);
 	delete particleContainer2;
+}
+
+unsigned long CheckpointRestartTest::getGlobalParticleNumber(ParticleContainer* particleContainer){
+	unsigned long localParticleCount = particleContainer->getNumberOfParticles();
+	_domainDecomposition->collCommInit(1);
+	_domainDecomposition->collCommAppendUnsLong(localParticleCount);
+	_domainDecomposition->collCommAllreduceSum();
+	auto globalNumParticles = _domainDecomposition->collCommGetUnsLong();
+	_domainDecomposition->collCommFinalize();
+	return globalNumParticles;
 }

--- a/src/io/tests/CheckpointRestartTest.cpp
+++ b/src/io/tests/CheckpointRestartTest.cpp
@@ -45,13 +45,14 @@ void CheckpointRestartTest::testCheckpointRestart(bool binary) {
 		= initializeFromFile(ParticleContainerFactory::LinkedCell, "VectorizationMultiComponentMultiPotentials_50_molecules.inp", 10.5);
 	auto initialParticleCount = getGlobalParticleNumber(particleContainer);
 
-	_domain->writeCheckpoint(getTestDataFilename("restart.test.dat", false), particleContainer, _domainDecomposition,
+	std::string filename = binary ? "restart.test" : "restart.test.dat";
+	_domain->writeCheckpoint(getTestDataFilename(filename, false), particleContainer, _domainDecomposition,
 	                         0., binary);
 
 	delete particleContainer;
 
 	ParticleContainer* particleContainer2
-		= initializeFromFile(ParticleContainerFactory::LinkedCell, "restart.test.dat", 10.5, binary);
+		= initializeFromFile(ParticleContainerFactory::LinkedCell, filename, 10.5, binary);
 
 	auto restartedParticleCount = getGlobalParticleNumber(particleContainer2);
 	ASSERT_EQUAL(initialParticleCount, restartedParticleCount);

--- a/src/io/tests/CheckpointRestartTest.h
+++ b/src/io/tests/CheckpointRestartTest.h
@@ -1,12 +1,12 @@
-
 /*
- * inputFileTest.h
+ * CheckpointRestartTest.h
  *
- *  Created on: 01.05.2012
- *      Author: yutaka
+ * Check whether a checkpoint can be successfully read again.
+ *
+ *  Created on: 11.08.2016
+ *      Author: seckler
  */
-#ifndef INPUTFILETEST_H_
-#define INPUTFILETEST_H_
+#pragma once
 
 #include "utils/TestWithSimulationSetup.h"
 
@@ -36,5 +36,3 @@ private:
 	void testCheckpointRestart(bool binary);
 	unsigned long getGlobalParticleNumber(ParticleContainer* particleContainer);
 };
-
-#endif /* INPUTFILETEST_H_ */

--- a/src/io/tests/CheckpointRestartTest.h
+++ b/src/io/tests/CheckpointRestartTest.h
@@ -16,18 +16,25 @@ class CheckpointRestartTest : public utils::TestWithSimulationSetup {
 	TEST_SUITE(CheckpointRestartTest);
 
 	// add a method which perform test
-	TEST_METHOD(testCheckpointRestart);
+	TEST_METHOD(testCheckpointRestartASCII);
+
+	// add a method which perform test
+	TEST_METHOD(testCheckpointRestartBinary);
 
 	// end suite declaration
 	TEST_SUITE_END();
 
 public:
-	CheckpointRestartTest();
-	virtual ~CheckpointRestartTest();
-	/*
-	 * testRemoveMomentum tests if removeMomentum in MDGenerator works properly or not.
-	 */
-	void testCheckpointRestart();
+	CheckpointRestartTest() = default;
+	virtual ~CheckpointRestartTest() = default;
+
+	void testCheckpointRestartASCII();
+
+	void testCheckpointRestartBinary();
+private:
+
+	void testCheckpointRestart(bool binary);
+	unsigned long getGlobalParticleNumber(ParticleContainer* particleContainer);
 };
 
 #endif /* INPUTFILETEST_H_ */

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -490,11 +490,12 @@ void DomainDecompBase::writeMoleculesToMPIFileBinary(const std::string& filename
 
 	MPI_Exscan(&numParticles_local, &numParticles_exscan, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
 
-	uint16_t particle_data_size;
+	uint16_t particle_data_size = 0;
+	// if no particle is found (begin is not valid) particle_data_size is zero and provides no problem.
+	if(begin.isValid())
 	{
-		Molecule dummy;
 		std::stringstream str;
-		dummy.writeBinary(str);
+		begin->writeBinary(str);
 		particle_data_size = str.str().size();
 	}
 	uint64_t buffer_size = 32768;

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -473,7 +473,7 @@ int DomainDecompBase::getNumProcs() const {
 
 void DomainDecompBase::barrier() const {
 }
-
+#ifdef ENABLE_MPI
 void DomainDecompBase::writeMoleculesToMPIFileBinary(const std::string& filename, ParticleContainer* moleculeContainer) const {
 	int rank = getRank();
 
@@ -559,7 +559,7 @@ void DomainDecompBase::writeMoleculesToMPIFileBinary(const std::string& filename
 	delete[] write_buffer;
 	MPI_File_close(&mpifh);
 }
-
+#endif
 void DomainDecompBase::writeMoleculesToFile(const std::string& filename, ParticleContainer* moleculeContainer,
                                             bool binary) const {
 #ifdef ENABLE_MPI
@@ -573,8 +573,9 @@ void DomainDecompBase::writeMoleculesToFile(const std::string& filename, Particl
 			if (getRank() == process) {
 				std::ofstream checkpointfilestream;
 				if (binary) {
-					checkpointfilestream.open((filename + ".dat").c_str(),
-					                          std::ios::binary | std::ios::out | std::ios::app);
+					checkpointfilestream.open(
+						(filename + ".dat").c_str(),
+						std::ios::binary | std::ios::out | (getRank() != 0 ? std::ios::app : std::ios::trunc));
 				} else {
 					checkpointfilestream.open(filename.c_str(), std::ios::app);
 					checkpointfilestream.precision(20);

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -573,10 +573,12 @@ void DomainDecompBase::writeMoleculesToFile(const std::string& filename, Particl
 			if (getRank() == process) {
 				std::ofstream checkpointfilestream;
 				if (binary) {
-					checkpointfilestream.open(
-						(filename + ".dat").c_str(),
-						std::ios::binary | std::ios::out | (getRank() != 0 ? std::ios::app : std::ios::trunc));
+					auto appendOrTruncate = getRank() != 0 ? std::ios::app : std::ios::trunc;
+					// truncate if we are binary and in rank 0, otherwise append!
+					checkpointfilestream.open((filename + ".dat").c_str(),
+											  std::ios::binary | std::ios::out | appendOrTruncate);
 				} else {
+					// always append in ascii mode, as we have written the header already to the same file.
 					checkpointfilestream.open(filename.c_str(), std::ios::app);
 					checkpointfilestream.precision(20);
 				}

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -479,7 +479,8 @@ void DomainDecompBase::writeMoleculesToMPIFileBinary(const std::string& filename
 
 	MPI_File mpifh;
 	MPI_Info_object mpiinfo;
-	MPI_File_open(MPI_COMM_WORLD, const_cast<char*>(filename.c_str()), MPI_MODE_WRONLY | MPI_MODE_CREATE, mpiinfo,
+	auto extfilename = filename + ".dat";
+	MPI_File_open(MPI_COMM_WORLD, extfilename.c_str(), MPI_MODE_WRONLY | MPI_MODE_CREATE, mpiinfo,
 	              &mpifh);
 
 	uint64_t numParticles_local = 0;

--- a/src/parallel/DomainDecompBase.h
+++ b/src/parallel/DomainDecompBase.h
@@ -172,6 +172,18 @@ public:
 	//! @param moleculeContainer e.g. needed for the cutoff radius
 	double getIOCutoffRadius(int dim, Domain* domain, ParticleContainer* moleculeContainer);
 
+
+#ifdef ENABLE_MPI
+	//! @brief appends molecule data to the file. The format is the same as that of the input file
+	//! @param filename name of the file into which the data will be written
+	//! @param moleculeContainer all Particles from this container will be written to the file
+	//!
+	//! This version uses, MPI IO.
+	//! @param filename name of the file into which the data will be written
+	//! @param moleculeContainer all Particles from this container will be written to the file
+	void writeMoleculesToMPIFileBinary(const std::string& filename, ParticleContainer* moleculeContainer) const;
+#endif // ENABLE_MPI
+
 	//! @brief appends molecule data to the file. The format is the same as that of the input file
 	//! @param filename name of the file into which the data will be written
 	//! @param moleculeContainer all Particles from this container will be written to the file

--- a/src/parallel/DomainDecompBase.h
+++ b/src/parallel/DomainDecompBase.h
@@ -175,9 +175,6 @@ public:
 
 #ifdef ENABLE_MPI
 	//! @brief appends molecule data to the file. The format is the same as that of the input file
-	//! @param filename name of the file into which the data will be written
-	//! @param moleculeContainer all Particles from this container will be written to the file
-	//!
 	//! This version uses, MPI IO.
 	//! @param filename name of the file into which the data will be written
 	//! @param moleculeContainer all Particles from this container will be written to the file
@@ -185,12 +182,9 @@ public:
 #endif // ENABLE_MPI
 
 	//! @brief appends molecule data to the file. The format is the same as that of the input file
-	//! @param filename name of the file into which the data will be written
-	//! @param moleculeContainer all Particles from this container will be written to the file
-	//!
-	//! Currently, parallel IO isn't used.
-	//! To ensure that not more than one process writes to the file at any time,
-	//! there is a loop over all processes with a barrier in between
+	//! If MPI is enabled and binary files are supposed to be written this function will call writeMoleculesToMPIFileBinary().
+	//! Otherwise, to ensure that not more than one process writes to the file at any time,
+	//! there is a loop over all processes with a barrier in between.
 	//! @param filename name of the file into which the data will be written
 	//! @param moleculeContainer all Particles from this container will be written to the file
 	//! @param binary flag, that is true if the output shall be binary

--- a/src/particleContainer/tests/ParticleContainerFactory.cpp
+++ b/src/particleContainer/tests/ParticleContainerFactory.cpp
@@ -59,7 +59,7 @@ ParticleContainer* ParticleContainerFactory::createInitializedParticleContainer(
 		inputReader.reset(new BinaryReader());
 		auto* binaryReader = dynamic_cast<BinaryReader*>(inputReader.get());
 		binaryReader->setPhaseSpaceHeaderFile(fileName + ".header.xml");
-		binaryReader->setPhaseSpaceFile(fileName);
+		binaryReader->setPhaseSpaceFile(fileName + ".dat");
 	} else {
 		inputReader.reset(new ASCIIReader());
 		auto* asciiReader = dynamic_cast<ASCIIReader*>(inputReader.get());

--- a/src/particleContainer/tests/ParticleContainerFactory.h
+++ b/src/particleContainer/tests/ParticleContainerFactory.h
@@ -39,7 +39,7 @@ public:
 	 * The caller is responsible for deleting the pointer!
 	 */
 	static ParticleContainer* createInitializedParticleContainer(
-			Type type, Domain* domain, DomainDecompBase* domainDecomposition, double cutoff, const std::string& fileName);
+			Type type, Domain* domain, DomainDecompBase* domainDecomposition, double cutoff, const std::string& fileName, bool binary);
 
 };
 

--- a/src/utils/TestWithSimulationSetup.cpp
+++ b/src/utils/TestWithSimulationSetup.cpp
@@ -52,10 +52,11 @@ void utils::TestWithSimulationSetup::tearDown() {
 
 
 ParticleContainer* utils::TestWithSimulationSetup::initializeFromFile(
-		ParticleContainerFactory::Type type, const char* fileName, double cutoff, bool binary) {
+		ParticleContainerFactory::Type type, const std::string& fileName, double cutoff, bool binary) {
 
+	bool checkExist = not binary;  // for binary the prefix is given, so we cannot check the file for existence.
 	return ParticleContainerFactory::createInitializedParticleContainer(
-			type, _domain, _domainDecomposition, cutoff, getTestDataFilename(fileName), binary);
+			type, _domain, _domainDecomposition, cutoff, getTestDataFilename(fileName, checkExist), binary);
 }
 
 #endif /* UNIT_TESTS */

--- a/src/utils/TestWithSimulationSetup.cpp
+++ b/src/utils/TestWithSimulationSetup.cpp
@@ -52,10 +52,10 @@ void utils::TestWithSimulationSetup::tearDown() {
 
 
 ParticleContainer* utils::TestWithSimulationSetup::initializeFromFile(
-		ParticleContainerFactory::Type type, const char* fileName, double cutoff) {
+		ParticleContainerFactory::Type type, const char* fileName, double cutoff, bool binary) {
 
 	return ParticleContainerFactory::createInitializedParticleContainer(
-			type, _domain, _domainDecomposition, cutoff, getTestDataFilename(fileName));
+			type, _domain, _domainDecomposition, cutoff, getTestDataFilename(fileName), binary);
 }
 
 #endif /* UNIT_TESTS */

--- a/src/utils/TestWithSimulationSetup.h
+++ b/src/utils/TestWithSimulationSetup.h
@@ -60,7 +60,6 @@ public:
 
 
 protected:
-
 	/**
 	 * Initialize a particle container from the given phase specification file.
 	 * The domain class is setup as far as the input file is concerned, and for
@@ -71,11 +70,12 @@ protected:
 	 * @param fileName the name of the file (relative to the testDataDirectory) which
 	 *                 is used for initialization
 	 * @param cutoff the value used for all kinds of cutoff radii
-	 *
+	 * @param binary specifies that the file pointed to is a binary file. If true the header of this file has to have the
+	 * additional extension .header.xml !
 	 * @note The caller is responsible for deleting the particle container.
 	 * @see ParticleContainerFactory::createInitializedParticleContainer()
 	 */
-	ParticleContainer* initializeFromFile(ParticleContainerFactory::Type type, const char* fileName, double cutoff);
+	ParticleContainer* initializeFromFile(ParticleContainerFactory::Type type, const char* fileName, double cutoff, bool binary=false);
 
 	int _rank;
 

--- a/src/utils/TestWithSimulationSetup.h
+++ b/src/utils/TestWithSimulationSetup.h
@@ -72,7 +72,6 @@ protected:
 	 * @param cutoff the value used for all kinds of cutoff radii
 	 * @param binary specifies that the file pointed to is a binary file. If true the header of this file has to have the
 	 * extension ".header.xml" and the data file ".dat".
-	 * @param checkExist specifies whether to check for existence of the file or not.
 	 * @note The caller is responsible for deleting the particle container.
 	 * @see ParticleContainerFactory::createInitializedParticleContainer()
 	 */

--- a/src/utils/TestWithSimulationSetup.h
+++ b/src/utils/TestWithSimulationSetup.h
@@ -68,14 +68,16 @@ protected:
 	 *
 	 * @param type the concrete implementation of the particleContainer to be created
 	 * @param fileName the name of the file (relative to the testDataDirectory) which
-	 *                 is used for initialization
+	 *                 is used for initialization, or the prefix of the filename for binary files.
 	 * @param cutoff the value used for all kinds of cutoff radii
 	 * @param binary specifies that the file pointed to is a binary file. If true the header of this file has to have the
-	 * additional extension .header.xml !
+	 * extension ".header.xml" and the data file ".dat".
+	 * @param checkExist specifies whether to check for existence of the file or not.
 	 * @note The caller is responsible for deleting the particle container.
 	 * @see ParticleContainerFactory::createInitializedParticleContainer()
 	 */
-	ParticleContainer* initializeFromFile(ParticleContainerFactory::Type type, const char* fileName, double cutoff, bool binary=false);
+	ParticleContainer* initializeFromFile(ParticleContainerFactory::Type type, const std::string& fileName,
+										  double cutoff, bool binary = false);
 
 	int _rank;
 

--- a/test_input/.gitignore
+++ b/test_input/.gitignore
@@ -1,1 +1,2 @@
 /restart.test.dat
+/restart.test.header.xml


### PR DESCRIPTION
# Description

Refactors the Checkpointing:
* Adds an additional test to also check binary checkpointing
* enables checkpoint-restart tests for AutoPas
* moves binary MPI-IO checkpoint writer to DomainDecompBase
* fixes binary checkpoints not using Molecule::writeBinary(...) by using a streambuffer.
* allows reading of binary checkpoints in tests.

## Related Pull Requests

- MPI-IO for CheckpointWriter was introduced in #112.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Adds new Test for binary checkpointing.
