### PR TITLE
Fixes bug in spatial profile virial output when using cylindrical coordinates

### DIFF
--- a/examples/general-plugins/SpatialProfiles/CartesianSampling/CartesianSampling.xml
+++ b/examples/general-plugins/SpatialProfiles/CartesianSampling/CartesianSampling.xml
@@ -111,14 +111,14 @@
       </component>
     </plugin>
 
-    <!-- MIRROR -->
+    <!-- MIRROR plugin disabled as new version seems to need DistControl as well
 
      <plugin name="Mirror">
       <yPos>55</yPos>
       <forceConstant>10</forceConstant>
       <direction>0</direction>
     </plugin>
-
+    -->
     <!-- SPATIAL PROFILE OUTPUT -->
 
      <plugin name="SpatialProfile">
@@ -132,6 +132,7 @@
         <recording>1</recording>
       </timesteps>
       <outputprefix>cartesian</outputprefix>
+      <profiledComponent>all</profiledComponent>
       <profiles>
         <density>1</density>
         <temperature>1</temperature>

--- a/examples/general-plugins/SpatialProfiles/CartesianSampling/CartesianSampling.xml
+++ b/examples/general-plugins/SpatialProfiles/CartesianSampling/CartesianSampling.xml
@@ -7,20 +7,20 @@
   </refunits>
   <simulation type="MD">
     <integrator type="Leapfrog">
-      <timestep unit="reduced">0.0005</timestep>
+      <timestep unit="reduced">0.0000000000001</timestep>
     </integrator>
     <run>
       <currenttime>0</currenttime>
       <production>
-        <steps>100</steps>
+        <steps>10</steps>
       </production>
     </run>
     <ensemble type="NVT">
       <temperature unit="reduced">0.86232</temperature>
       <domain type="box">
-        <lx>72.7626</lx>
-        <ly>62.9432</ly>
-        <lz>72.7626</lz>
+        <lx>50.0</lx>
+        <ly>50.0</ly>
+        <lz>50.0</lz>
       </domain>
       <components>
         <moleculetype id="1" name="Test">
@@ -39,7 +39,11 @@
         </moleculetype>
       </components>
       <phasespacepoint>
-        <file type="ASCII">Ads_LJ1043.inp</file>
+          <generator name="CubicGridGenerator">
+              <specification>density</specification>
+              <density>0.1</density>
+              <binaryMixture>false</binaryMixture>
+          </generator>
       </phasespacepoint>
     </ensemble>
     
@@ -69,9 +73,9 @@
                 <lcx>0.0</lcx>
                 <lcy>0.0</lcy>
                 <lcz>0.0</lcz>
-                <ucx>72.7626</ucx>
-                <ucy>62.9432</ucy>
-                <ucz>72.7626</ucz>
+                <ucx>50.0</ucx>
+                <ucy>50.0</ucy>
+                <ucz>50.0</ucz>
               </coords>
               <target>
                 <temperature>293.44</temperature>
@@ -91,7 +95,7 @@
 
       <outputplugin name="VTKMoleculeWriter">
         <outputprefix>vtkOutput</outputprefix>
-        <writefrequency>100</writefrequency>
+        <writefrequency>10</writefrequency>
       </outputplugin>
     </output>
 
@@ -124,9 +128,9 @@
      <plugin name="SpatialProfile">
       <mode>cartesian</mode>
       <x>1</x>
-      <y>20</y>
-      <z>20</z>
-      <writefrequency>100</writefrequency>
+      <y>5</y>
+      <z>5</z>
+      <writefrequency>10</writefrequency>
       <timesteps>
         <init>1</init>
         <recording>1</recording>
@@ -141,5 +145,26 @@
         <virial>1</virial>
       </profiles>
     </plugin>
+
+      <plugin name="SpatialProfile">
+          <mode>cylinder</mode>
+          <r>5</r>
+          <h>5</h>
+          <phi>1</phi>
+          <writefrequency>10</writefrequency>
+          <timesteps>
+              <init>1</init>
+              <recording>1</recording>
+          </timesteps>
+          <outputprefix>cylinder</outputprefix>
+          <profiledComponent>all</profiledComponent>
+          <profiles>
+              <density>1</density>
+              <temperature>1</temperature>
+              <velocity>1</velocity>
+              <velocity3d>1</velocity3d>
+              <virial>1</virial>
+          </profiles>
+      </plugin>
    </simulation>
 </mardyn>

--- a/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
+++ b/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
@@ -153,12 +153,13 @@
 	      </component>
 	    </plugin>
 
-	    <!-- MIRROR ON TOP -->
+	    <!-- MIRROR ON TOP
 	    <plugin name="Mirror">
 	      <yPos>78</yPos>
 	      <forceConstant>10</forceConstant>
 	      <direction>0</direction>
 	    </plugin>
+	    -->
 
 	    <!-- CARTESIAN/CYLINDER PROFILE -->
 	    <plugin name="SpatialProfile">
@@ -176,7 +177,9 @@
 	        <recording>5</recording>
 	      </timesteps>
 	      <outputprefix>drop.cyl.</outputprefix>
-	      <profiles>
+          <profiledComponent>all</profiledComponent>
+
+            <profiles>
 	        <density>1</density>
 	        <temperature>0</temperature>
 	        <velocity>0</velocity>

--- a/src/plugins/profiles/DensityProfile.cpp
+++ b/src/plugins/profiles/DensityProfile.cpp
@@ -5,12 +5,12 @@
 
 #include "DensityProfile.h"
 
-void DensityProfile::output (string prefix, long unsigned accumulatedDatasets) {
+void DensityProfile::output(string prefix, long unsigned accumulatedDatasets) {
 	global_log->info() << "[DensityProfile] output" << std::endl;
 
 	// Setup outfile
 	_accumulatedDatasets = accumulatedDatasets;
-	_profilePrefix = prefix + "_kartesian.NDpr";
+	_profilePrefix = prefix + ".NDpr";
 	ofstream outfile(_profilePrefix.c_str());
 	outfile.precision(6);
 

--- a/src/plugins/profiles/TemperatureProfile.cpp
+++ b/src/plugins/profiles/TemperatureProfile.cpp
@@ -13,7 +13,7 @@ void TemperatureProfile::output(string prefix, long unsigned accumulatedDatasets
 
     // Generate Outfile
     _accumulatedDatasets = accumulatedDatasets;
-    _profilePrefix = prefix + "_kartesian.Temppr";
+    _profilePrefix = prefix + ".Temppr";
     ofstream outfile(_profilePrefix.c_str());
     outfile.precision(6);
 

--- a/src/plugins/profiles/Velocity3dProfile.cpp
+++ b/src/plugins/profiles/Velocity3dProfile.cpp
@@ -6,13 +6,13 @@
 #include "Velocity3dProfile.h"
 #include "DensityProfile.h"
 
-void Velocity3dProfile::output (string prefix, long unsigned accumulatedDatasets) {
+void Velocity3dProfile::output(string prefix, long unsigned accumulatedDatasets) {
 	global_log->info() << "[Velocity3dProfile] output" << std::endl;
 
 	// Setup outfile
 	_accumulatedDatasets = accumulatedDatasets;
 	_profilePrefix = prefix;
-	_profilePrefix += "_kartesian.V3Dpr";
+	_profilePrefix += ".V3Dpr";
 	ofstream outfile(_profilePrefix.c_str());
 	outfile.precision(6);
 

--- a/src/plugins/profiles/VelocityAbsProfile.cpp
+++ b/src/plugins/profiles/VelocityAbsProfile.cpp
@@ -5,12 +5,12 @@
 #include "VelocityAbsProfile.h"
 #include "plugins/profiles/DensityProfile.h"
 
-void VelocityAbsProfile::output (string prefix, long unsigned accumulatedDatasets) {
+void VelocityAbsProfile::output(string prefix, long unsigned accumulatedDatasets) {
 	global_log->info() << "[VelocityAbsProfile] output" << std::endl;
 
 	// Setup outfile
 	_accumulatedDatasets = accumulatedDatasets;
-	_profilePrefix = prefix + "_kartesian.VAbspr";
+	_profilePrefix = prefix + ".VAbspr";
 	ofstream outfile(_profilePrefix.c_str());
 	outfile.precision(6);
 

--- a/src/plugins/profiles/VirialProfile.cpp
+++ b/src/plugins/profiles/VirialProfile.cpp
@@ -31,7 +31,9 @@ void VirialProfile::output(string prefix, long unsigned accumulatedDatasets) {
 	double layerHeight = _samplInfo.globalLength[1] / _samplInfo.universalProfileUnit[1];
 	if (_samplInfo.cylinder) {
 		// V = height * PI * R^2
-		layerVolume = layerHeight * M_PI * _samplInfo.globalLength[0] * _samplInfo.globalLength[0];
+		// Get max radius of the cylinder inside the box domain
+		double radius = _samplInfo.globalLength[0]/2;
+		layerVolume = layerHeight * M_PI * radius * radius;
 	} else {
 		// V = height * X * Z
 		layerVolume = layerHeight * _samplInfo.globalLength[0] * _samplInfo.globalLength[2];


### PR DESCRIPTION
# Description

Fixes a bug in cylindrical volume calculation for the virial pressure output. 
Used Diameter instead of Radius for calculation.

Also refactors line endings for Profile classes.

# How Has This Been Tested?

Results for a simple test case (examples/general-plugins/SpatialProfiles/CartesianSampling) using both cartesian and cylindrical outputs agree now.
