### PR TITLE
Add deconstruction of plugins in Simulation::finalize

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -1201,6 +1201,8 @@ void Simulation::finalize() {
 		delete _domainDecomposition;
 		_domainDecomposition = nullptr;
 	}
+
+    _plugins.remove_if([](PluginBase * plugin) { delete plugin; return true; });
 	global_simulation = nullptr;
 }
 

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -1202,7 +1202,7 @@ void Simulation::finalize() {
 		_domainDecomposition = nullptr;
 	}
 
-    _plugins.remove_if([](PluginBase * plugin) { delete plugin; return true; });
+	_plugins.remove_if([](PluginBase * plugin) { delete plugin; return true; });
 	global_simulation = nullptr;
 }
 


### PR DESCRIPTION
The destructor of every enabled plugin has to be called in simlulation's
finalize method as a plugin may have initialized MPI related data, which
are not allowed to be cleaned up after MPI_Finalize() is called.

# Description

Call destructor for every enabled plugin in Simulation::finalize() and remove the deconstructed plugin from the plugin list before MPI_Finalize and Simulation::~Simulation() is called.

## Resolved Issues

- [x] #123

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Generator example mkTcTs with MPI Info option beeing used
