### PR TITLE
Use AutoPas defaults

### DIFF
--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -24,7 +24,7 @@ if (ENABLE_AUTOPAS)
     FetchContent_Declare(
             autopasfetch
             GIT_REPOSITORY ${autopasRepoPath}
-            GIT_TAG 498e1742c541d7c9bbedc528402df8f95b807a1c
+            GIT_TAG ad89a14c9134a0869ac2298d233e0491b35055d0
     )
 
     # Get autopas source and binary directories from CMake project

--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -24,7 +24,7 @@ if (ENABLE_AUTOPAS)
     FetchContent_Declare(
             autopasfetch
             GIT_REPOSITORY ${autopasRepoPath}
-            GIT_TAG ad89a14c9134a0869ac2298d233e0491b35055d0
+            GIT_TAG 918ce7c356250df60b9a1e217482a0c8d4f7bf0d
     )
 
     # Get autopas source and binary directories from CMake project

--- a/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
@@ -34,11 +34,7 @@
 		    <updateFrequency>1000</updateFrequency>
 	    </parallelisation>
       <datastructure type="AutoPas">
-        <allowedTraversals>c01, c08, c18, sli</allowedTraversals>
         <allowedContainers>linkedCells</allowedContainers>
-        <selectorStrategy>fastestMedian</selectorStrategy>
-        <dataLayouts>AoS</dataLayouts>
-        <newton3>enabled</newton3>
         <tuningInterval>10000</tuningInterval>
         <tuningSamples>10</tuningSamples>
         <rebuildFrequency>10</rebuildFrequency>

--- a/examples/Argon/200K_18mol_l/config_autopas_soa.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_soa.xml
@@ -39,6 +39,8 @@
         <newton3>enabled</newton3>
         <tuningInterval>1000</tuningInterval>
         <tuningSamples>3</tuningSamples>
+        <rebuildFrequency>10</rebuildFrequency>
+        <skin>0.4</skin>
       </datastructure>
       <cutoffs type="CenterOfMass">
         <radiusLJ unit="reduced">33.0702</radiusLJ>

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -211,13 +211,15 @@
         <!-- specify all allowed traversals as a comma separated list -->
         <allowedTraversals>c08, sli</allowedTraversals>
         <!-- specify all allowed containers as a comma separated list -->
-        <!-- possible values:
-          - directSum
-          - linkedCells
-          - verlet
-          - vcells
-          - vcluster
-          -->
+        <!-- possible values include:
+           - DirectSum
+           - LinkedCells
+           - VerletLists
+           - VerletListsCells
+           - VerletClusterLists
+           - VarVerletListsAsBuild
+           - VerletClusterCells
+        -->
         <allowedContainers>linkedCells, verletlists, verletclusterlists</allowedContainers>
         <!-- specify what metric the selector should use to determine the optimal traversal -->
         <!-- possible values: fastetAbsolute, fastestMean, fastestMedian -->

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -73,7 +73,7 @@
               <Izz>47.02459341</Izz>
             </momentsofinertia>
           </moleculetype>
-          
+
           <mixing>
             <rule type="LB" cid1="1" cid2="2">
               <eta>1.0</eta>
@@ -256,7 +256,7 @@
     <!-- output plugins
 	There are several output plugins which can be used to generate some output files while running simulations.
 	The following comments describe the provided output plugins. -->
-	
+
 	<!-- general information about properties of the output plugins:
     The attribute “name“ holds the name of the plugin user want to use performing an output. The names of the provided plugins are listed below:
       - CheckpointWriter
@@ -264,7 +264,7 @@
       - XyzWriter
       - VISWriter
       - MmspdWriter
-      - PovWriter	  
+      - PovWriter
       - StatisticsWriter
       - DecompWriter
     The element “writefrequency” contains a integer value which controls the frequency of writing out the data. For example the value “10” makes
@@ -273,7 +273,7 @@
     in a output file named “default.res”. -->
     <output>
 
-       <!-- CheckpointWriter plugin 
+       <!-- CheckpointWriter plugin
       This writer will create a restart file which format or structure is the same as used by input files *.inp.
       These files can be used to continue a simulation. -->
       <outputplugin name="CheckpointWriter">
@@ -298,7 +298,7 @@
         <writefrequency>10</writefrequency>
       </outputplugin>
 
-      <!-- ResultWriter plugin 
+      <!-- ResultWriter plugin
         Writes thermodynamic properties to a file. The following values will be written to a file:
         - Simulation time step
         - time since the simulation started
@@ -327,7 +327,7 @@
       <!-- visualization output plugins
       These writers are used to generate files which can be used for visualization purpose by different visualization software.
       Depending on the specific software different file formats are supported. -->
-  
+
       <!-- XyzWriter plugin
       The *.xyz-format contains x, y, z coordinates of the molecules. Such a file can be read by visualization software like vmd
       (for detail information visit: http://www.ks.uiuc.edu/Research/vmd/). -->
@@ -391,7 +391,7 @@
         <writefrequency>10</writefrequency>
         <outputprefix>default</outputprefix>
       </outputplugin>
-	  
+
     </output>
   </simulation>
 </mardyn>

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -224,16 +224,24 @@
         <!-- specify what metric the selector should use to determine the optimal traversal -->
         <!-- possible values: fastetAbsolute, fastestMean, fastestMedian -->
         <selectorStrategy>fastestAbsolute</selectorStrategy>
+        <!-- set the auto tuning algorithm -->
+        <tuningStrategy>fullSearch</tuningStrategy>
         <!-- Data layouts to be used: AoS, SoA -->
         <dataLayouts>SoA</dataLayouts>
         <!-- Allowed choices for newton 3 optimization: enabled, disabled -->
         <newton3>enabled</newton3>
+        <!-- Only for Bayesian tuning strategies: sets the function that predicts knowledge gain from samples -->
+        <tuningAcquisitionFunction>upper-confidence-bound</tuningAcquisitionFunction>
         <!-- How many iterations before retuning -->
         <tuningInterval>1000</tuningInterval>
         <!-- How many samples should the tuner take for each tested combination (=1 Evidence) -->
         <tuningSamples>5</tuningSamples>
         <!-- How many evidences a tuning strategy should sample (not used by all strategies, i.e. fullSearch) -->
         <maxEvidence>20</maxEvidence>
+        <!-- Number of iterations after which autopas rebuilds it's containers -->
+        <rebuildFrequency>6</rebuildFrequency>
+        <!-- Verlet skin as absolute length added to the cutoff -->
+        <skin>0.2</skin>
       </datastructure>
 
       <!-- cutoff definitions -->

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -205,6 +205,9 @@
       </datastructure>
 
       <datastructure type="AutoPas">
+        <!-- for a list of possible options see the setter functions in https://www5.in.tum.de/AutoPas/doxygen_doc/master/classautopas_1_1AutoPas.html -->
+        <!-- for possible values see the respective options in https://www5.in.tum.de/AutoPas/doxygen_doc/master/namespaceautopas_1_1options.html-->
+
         <!-- specify all allowed traversals as a comma separated list -->
         <allowedTraversals>c08, sli</allowedTraversals>
         <!-- specify all allowed containers as a comma separated list -->
@@ -215,13 +218,10 @@
           - vcells
           - vcluster
           -->
-        <allowedContainers>linkedCells, vcells, vcluster</allowedContainers>
+        <allowedContainers>linkedCells, verletlists, verletclusterlists</allowedContainers>
         <!-- specify what metric the selector should use to determine the optimal traversal -->
         <!-- possible values: fastetAbsolute, fastestMean, fastestMedian -->
-        <selectorStrategy>fastestMedian</selectorStrategy>
-        <!-- specify which tuning algorithm should be used -->
-        <!-- possible values: fullSearch, bayesian -->
-        <selectorStrategy>fastestMedian</selectorStrategy>
+        <selectorStrategy>fastestAbsolute</selectorStrategy>
         <!-- Data layouts to be used: AoS, SoA -->
         <dataLayouts>SoA</dataLayouts>
         <!-- Allowed choices for newton 3 optimization: enabled, disabled -->

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -108,8 +108,8 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 	_verletClusterSize = static_cast<unsigned int>(xmlconfig.getNodeValue_int("verletClusterSize", static_cast<int>(_verletClusterSize)));
 
 	// double
-	_verletSkin = static_cast<unsigned int>(
-		xmlconfig.getNodeValue_double("skin", static_cast<int>(_verletSkin)));
+	_verletSkin = static_cast<double>(
+		xmlconfig.getNodeValue_double("skin", static_cast<double>(_verletSkin)));
 
 	xmlconfig.changecurrentnode(oldPath);
 }

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -95,6 +95,7 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 									  xmlconfig, "tuningAcquisitionFunction", {_tuningAcquisitionFunction})
 									  .begin();
 	// get numeric options from xml
+	//int
 	_maxEvidence = static_cast<unsigned int>(
 		xmlconfig.getNodeValue_int("maxEvidence", static_cast<int>(_maxEvidence)));
 	_tuningSamples = static_cast<unsigned int>(
@@ -103,46 +104,43 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 		xmlconfig.getNodeValue_int("tuningInterval", static_cast<int>(_tuningFrequency)));
 	_verletRebuildFrequency = static_cast<unsigned int>(xmlconfig.getNodeValue_int(
 		"rebuildFrequency", static_cast<int>(_verletRebuildFrequency)));
+	_verletClusterSize = static_cast<unsigned int>(xmlconfig.getNodeValue_int("verletClusterSize", static_cast<int>(_verletClusterSize)));
+
+	// double
 	_verletSkin = static_cast<unsigned int>(
 		xmlconfig.getNodeValue_double("skin", static_cast<int>(_verletSkin)));
 
-	// generate string representation of parameters with multiple options
-	std::stringstream dataLayoutChoicesStream;
-	for_each(_dataLayoutChoices.begin(), _dataLayoutChoices.end(),
-			 [&](auto &choice) { dataLayoutChoicesStream << choice.to_string() << " "; });
-	std::stringstream containerChoicesStream;
-	for_each(_containerChoices.begin(), _containerChoices.end(),
-			 [&](auto &choice) { containerChoicesStream << choice.to_string() << " "; });
-	std::stringstream traversalChoicesStream;
-	for_each(_traversalChoices.begin(), _traversalChoices.end(),
-			 [&](auto &choice) { traversalChoicesStream << choice.to_string() << " "; });
-	std::stringstream newton3ChoicesStream;
-	for_each(_newton3Choices.begin(), _newton3Choices.end(),
-			 [&](auto &choice) { newton3ChoicesStream << choice.to_string() << " "; });
-
 	// print full configuration to the command line
-	int valueOffset = 20;
+	int valueOffset = 28;
 	global_log->info() << "AutoPas configuration:" << endl
 					   << setw(valueOffset) << left << "Data Layout "
-					   << ": " << dataLayoutChoicesStream.str() << endl
+					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedDataLayouts()) << endl
 					   << setw(valueOffset) << left << "Container "
-					   << ": " << containerChoicesStream.str() << endl
+					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedContainers()) << endl
+					   << setw(valueOffset) << left << "Cell size Factor "
+					   << ": " << _autopasContainer.getAllowedCellSizeFactors() << endl
 					   << setw(valueOffset) << left << "Traversals "
-					   << ": " << traversalChoicesStream.str() << endl
+					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedTraversals()) << endl
 					   << setw(valueOffset) << left << "Newton3"
-					   << ": " << newton3ChoicesStream.str() << endl
+					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedNewton3Options()) << endl
 					   << setw(valueOffset) << left << "Tuning strategy "
-					   << ": " << _tuningStrategyOption.to_string() << endl
+					   << ": " << _autopasContainer.getTuningStrategyOption() << endl
 					   << setw(valueOffset) << left << "Selector strategy "
-					   << ": " << _selectorStrategy.to_string() << endl
+					   << ": " << _autopasContainer.getSelectorStrategy() << endl
 					   << setw(valueOffset) << left << "Tuning frequency"
-					   << ": " << _tuningFrequency << endl
+					   << ": " << _autopasContainer.getTuningInterval() << endl
 					   << setw(valueOffset) << left << "Number of samples "
-					   << ": " << _tuningSamples << endl
+					   << ": " << _autopasContainer.getNumSamples() << endl
 					   << setw(valueOffset) << left << "Tuning Acquisition Function"
-					   << ": " << _tuningAcquisitionFunction.to_string() << endl
+					   << ": " << _autopasContainer.getAcquisitionFunction() << endl
 					   << setw(valueOffset) << left << "Number of evidence "
-					   << ": " << _maxEvidence << endl;
+					   << ": " << _autopasContainer.getMaxEvidence() << endl
+					   << setw(valueOffset) << left << "Verlet Cluster size "
+					   << ": " << _autopasContainer.getVerletClusterSize() << endl
+					   << setw(valueOffset) << left << "Rebuild frequency "
+					   << ": " << _autopasContainer.getVerletRebuildFrequency() << endl
+					   << setw(valueOffset) << left << "Verlet Skin "
+					   << ": " << _autopasContainer.getVerletSkin() << endl;
 
 	xmlconfig.changecurrentnode(oldPath);
 }

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -16,6 +16,21 @@
 AutoPasContainer::AutoPasContainer(double cutoff)
 	: _cutoff(cutoff),
 	  _particlePropertiesLibrary(cutoff) {
+
+      // use autopas defaults. This block is important when we do not read from an XML like in the unit tests
+      _verletSkin = _autopasContainer.getVerletSkin();
+      _verletRebuildFrequency = _autopasContainer.getVerletRebuildFrequency();
+      _tuningFrequency = _autopasContainer.getTuningInterval();
+      _tuningSamples = _autopasContainer.getNumSamples();
+      _maxEvidence = _autopasContainer.getMaxEvidence();
+      _traversalChoices = _autopasContainer.getAllowedTraversals();
+      _containerChoices = _autopasContainer.getAllowedContainers();
+      _selectorStrategy = _autopasContainer.getSelectorStrategy();
+      _tuningStrategyOption = _autopasContainer.getTuningStrategyOption();
+      _tuningAcquisitionFunction = _autopasContainer.getAcquisitionFunction();
+      _dataLayoutChoices = _autopasContainer.getAllowedDataLayouts();
+      _newton3Choices=_autopasContainer.getAllowedNewton3Options();
+
 #ifdef ENABLE_MPI
 	std::stringstream logFileName;
 

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -27,6 +27,7 @@ AutoPasContainer::AutoPasContainer(double cutoff) : _cutoff(cutoff), _particlePr
 	_tuningAcquisitionFunction = _autopasContainer.getAcquisitionFunction();
 	_dataLayoutChoices = _autopasContainer.getAllowedDataLayouts();
 	_newton3Choices = _autopasContainer.getAllowedNewton3Options();
+	_verletClusterSize = _autopasContainer.getVerletClusterSize();
 
 #ifdef ENABLE_MPI
 	std::stringstream logFileName;
@@ -155,6 +156,7 @@ bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {
 	_autopasContainer.setCutoff(_cutoff);
 	_autopasContainer.setVerletSkin(_verletSkin);
 	_autopasContainer.setVerletRebuildFrequency(_verletRebuildFrequency);
+	_autopasContainer.setVerletClusterSize(_verletClusterSize);
 	_autopasContainer.setTuningInterval(_tuningFrequency);
 	_autopasContainer.setNumSamples(_tuningSamples);
 	_autopasContainer.setSelectorStrategy(_selectorStrategy);

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -111,38 +111,6 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 	_verletSkin = static_cast<unsigned int>(
 		xmlconfig.getNodeValue_double("skin", static_cast<int>(_verletSkin)));
 
-	// print full configuration to the command line
-	int valueOffset = 28;
-	global_log->info() << "AutoPas configuration:" << endl
-					   << setw(valueOffset) << left << "Data Layout "
-					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedDataLayouts()) << endl
-					   << setw(valueOffset) << left << "Container "
-					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedContainers()) << endl
-					   << setw(valueOffset) << left << "Cell size Factor "
-					   << ": " << _autopasContainer.getAllowedCellSizeFactors() << endl
-					   << setw(valueOffset) << left << "Traversals "
-					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedTraversals()) << endl
-					   << setw(valueOffset) << left << "Newton3"
-					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedNewton3Options()) << endl
-					   << setw(valueOffset) << left << "Tuning strategy "
-					   << ": " << _autopasContainer.getTuningStrategyOption() << endl
-					   << setw(valueOffset) << left << "Selector strategy "
-					   << ": " << _autopasContainer.getSelectorStrategy() << endl
-					   << setw(valueOffset) << left << "Tuning frequency"
-					   << ": " << _autopasContainer.getTuningInterval() << endl
-					   << setw(valueOffset) << left << "Number of samples "
-					   << ": " << _autopasContainer.getNumSamples() << endl
-					   << setw(valueOffset) << left << "Tuning Acquisition Function"
-					   << ": " << _autopasContainer.getAcquisitionFunction() << endl
-					   << setw(valueOffset) << left << "Number of evidence "
-					   << ": " << _autopasContainer.getMaxEvidence() << endl
-					   << setw(valueOffset) << left << "Verlet Cluster size "
-					   << ": " << _autopasContainer.getVerletClusterSize() << endl
-					   << setw(valueOffset) << left << "Rebuild frequency "
-					   << ": " << _autopasContainer.getVerletRebuildFrequency() << endl
-					   << setw(valueOffset) << left << "Verlet Skin "
-					   << ": " << _autopasContainer.getVerletSkin() << endl;
-
 	xmlconfig.changecurrentnode(oldPath);
 }
 
@@ -169,6 +137,38 @@ bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {
 	_autopasContainer.setMaxEvidence(_maxEvidence);
 	_autopasContainer.init();
 	autopas::Logger::get()->set_level(autopas::Logger::LogLevel::debug);
+
+  // print full configuration to the command line
+  int valueOffset = 28;
+  global_log->info() << "AutoPas configuration:" << endl
+                     << setw(valueOffset) << left << "Data Layout "
+                     << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedDataLayouts()) << endl
+                     << setw(valueOffset) << left << "Container "
+                     << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedContainers()) << endl
+                     << setw(valueOffset) << left << "Cell size Factor "
+                     << ": " << _autopasContainer.getAllowedCellSizeFactors() << endl
+                     << setw(valueOffset) << left << "Traversals "
+                     << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedTraversals()) << endl
+                     << setw(valueOffset) << left << "Newton3"
+                     << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedNewton3Options()) << endl
+                     << setw(valueOffset) << left << "Tuning strategy "
+                     << ": " << _autopasContainer.getTuningStrategyOption() << endl
+                     << setw(valueOffset) << left << "Selector strategy "
+                     << ": " << _autopasContainer.getSelectorStrategy() << endl
+                     << setw(valueOffset) << left << "Tuning frequency"
+                     << ": " << _autopasContainer.getTuningInterval() << endl
+                     << setw(valueOffset) << left << "Number of samples "
+                     << ": " << _autopasContainer.getNumSamples() << endl
+                     << setw(valueOffset) << left << "Tuning Acquisition Function"
+                     << ": " << _autopasContainer.getAcquisitionFunction() << endl
+                     << setw(valueOffset) << left << "Number of evidence "
+                     << ": " << _autopasContainer.getMaxEvidence() << endl
+                     << setw(valueOffset) << left << "Verlet Cluster size "
+                     << ": " << _autopasContainer.getVerletClusterSize() << endl
+                     << setw(valueOffset) << left << "Rebuild frequency "
+                     << ": " << _autopasContainer.getVerletRebuildFrequency() << endl
+                     << setw(valueOffset) << left << "Verlet Skin "
+                     << ": " << _autopasContainer.getVerletSkin() << endl;
 
 	memcpy(_boundingBoxMin, bBoxMin, 3 * sizeof(double));
 	memcpy(_boundingBoxMax, bBoxMax, 3 * sizeof(double));

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -13,23 +13,20 @@
 #include "autopas/utils/StringUtils.h"
 #include "parallel/DomainDecompBase.h"
 
-AutoPasContainer::AutoPasContainer(double cutoff)
-	: _cutoff(cutoff),
-	  _particlePropertiesLibrary(cutoff) {
-
-      // use autopas defaults. This block is important when we do not read from an XML like in the unit tests
-      _verletSkin = _autopasContainer.getVerletSkin();
-      _verletRebuildFrequency = _autopasContainer.getVerletRebuildFrequency();
-      _tuningFrequency = _autopasContainer.getTuningInterval();
-      _tuningSamples = _autopasContainer.getNumSamples();
-      _maxEvidence = _autopasContainer.getMaxEvidence();
-      _traversalChoices = _autopasContainer.getAllowedTraversals();
-      _containerChoices = _autopasContainer.getAllowedContainers();
-      _selectorStrategy = _autopasContainer.getSelectorStrategy();
-      _tuningStrategyOption = _autopasContainer.getTuningStrategyOption();
-      _tuningAcquisitionFunction = _autopasContainer.getAcquisitionFunction();
-      _dataLayoutChoices = _autopasContainer.getAllowedDataLayouts();
-      _newton3Choices=_autopasContainer.getAllowedNewton3Options();
+AutoPasContainer::AutoPasContainer(double cutoff) : _cutoff(cutoff), _particlePropertiesLibrary(cutoff) {
+	// use autopas defaults. This block is important when we do not read from an XML like in the unit tests
+	_verletSkin = _autopasContainer.getVerletSkin();
+	_verletRebuildFrequency = _autopasContainer.getVerletRebuildFrequency();
+	_tuningFrequency = _autopasContainer.getTuningInterval();
+	_tuningSamples = _autopasContainer.getNumSamples();
+	_maxEvidence = _autopasContainer.getMaxEvidence();
+	_traversalChoices = _autopasContainer.getAllowedTraversals();
+	_containerChoices = _autopasContainer.getAllowedContainers();
+	_selectorStrategy = _autopasContainer.getSelectorStrategy();
+	_tuningStrategyOption = _autopasContainer.getTuningStrategyOption();
+	_tuningAcquisitionFunction = _autopasContainer.getAcquisitionFunction();
+	_dataLayoutChoices = _autopasContainer.getAllowedDataLayouts();
+	_newton3Choices = _autopasContainer.getAllowedNewton3Options();
 
 #ifdef ENABLE_MPI
 	std::stringstream logFileName;
@@ -60,11 +57,12 @@ AutoPasContainer::AutoPasContainer(double cutoff)
  * @return
  */
 template <class OptionType>
-auto parseAutoPasOption(XMLfileUnits &xmlconfig, const std::string &xmlString, const std::set<OptionType> &defaultValue) {
-    auto stringInXml = string_utils::toLowercase(xmlconfig.getNodeValue_string(xmlString));
-    if(stringInXml.empty()) {
-      return defaultValue;
-    }
+auto parseAutoPasOption(XMLfileUnits &xmlconfig, const std::string &xmlString,
+						const std::set<OptionType> &defaultValue) {
+	auto stringInXml = string_utils::toLowercase(xmlconfig.getNodeValue_string(xmlString));
+	if (stringInXml.empty()) {
+		return defaultValue;
+	}
 	try {
 		return OptionType::parseOptions(stringInXml);
 	} catch (const std::exception &e) {
@@ -83,36 +81,32 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 
 	// if any option is not specified in the XML use the autopas defaults
 	// get option values from xml
-	_traversalChoices = parseAutoPasOption<autopas::TraversalOption>(xmlconfig,
-	                                                                 "allowedTraversals",
-	                                                                 _autopasContainer.getAllowedTraversals());
-	_containerChoices = parseAutoPasOption<autopas::ContainerOption>(xmlconfig,
-	                                                                 "allowedContainers",
-	                                                                 _autopasContainer.getAllowedContainers());
+	_traversalChoices = parseAutoPasOption<autopas::TraversalOption>(xmlconfig, "allowedTraversals", _traversalChoices);
+	_containerChoices = parseAutoPasOption<autopas::ContainerOption>(xmlconfig, "allowedContainers", _containerChoices);
 	_selectorStrategy =
-	    *parseAutoPasOption<autopas::SelectorStrategyOption>(xmlconfig, "selectorStrategy",
-	                                                         {_autopasContainer.getSelectorStrategy()}).begin();
+		*parseAutoPasOption<autopas::SelectorStrategyOption>(xmlconfig, "selectorStrategy", {_selectorStrategy})
+			 .begin();
 	_tuningStrategyOption =
-	    *parseAutoPasOption<autopas::TuningStrategyOption>(xmlconfig,
-	                                                       "tuningStrategy",
-	                                                       {_autopasContainer.getTuningStrategyOption()}).begin();
-	_dataLayoutChoices = parseAutoPasOption<autopas::DataLayoutOption>(xmlconfig,
-	                                                                   "dataLayouts",
-	                                                                   _autopasContainer.getAllowedDataLayouts());
-	_newton3Choices =
-	    parseAutoPasOption<autopas::Newton3Option>(xmlconfig, "newton3", _autopasContainer.getAllowedNewton3Options());
+		*parseAutoPasOption<autopas::TuningStrategyOption>(xmlconfig, "tuningStrategy", {_tuningStrategyOption})
+			 .begin();
+	_dataLayoutChoices = parseAutoPasOption<autopas::DataLayoutOption>(xmlconfig, "dataLayouts", _dataLayoutChoices);
+	_newton3Choices = parseAutoPasOption<autopas::Newton3Option>(xmlconfig, "newton3", _newton3Choices);
 	_tuningAcquisitionFunction = *parseAutoPasOption<autopas::AcquisitionFunctionOption>(
-      xmlconfig, "tuningAcquisitionFunction",
-      {_autopasContainer.getAcquisitionFunction()})
-      .begin();
+									  xmlconfig, "tuningAcquisitionFunction", {_tuningAcquisitionFunction})
+									  .begin();
 	// get numeric options from xml
-	_maxEvidence = static_cast<unsigned int>(xmlconfig.getNodeValue_int("maxEvidence", static_cast<int>(_autopasContainer.getMaxEvidence())));
-	_tuningSamples = static_cast<unsigned int>(xmlconfig.getNodeValue_int("tuningSamples", static_cast<int>(_autopasContainer.getNumSamples())));
-	_tuningFrequency = static_cast<unsigned int>(xmlconfig.getNodeValue_int("tuningInterval", static_cast<int>(_autopasContainer.getTuningInterval())));
-	_verletRebuildFrequency = static_cast<unsigned int>(xmlconfig.getNodeValue_int("rebuildFrequency", static_cast<int>(_autopasContainer.getVerletRebuildFrequency())));
-	_verletSkin = static_cast<unsigned int>(xmlconfig.getNodeValue_double("skin", static_cast<int>(_autopasContainer.getVerletSkin())));
+	_maxEvidence = static_cast<unsigned int>(
+		xmlconfig.getNodeValue_int("maxEvidence", static_cast<int>(_maxEvidence)));
+	_tuningSamples = static_cast<unsigned int>(
+		xmlconfig.getNodeValue_int("tuningSamples", static_cast<int>(_tuningSamples)));
+	_tuningFrequency = static_cast<unsigned int>(
+		xmlconfig.getNodeValue_int("tuningInterval", static_cast<int>(_tuningFrequency)));
+	_verletRebuildFrequency = static_cast<unsigned int>(xmlconfig.getNodeValue_int(
+		"rebuildFrequency", static_cast<int>(_verletRebuildFrequency)));
+	_verletSkin = static_cast<unsigned int>(
+		xmlconfig.getNodeValue_double("skin", static_cast<int>(_verletSkin)));
 
-	//generate string representation of parameters with multiple options
+	// generate string representation of parameters with multiple options
 	std::stringstream dataLayoutChoicesStream;
 	for_each(_dataLayoutChoices.begin(), _dataLayoutChoices.end(),
 			 [&](auto &choice) { dataLayoutChoicesStream << choice.to_string() << " "; });

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -112,11 +112,11 @@ private:
 	void traverseTemplateHelper();
 
 	double _cutoff{0.};
-	double _verletSkin{0.};
-	unsigned int _verletRebuildFrequency{1u};
-	unsigned int _tuningFrequency{1000u};
-	unsigned int _tuningSamples{3u};
-	unsigned int _maxEvidence{10};
+	double _verletSkin;
+	unsigned int _verletRebuildFrequency;
+	unsigned int _tuningFrequency;
+	unsigned int _tuningSamples;
+	unsigned int _maxEvidence;
 	using CellType = autopas::FullParticleCell<Molecule>;
 	autopas::AutoPas<Molecule, CellType> _autopasContainer;
 

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -114,6 +114,7 @@ private:
 	double _cutoff{0.};
 	double _verletSkin;
 	unsigned int _verletRebuildFrequency;
+	unsigned int _verletClusterSize;
 	unsigned int _tuningFrequency;
 	unsigned int _tuningSamples;
 	unsigned int _maxEvidence;


### PR DESCRIPTION
# Description

- [x] simplify defaults handling in AutoPasContainer.cpp
- [x] if nothing is given in the XML for an option use the AutoPas defaults
- [x] if you don't care about configuring AutoPas you can now even just use the following in your XML:
```
    <datastructure type="AutoPas">
    </datastructure>
```

## Related Pull Requests

- [x] needs [AutoPas #471](https://github.com/AutoPas/AutoPas/pull/471)

## ~Resolved Issues~

# How Has This Been Tested?

I let ls1 run with the autopas examples and with an empty autopas `datastructure` tag.