### PR TITLE
Fixes ValidationRun

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -409,7 +409,6 @@ pipeline {
                                               $legacyCellProcessorOption \
                                               $allmpi \
                                               -c \"\$(realpath \$(find ../../validationInput/$configDirVar/ -type f -name *.xml) )\" \
-                                              -i \"\$(realpath \$(find ../../validationInput/$configDirVar/ -type f \\( -iname \\*.dat -o -iname \\*.inp -o -iname \\*.xdr \\)) )\" \
                                               $plugins $icount $sameParTypeOption $mpicmd $mpiextra
                                           """
                                         }

--- a/validation/validationInput/surface-tension_LRC_CO2_Merker_280/config.xml
+++ b/validation/validationInput/surface-tension_LRC_CO2_Merker_280/config.xml
@@ -13,7 +13,7 @@
     </integrator>
 
     <run>
-      <currenttime>612.4</currenttime>
+      <currenttime>0.</currenttime>
       <production>
         <steps>20000</steps>
       </production>

--- a/validation/validationInput/surface-tension_LRC_CO2_Merker_280/config.xml
+++ b/validation/validationInput/surface-tension_LRC_CO2_Merker_280/config.xml
@@ -83,8 +83,8 @@
         <smooth>0</smooth>
         <frequency>10</frequency>
         <writecontrol>
-          <start>10000</start>
-          <frequency>100</frequency>
+          <start>0</start>
+          <frequency>5</frequency>
           <stop>11000</stop>
         </writecontrol>
       </longrange>

--- a/validation/validationRun/.gitignore
+++ b/validation/validationRun/.gitignore
@@ -1,5 +1,6 @@
 new/
 reference/
+input/
 *.pyc
 *.inp
 *.xml

--- a/validation/validationRun/.gitignore
+++ b/validation/validationRun/.gitignore
@@ -1,0 +1,6 @@
+new/
+reference/
+*.pyc
+*.inp
+*.xml
+MarDyn

--- a/validation/validationRun/validationRun.py
+++ b/validation/validationRun/validationRun.py
@@ -296,9 +296,9 @@ def doRun(directory, MardynExe):
 
     if legacyCellProcessor and directory == "new":
         cmd.extend(
-            ['./' + MardynExe, "--legacy-cell-processor", "--final-checkpoint=0", xmlBase, "--steps", numIterations]);
+            ['./' + MardynExe, "--legacy-cell-processor", "--final-checkpoint=0", xmlBase, "--steps", numIterations])
     else:
-        cmd.extend(['./' + MardynExe, "--final-checkpoint=0", xmlBase, "--steps", numIterations]);
+        cmd.extend(['./' + MardynExe, "--final-checkpoint=0", xmlBase, "--steps", numIterations])
     # cmd.extend(['/work_fast/tchipevn/SDE/sde-external-7.41.0-2016-03-03-lin/sde64', '-knl', '--', './' + MardynExe, "--final-checkpoint=0", xmlBase, numIterations]);
     print(cmd)
     print("================")

--- a/validation/validationRun/validationRun.py
+++ b/validation/validationRun/validationRun.py
@@ -24,6 +24,7 @@ from subprocess import Popen, PIPE
 from shlex import split
 import compareHelpers
 import time
+
 # from twisted.internet.defer import returnValue
 
 mpi = '-1'
@@ -66,8 +67,8 @@ legacyCellProcessor = False
 
 allMPI = False
 MPI_START = 'mpirun'  # e.g. I need to set it to mpirun.mpich locally
-print options
-baseRemote=""
+print(options)
+baseRemote = ""
 for opt, arg in options:
     if opt in ('-n', '--newMarDyn'):
         newMarDyn = arg
@@ -82,7 +83,7 @@ for opt, arg in options:
     elif opt in ('-M', '--mpicmd'):
         MPI_START = arg
     elif opt in ('-p', '--plugin'):
-        if(not nonDefaultPlugins):  # first encounter of "-p" -> clear plugin list
+        if (not nonDefaultPlugins):  # first encounter of "-p" -> clear plugin list
             nonDefaultPlugins = True
             comparePlugins = []
         comparePlugins.append(arg)
@@ -91,18 +92,20 @@ for opt, arg in options:
     elif opt in ('-I', '--numIterations'):
         numIterations = arg
     elif opt in ('-h', '--help'):
-        print "Make sure two versions of mardyn produce identical simulation results. Sample usage:"
-        print """ ./vr -m 4 -n MarDyn.PAR_RELEASE_AVX2 -o MarDyn.PAR_RELEASE_AOS -c ../examples/surface-tension_LRC/C6H12_500/C6H12_500_1R.xml -i ../examples/surface-tension_LRC/C6H12_500/C6H12_500.inp -p GammaWriter -I 10 """
-        print " multiple -p are possible. Currently ResultWriter, GammaWriter and RDF are supported."
-        print " -b specifies, that the base (old file) is assumed to be sequential"
-        print " -r specifies the remote host "
-        print " --remoteprefix changes the prefix of the directory, that is used on the remote host. as relative path to $HOME or absolute path if path starts with /"
+        print("Make sure two versions of mardyn produce identical simulation results. Sample usage:")
+        print(" multiple -p are possible. Currently ResultWriter, GammaWriter and RDF are supported.")
+        print(
+            """ ./vr -m 4 -n MarDyn.PAR_RELEASE_AVX2 -o MarDyn.PAR_RELEASE_AOS -c ../examples/surface-tension_LRC/C6H12_500/C6H12_500_1R.xml -i ../examples/surface-tension_LRC/C6H12_500/C6H12_500.inp -p GammaWriter -I 10 """)
+        print(" -b specifies, that the base (old file) is assumed to be sequential")
+        print(" -r specifies the remote host ")
+        print(
+            " --remoteprefix changes the prefix of the directory, that is used on the remote host. as relative path to $HOME or absolute path if path starts with /")
         exit(1)
     elif opt in ('-b', '--baseisnormal'):
         baseisnormal = 1
     elif opt in ('-r', '--remote'):
         remote = arg
-        print "remote", remote
+        print("remote", remote)
     elif opt in ('-R', '--remoteprefix'):
         remoteprefix = arg
     elif opt in ('--baseIsLocal'):
@@ -118,25 +121,22 @@ for opt, arg in options:
     elif opt in ('-S', '--srunFix'):
         os.environ["I_MPI_PMI_LIBRARY"] = "/usr/lib64/libpmi.so"
     else:
-        print "unknown option: " + opt
+        print("unknown option: " + opt)
         exit(1)
 
 if baseIsLocal and baseRemote:
-    print "defined baseIsLocal and defined a base remote host. this contradicts itself. exiting..."
+    print("defined baseIsLocal and defined a base remote host. this contradicts itself. exiting...")
     exit(1)
 
 # disable disabled plugins:
 for dPlugin in disabledPlugins:
     comparePlugins.remove(dPlugin)
 
-
 SEQ = (mpi == '-1')
 PAR = not SEQ
 
 noReferenceRun = (oldMarDyn == '-1')
 doReferenceRun = not noReferenceRun
-
-
 
 comparePostfixes = []
 for i in range(len(comparePlugins)):
@@ -149,30 +149,29 @@ for i in range(len(comparePlugins)):
     elif comparePlugin == 'RDF':
         comparePostfixes.append('.rdf')
     else:
-        print "Plugin " + comparePlugin + " not supported yet."
-        print "Have a look whether you can add it yourself."
+        print("Plugin " + comparePlugin + " not supported yet.")
+        print("Have a look whether you can add it yourself.")
         exit(1)
 
-
 if noReferenceRun:
-    print "no old version given. Will try to reuse existing output, by not erasing it at start."
+    print("no old version given. Will try to reuse existing output, by not erasing it at start.")
 
 # JUMP to validationRuns - extract path to validationRuns from argv[0]!
 pathToValidationRuns = ntpath.dirname(os.path.realpath(__file__))
 pathToValidationRuns = os.path.realpath(pathToValidationRuns)
 
-print pathToValidationRuns
+print(pathToValidationRuns)
 
 # first clean all the folders
 cleanUpCommand = ['rm']
 cleanUpCommand.extend(glob(pathToValidationRuns + '/*.xml'))
-cleanUpCommand.extend(glob(pathToValidationRuns + '/*.cfg')) # remains for cleanup
+cleanUpCommand.extend(glob(pathToValidationRuns + '/*.cfg'))  # remains for cleanup
 cleanUpCommand.extend(glob(pathToValidationRuns + '/*.inp'))
 cleanUpCommand.extend(glob(pathToValidationRuns + '/new/*'))
 if doReferenceRun:
     cleanUpCommand.extend(glob(pathToValidationRuns + '/reference/*'))
 cleanUpCommand.extend(glob(pathToValidationRuns + '/MarDyn*'))
-p = Popen(cleanUpCommand,stdout=PIPE, stderr=PIPE)
+p = Popen(cleanUpCommand, stdout=PIPE, stderr=PIPE)
 p.communicate()  # suppresses possible errors if nothing there yet, as we don't want them for rm
 
 # copy all there
@@ -186,7 +185,7 @@ os.chdir(pathToValidationRuns)
 # get the basenames
 xmlBase = ntpath.basename(xmlFilename)
 inpBase = ntpath.basename(inpFilename)
-additionalFileBases=[]
+additionalFileBases = []
 additionalFileBases[:] = [ntpath.basename(fn) for fn in additionalFilenames]
 oldMarDynBase = ntpath.basename(oldMarDyn)
 newMarDynBase = ntpath.basename(newMarDyn)
@@ -194,41 +193,40 @@ newMarDynBase = ntpath.basename(newMarDyn)
 # print "append ComparisonWriter here"
 # print "append ComparisonWriter here"
 with open(xmlBase, "r") as prev_file:
-  with open("tmp.xml", "w") as new_file:
-    contents = prev_file.readlines()
-    #Now contents is a list of strings and you may add the new line to this list at any position
-    #contents.insert(4, "\n This is a new line \n ")
+    with open("tmp.xml", "w") as new_file:
+        contents = prev_file.readlines()
+        # Now contents is a list of strings and you may add the new line to this list at any position
+        # contents.insert(4, "\n This is a new line \n ")
 
+        for i in range(len(contents)):
+            line = contents[i]
+            if 'RDF' in comparePlugins and line.find("<run>") != -1:
+                contents.insert(i + 1, """<equilibration><steps>0</steps></equilibration>\n""")
+                i += 1
+                continue
 
-    for i in range(len(contents)):
-        line=contents[i]
-        if 'RDF' in comparePlugins and line.find("<run>") != -1:
-            contents.insert(i+1,"""<equilibration><steps>0</steps></equilibration>\n""")
-            i+=1
-            continue
-
-        if line.find("<output>") != -1:
-            for comparePlugin in comparePlugins:
-                if comparePlugin == 'RDF':  # configuring RDF within the xml is different...
-                    contents.insert(i+1, """
+            if line.find("<output>") != -1:
+                for comparePlugin in comparePlugins:
+                    if comparePlugin == 'RDF':  # configuring RDF within the xml is different...
+                        contents.insert(i + 1, """
         <outputplugin name="RDF">
             <writefrequency>10</writefrequency>
             <outputprefix>val.comparison</outputprefix>
             <intervallength>0.003</intervallength>
             <bins>1000</bins>
         </outputplugin>\n""")
-                    i+=1
-                    #myfile.write("initStatistics 0\nRDF 0.003 1000\nRDFOutputTimesteps 10\nRDFOutputPrefix val.comparison\n")
-                else:
-                    contents.insert(i+1, """
-        <outputplugin name=\""""+ comparePlugin+ """\">
+                        i += 1
+                        # myfile.write("initStatistics 0\nRDF 0.003 1000\nRDFOutputTimesteps 10\nRDFOutputPrefix val.comparison\n")
+                    else:
+                        contents.insert(i + 1, """
+        <outputplugin name=\"""" + comparePlugin + """\">
             <writefrequency>1</writefrequency>
             <outputprefix>val.comparison</outputprefix>
         </outputplugin>""")
-                    i+=1
-                  #myfile.write("output " + comparePlugin + " 1 val.comparison\n")
-    new_file.write("".join(contents))
-call(['mv','tmp.xml',xmlBase])
+                        i += 1
+                    # myfile.write("output " + comparePlugin + " 1 val.comparison\n")
+        new_file.write("".join(contents))
+call(['mv', 'tmp.xml', xmlBase])
 
 comparisonFilenames = []
 for comparePostfix in comparePostfixes:
@@ -247,6 +245,7 @@ call(['cp', inpBase, 'new/'])
 if len(additionalFileBases):
     call(['cp'] + additionalFileBases + ['new/'])
 call(['cp', newMarDynBase, 'new/'])
+
 
 def doRun(directory, MardynExe):
     # first run
@@ -270,16 +269,16 @@ def doRun(directory, MardynExe):
         p = Popen(mkdircmd, stdout=PIPE, stderr=PIPE)
         out, err = p.communicate()
         if p.returncode:
-            print "error on mkdir -p:"
-            print out, err
+            print("error on mkdir -p:")
+            print(out, err)
             exit(1)
         remotedirectory = remoteprefix + "/" + directory
         command = "rsync --delete-before -r ../" + directory + " " + rsyncremote + ":" + remoteprefix
-        print command
+        print(command)
         p = Popen(split(command))
         p.wait()
         if p.returncode:
-            print "error on rsync"
+            print("error on rsync")
             exit(1)
         command = "cd " + remotedirectory + " && pwd && "
         cmd.extend(['ssh', localRemote, command])
@@ -296,75 +295,78 @@ def doRun(directory, MardynExe):
             cmd.extend(['-n', str(mpi)])
 
     if legacyCellProcessor and directory == "new":
-        cmd.extend(['./' + MardynExe, "--legacy-cell-processor", "--final-checkpoint=0", xmlBase, "--steps", numIterations]);
+        cmd.extend(
+            ['./' + MardynExe, "--legacy-cell-processor", "--final-checkpoint=0", xmlBase, "--steps", numIterations]);
     else:
         cmd.extend(['./' + MardynExe, "--final-checkpoint=0", xmlBase, "--steps", numIterations]);
-    #cmd.extend(['/work_fast/tchipevn/SDE/sde-external-7.41.0-2016-03-03-lin/sde64', '-knl', '--', './' + MardynExe, "--final-checkpoint=0", xmlBase, numIterations]);
-    print cmd
-    print "================"
+    # cmd.extend(['/work_fast/tchipevn/SDE/sde-external-7.41.0-2016-03-03-lin/sde64', '-knl', '--', './' + MardynExe, "--final-checkpoint=0", xmlBase, numIterations]);
+    print(cmd)
+    print("================")
     t = time.time()
     while True:
         # repeatedly try this if srun was not working
         p = Popen(cmd, stdout=PIPE, stderr=PIPE)
         out, err = p.communicate()
-        if p.returncode == 1 and ("Job violates accounting/QOS policy" in err or "Socket timed out on send/recv" in err):
-            print "srun submit limit reached or socket timed out error, trying again in 60s"
+        if p.returncode == 1 and (
+                "Job violates accounting/QOS policy" in err or "Socket timed out on send/recv" in err):
+            print("srun submit limit reached or socket timed out error, trying again in 60s")
             time.sleep(60)
             continue
         break
     t = time.time() - t
-    print "elapsed time:", t
+    print("elapsed time:", t)
     if p.returncode:
-        print "error while executing program:"
-        print out, err
+        print("error while executing program:")
+        print(out, err)
         exit(1)
-    print out, err
+    print(out, err)
     if doRemote:  # sync back
         command = "rsync " + rsyncremote + ":" + remotedirectory + "/* ./"
-        print command
+        print(command)
         p = Popen(split(command))
         p.wait()
 
     if "RDF" in comparePlugins:
         p = Popen(['ls', '-r'] + glob("val.comparison*.rdf"), stdout=PIPE, stderr=PIPE)
         out, err = p.communicate()
-        p = Popen(split("cp "+ split(out)[0] + " val.comparison.rdf"))
+        p = Popen(split("cp " + split(out)[0] + " val.comparison.rdf"))
         # Copy newest rdf file to val.comparison.rdf
         p.wait()
-    for comparisonFilename in  comparisonFilenames:
+    for comparisonFilename in comparisonFilenames:
         # possible switch/if statements if other comparison plugins require different output.
-        p = Popen(split("sed -i.bak '/^#/d; s/[[:blank:]]*$//; /^$/d' " + comparisonFilename))  # deletes lines starting with #.
+        p = Popen(split(
+            "sed -i.bak '/^#/d; s/[[:blank:]]*$//; /^$/d' " + comparisonFilename))  # deletes lines starting with #.
         # These are the lines containing timestamps, and have to be removed for proper comparison.
         p.wait()
     os.chdir('..')
 
-print "new run:"
+
+print("new run:")
 # first run
 doRun('new', newMarDynBase)
 
-## second run
+# second run
 if doReferenceRun:
-    print "reference run:"
+    print("reference run:")
     doRun('reference', oldMarDynBase)
 returnValue = 0
-#call(['diff' 'reference/val.comparison.res' 'new/val.comparison.res'])
-print ""
+# call(['diff' 'reference/val.comparison.res' 'new/val.comparison.res'])
+print("")
 for i in range(len(comparePlugins)):
     localReturn = compareHelpers.compareFiles("reference/" + comparisonFilenames[i], "new/" + comparisonFilenames[i])
     returnValue += localReturn
     if localReturn == 0:
-        print "Identical values! for ", comparePlugins[i]
+        print("Identical values! for ", comparePlugins[i])
     else:
-        print "mismatches for ", comparePlugins[i]
-
+        print("mismatches for ", comparePlugins[i])
 
 if returnValue == 0:
-    print ""
-    print "Identical values!"
-    print ""
+    print("")
+    print("Identical values!")
+    print("")
     exit(0)
 else:
-    print ""
-    print "mismatches"
-    print ""
+    print("")
+    print("mismatches")
+    print("")
     exit(1)


### PR DESCRIPTION
# Description

This PR includes the following changes to the validationRun.py script:
- Updates validationRun.py to python3
- Fixes a potential overwriting of the new with the old executable if they have the same name. The executables are now properly separated into different directories.
- The Input directory (the one in which the XML file (`-c`, `--xmlFilename`) resides) is now completely copied to the run directories. This allows new-style XML input with multiple XML files. 
- Removes the arguments `-i`, `--inputFile`, `--additionalFiles` from the script, as they are no longer needed (see above).

## Related Pull Requests

- necessary because of #130


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] locally
- [ ] Jenkins
