### PR TITLE
Fix of error in MettDaemon plugin

### DIFF
--- a/src/plugins/NEMD/MettDeamon.cpp
+++ b/src/plugins/NEMD/MettDeamon.cpp
@@ -246,6 +246,7 @@ void update_velocity_vectors(Random* rnd, const uint64_t& numSamples, const doub
 MettDeamon::MettDeamon() :
 		_bIsRestart(false),
 		_bInitFeedrateLog(false),
+		_bInitRestartLog(false),
 		_dAreaXZ(0.),
 		_dInvDensityArea(0.),
 		_dDeletedMolsPerTimestep(0.),
@@ -265,15 +266,6 @@ MettDeamon::MettDeamon() :
 		_nDeleteNonVolatile(0)
 {
 	_dAreaXZ = global_simulation->getDomain()->getGlobalLength(0) * global_simulation->getDomain()->getGlobalLength(2);
-
-	// init restart file
-	std::stringstream fnamestream;
-	fnamestream << "MettDeamonRestart_movdir-" << (uint32_t)_nMovingDirection << ".dat";
-	std::ofstream ofs(fnamestream.str().c_str(), std::ios::out);
-	std::stringstream outputstream;
-	outputstream << "     simstep" << "   slabIndex" << "                  deltaY" << std::endl;
-	ofs << outputstream.str();
-	ofs.close();
 
 	// summation of deleted molecules
 	_listDeletedMolecules.clear();
@@ -1025,6 +1017,19 @@ void MettDeamon::writeRestartfile()
 
 	if(domainDecomp.getRank() != 0)
 		return;
+
+	// init restart file
+	if(not _bInitRestartLog)
+	{
+		std::stringstream fnamestream;
+		fnamestream << "MettDeamonRestart_movdir-" << (uint32_t)_nMovingDirection << ".dat";
+		std::ofstream ofs(fnamestream.str().c_str(), std::ios::out);
+		std::stringstream outputstream;
+		outputstream << "     simstep" << "   slabIndex" << "                  deltaY" << std::endl;
+		ofs << outputstream.str();
+		ofs.close();
+		_bInitRestartLog = true;
+	}
 
 	std::stringstream fnamestream;
 	fnamestream << "MettDeamonRestart_movdir-" << (uint32_t)_nMovingDirection << ".dat";

--- a/src/plugins/NEMD/MettDeamon.h
+++ b/src/plugins/NEMD/MettDeamon.h
@@ -234,7 +234,7 @@ public:
 
 	// connection to other general plugins
 	void setActualFeedrate(const double& feed_actual) {_feedrate.feed.actual = feed_actual;
-	global_log->info() << "[MettDeamon]: Set new feedrate by MDFRD to vf=" << feed_actual << std::endl;}
+	global_log->info() << "[MettDeamon]: Set new feedrate by MDFRD to vf= " << feed_actual << std::endl;}
 	double getInvDensityArea() {return _dInvDensityArea;}
 
 private:
@@ -278,6 +278,7 @@ private:
 	std::unique_ptr<Reservoir> _reservoir;
 	bool _bIsRestart;  // simulation is a restart?
 	bool _bInitFeedrateLog;
+	bool _bInitRestartLog;
 	double _dAreaXZ;
 	double _dInvDensityArea;
 	double _dDeletedMolsPerTimestep;


### PR DESCRIPTION
Fixes an error that caused the creation of a file (_MettDeamonRestart_movdir-0.dat_) by the MettDaemon plugin even if the plugin was not enabled.
Now the file is only created if MettDaemon plugin in enabled in xml-Config.
