### PR TITLE
Fix temperature control

### DIFF
--- a/src/thermostats/TemperatureControl.cpp
+++ b/src/thermostats/TemperatureControl.cpp
@@ -368,12 +368,6 @@ void ControlRegionT::ControlTemperature(Molecule* mol)
 		double vcorr = 2. - 1. / globalTV._betaTrans;
 		double Dcorr = 2. - 1. / globalTV._betaRot;
 
-/*
-	mol->setv(0, mol->v(0) * vcorr);
-//    mol->setv(1, mol->v(1) * vcorr);
-	mol->setv(2, mol->v(2) * vcorr);
-*/
-
 		// measure added kin. energy
 		double v2_old = mol->v2();
 

--- a/src/thermostats/TemperatureControl.cpp
+++ b/src/thermostats/TemperatureControl.cpp
@@ -533,8 +533,6 @@ void ControlRegionT::writeAddedEkin(DomainDecompBase* domainDecomp, const uint64
 
 	std::stringstream outputstream;
 	outputstream.write(reinterpret_cast<const char*>(_addedEkin.data.global.data()), 8*_addedEkin.data.global.size());
-//	std::vector<double> vec{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20};
-//	outputstream.write(reinterpret_cast<const char*>(vec.data()), 8*vec.size());
 
 	ofstream fileout(filenamestream.str().c_str(), std::ios::app | std::ios::binary);
 	fileout << outputstream.str();

--- a/src/thermostats/TemperatureControl.cpp
+++ b/src/thermostats/TemperatureControl.cpp
@@ -501,6 +501,9 @@ void ControlRegionT::update(SubjectBase* subject)
 
 void ControlRegionT::writeAddedEkin(DomainDecompBase* domainDecomp, const uint64_t& simstep)
 {
+	if(_localMethod != VelocityScaling)
+		return;
+	
 	if( simstep % _addedEkin.writeFreq != 0)
 		return;
 


### PR DESCRIPTION
# Description

Fixed thermostat TemperatureControl by guarding method ControlRegionT::writeAddedEkin(...) against execution in case of using 'Anderson' as local method. This feature is not supported because control region will not be divided into slabs/bins.

Method ControlRegionT::writeAddedEkin(...) crashed (MPI error) without this guard in case of using 'Anderson' as local method.

## Related Pull Requests

- #128

# How Has This Been Tested?

Tested adsorption example of Michaela Heier. Simulation crashed when program executed method ControlRegionT::writeAddedEkin(...).

After guarding this method against execution in case of using 'Anderson' as local method fixed the problem.

