### PR TITLE
Fixes neighbor acquirer using mpi comm world

### DIFF
--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -35,9 +35,9 @@ DomainDecompMPIBase::DomainDecompMPIBase() :
 #endif
 	//_neighbourCommunicationScheme = new DirectNeighbourCommunicationScheme(new FullShell());
 
-	MPI_CHECK(MPI_Comm_rank(MPI_COMM_WORLD, &_rank));
+	MPI_CHECK(MPI_Comm_rank(_comm, &_rank));
 
-	MPI_CHECK(MPI_Comm_size(MPI_COMM_WORLD, &_numProcs));
+	MPI_CHECK(MPI_Comm_size(_comm, &_numProcs));
 
 	ParticleData::getMPIType(_mpiParticleType);
 
@@ -183,7 +183,7 @@ void DomainDecompMPIBase::assertIntIdentity(int IX) {
 			MPI_CHECK(MPI_Recv(&recv, 1, MPI_INT, i, 2 * i + 17, _comm, &s));
 			if (recv != IX) {
 				global_log->error() << "IX is " << IX << " for rank 0, but " << recv << " for rank " << i << ".\n";
-				MPI_Abort(MPI_COMM_WORLD, 911);
+				MPI_Abort(_comm, 911);
 			}
 		}
 		global_log->info() << "IX = " << recv << " for all " << _numProcs << " ranks.\n";
@@ -212,7 +212,7 @@ void DomainDecompMPIBase::assertDisjunctivity(ParticleContainer* moleculeContain
 		for (auto m = moleculeContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); m.isValid(); ++m) {
 			if(check.find(m->getID()) != check.end()){
 				global_log->error() << "Rank 0 contains a duplicated particle with id " << m->getID() << std::endl;
-				MPI_Abort(MPI_COMM_WORLD, 1);
+				MPI_Abort(_comm, 1);
 			}
 			check[m->getID()] = 0;
 		}
@@ -228,7 +228,7 @@ void DomainDecompMPIBase::assertDisjunctivity(ParticleContainer* moleculeContain
 				if (check.find(recv[j]) != check.end()) {
 					global_log->error() << "Ranks " << check[recv[j]] << " and " << i << " both propagate ID "
 							<< recv[j] << endl;
-					MPI_Abort(MPI_COMM_WORLD, 1);
+					MPI_Abort(_comm, 1);
 				} else
 					check[recv[j]] = i;
 			}

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -143,7 +143,7 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 											 domain->getGlobalLength(2)};
 	// 0. skin, as it is not needed for the migration of particles!
 	std::tie(recvNeighbors, sendNeighbors) =
-		NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownDomain, desiredDomain, 0. /*skin*/);
+		NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownDomain, desiredDomain, 0. /*skin*/, _comm);
 
 	std::vector<Molecule> dummy;
 	for (auto& sender : sendNeighbors) {

--- a/src/parallel/NeighborAcquirer.h
+++ b/src/parallel/NeighborAcquirer.h
@@ -22,11 +22,12 @@ public:
 	 * desiredRegions lie outside of ownRegion.
 	 * @param partners01 Vector of communication partners that contain domains outside of ownRegion.
 	 * @param partners02 Vector of communication partners that contain domains inside of ownRegion.
+	 * @param comm the mpi communicator
 	 * @return A tuple of 2 vectors: The first vector represents the partners NOT owning the haloDomain, while the
 	 * second vector will own the particles.
 	 */
 	static std::tuple<std::vector<CommunicationPartner>, std::vector<CommunicationPartner>> acquireNeighbors(
-		const std::array<double,3>& globalDomainLength, HaloRegion* ownRegion, std::vector<HaloRegion>& desiredRegions, double skin);
+		const std::array<double,3>& globalDomainLength, HaloRegion* ownRegion, std::vector<HaloRegion>& desiredRegions, double skin, const MPI_Comm& comm);
 
 	static std::vector<CommunicationPartner> squeezePartners(const std::vector<CommunicationPartner>& partners);
 

--- a/src/parallel/NeighbourCommunicationScheme.cpp
+++ b/src/parallel/NeighbourCommunicationScheme.cpp
@@ -468,10 +468,10 @@ void DirectNeighbourCommunicationScheme::initCommunicationPartners(double cutoff
 		std::array<double, 3> globalDomainLength {domain->getGlobalLength(0),domain->getGlobalLength(1), domain->getGlobalLength(2)};
 		// assuming p1 sends regions to p2
 		std::tie((*_haloImportForceExportNeighbours)[0], (*_haloExportForceImportNeighbours)[0]) =
-			NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownRegion, haloOrForceRegions, skin);
+			NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownRegion, haloOrForceRegions, skin, domainDecomp->getCommunicator());
 		// p1 notes reply, p2 notes owned as haloExportForceImport
 		std::tie((*_leavingExportNeighbours)[0], (*_leavingImportNeighbours)[0]) =
-			NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownRegion, leavingRegions, 0.);
+			NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownRegion, leavingRegions, 0.,  domainDecomp->getCommunicator());
 		// p1 notes reply, p2 notes owned as leaving import
 
 

--- a/src/parallel/NeighbourCommunicationScheme.cpp
+++ b/src/parallel/NeighbourCommunicationScheme.cpp
@@ -398,9 +398,6 @@ void DirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI(ParticleCo
 
 
 void NeighbourCommunicationScheme::selectNeighbours(MessageType msgType, bool import) {
-	int my_rank;
-	MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
-	
 	switch(msgType) {
 		case LEAVING_ONLY:
 			// leavingImport / leavingExport

--- a/src/parallel/tests/NeighborAcquirerTest.cpp
+++ b/src/parallel/tests/NeighborAcquirerTest.cpp
@@ -220,7 +220,7 @@ void NeighborAcquirerTest::testCorrectNeighborAcquisition() {
 	std::vector<CommunicationPartner> leavingExportNeighbours;
 	std::vector<CommunicationPartner> leavingImportNeighbours;
 	std::tie(leavingExportNeighbours, leavingImportNeighbours) =
-		NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownRegion, leavingRegions, 0.);
+		NeighborAcquirer::acquireNeighbors(globalDomainLength, &ownRegion, leavingRegions, 0., MPI_COMM_WORLD);
 	// p1 notes reply, p2 notes owned as leaving import
 
 	for (auto& neighbor : leavingExportNeighbours) {


### PR DESCRIPTION
# Description

This only affects the push-pull communication scheme.

This prevents bugs when ranks are reordered.
Previously, when ranks were reordered (this is allowed in the standard domain decomposition), wrong ranks might be indicated within the NeighborAcquirer that is used when using the push-pull communication scheme.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] On Hawk there was a deadlock. This is now no longer observable.
