### PR TITLE
Adds Dropaligner, Dropaccelerator and FixRegion plugins

### DIFF
--- a/src/Domain.h
+++ b/src/Domain.h
@@ -67,7 +67,7 @@ public:
 	//!                     Methods to achieve this are available in domainDecomp
 	//! @param currentTime The current time to be printed.
 	//! @param useBinaryFormat indicates wheter binary I/O is used or not
-	void writeCheckpoint( std::string filename, ParticleContainer* particleContainer,
+	void writeCheckpoint( const std::string& filename, ParticleContainer* particleContainer,
 			DomainDecompBase* domainDecomp, double currentTime, bool useBinaryFormat = false);
 
 	//! @brief writes a checkpoint file that can be used to continue the simulation
@@ -80,11 +80,11 @@ public:
 	//! @param domainDecomp In the parallel version, the file has to be written by more than one process.
 	//!                     Methods to achieve this are available in domainDecomp
 	//! @param currentTime The current time to be printed.
-	void writeCheckpointHeader(std::string filename,
+	void writeCheckpointHeader(const std::string& filename,
 			ParticleContainer* particleContainer,
 			const DomainDecompBase* domainDecomp, double currentTime);
 
-	void writeCheckpointHeaderXML(std::string filename,
+	void writeCheckpointHeaderXML(const std::string& filename,
 			ParticleContainer* particleContainer,
 			const DomainDecompBase* domainDecomp, double currentTime);
 

--- a/src/io/MPI_IOReader.cpp
+++ b/src/io/MPI_IOReader.cpp
@@ -133,8 +133,9 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 			domain->setTargetTemperature(thermostat_id, targetT);
 		} else if((token == "ComponentThermostat") || (token == "CT") || (token == "o")) {
 			// specify a thermostat for a component
-			if(!domain->severalThermostats())
+			if (not domain->severalThermostats()) {
 				domain->enableComponentwiseThermostat();
+			}
 			int component_id;
 			int thermostat_id;
 			_phaseSpaceHeaderFileStream >> component_id >> thermostat_id;

--- a/src/molecules/FullMolecule.h
+++ b/src/molecules/FullMolecule.h
@@ -74,7 +74,13 @@ public:
 
 	/** get coordinate of the current angular momentum  onto molecule */
 	double M(unsigned short d) const override { return _M[d]; }
+	
+	/** get Drop true or false**/
+	bool DROP() const override { return _DROP; }
 
+	/**set Drop true or false**/
+	void setDROP(bool t) override { _DROP = t; }
+	
 	/** get the virial **/
 	double Vi(unsigned short d) const override { return _Vi[d];}
 
@@ -346,7 +352,9 @@ protected:
 	double _L[3];  /**< angular momentum */
 	double _Vi[3]; /** Virial tensor **/
     unsigned long _id;  /**< IDentification number of that molecule */
-
+	
+	bool _DROP; /**<is the molecule part of the Drop */
+	
 	double _m; /**< total mass */
 	double _I[3],_invI[3];  // moment of inertia for principal axes and it's inverse
 

--- a/src/molecules/FullMolecule.h
+++ b/src/molecules/FullMolecule.h
@@ -75,12 +75,6 @@ public:
 	/** get coordinate of the current angular momentum  onto molecule */
 	double M(unsigned short d) const override { return _M[d]; }
 	
-	/** get Drop true or false**/
-	bool DROP() const override { return _DROP; }
-
-	/**set Drop true or false**/
-	void setDROP(bool t) override { _DROP = t; }
-	
 	/** get the virial **/
 	double Vi(unsigned short d) const override { return _Vi[d];}
 
@@ -352,8 +346,6 @@ protected:
 	double _L[3];  /**< angular momentum */
 	double _Vi[3]; /** Virial tensor **/
     unsigned long _id;  /**< IDentification number of that molecule */
-	
-	bool _DROP; /**<is the molecule part of the Drop */
 	
 	double _m; /**< total mass */
 	double _I[3],_invI[3];  // moment of inertia for principal axes and it's inverse

--- a/src/molecules/MoleculeInterface.h
+++ b/src/molecules/MoleculeInterface.h
@@ -83,6 +83,9 @@ public:
 	}
 	virtual double M(unsigned short d) const = 0;
 	virtual double Vi(unsigned short d) const = 0;
+	
+	virtual bool DROP() const = 0;
+	virtual void setDROP(bool t) = 0;
 
 	virtual void setD(unsigned short d, double D) = 0;
 

--- a/src/molecules/MoleculeInterface.h
+++ b/src/molecules/MoleculeInterface.h
@@ -84,9 +84,6 @@ public:
 	virtual double M(unsigned short d) const = 0;
 	virtual double Vi(unsigned short d) const = 0;
 	
-	virtual bool DROP() const = 0;
-	virtual void setDROP(bool t) = 0;
-
 	virtual void setD(unsigned short d, double D) = 0;
 
 	inline virtual void move(int d, double dr) = 0;

--- a/src/plugins/Dropaccelerator.cpp
+++ b/src/plugins/Dropaccelerator.cpp
@@ -12,179 +12,157 @@
 //!
 //!
 //! \param xmlconfig  read from config.xml
-void Dropaccelerator::readXML(XMLfileUnits& xmlconfig){
-
-    xmlconfig.getNodeValue("xposition", _xPosition);
-    xmlconfig.getNodeValue("yposition", _yPosition);
-    xmlconfig.getNodeValue("zposition", _zPosition);
-    xmlconfig.getNodeValue("dropradius", _Dropradius);
-    xmlconfig.getNodeValue("velocity", _Veloc);
-    xmlconfig.getNodeValue("starttime", _StartSimstep);
-    xmlconfig.getNodeValue("steps", _Steps);
-   
+void Dropaccelerator::readXML(XMLfileUnits& xmlconfig) {
+	xmlconfig.getNodeValue("xposition", _xPosition);
+	xmlconfig.getNodeValue("yposition", _yPosition);
+	xmlconfig.getNodeValue("zposition", _zPosition);
+	xmlconfig.getNodeValue("dropradius", _Dropradius);
+	xmlconfig.getNodeValue("velocity", _Veloc);
+	xmlconfig.getNodeValue("starttime", _StartSimstep);
+	xmlconfig.getNodeValue("steps", _Steps);
 
 	// SANITY CHECK
-    if(_INTERVAL < 1 || _Steps <= 0 || _Veloc < 0 || _StartSimstep < 0 || _xPosition <= 0. || _yPosition <= 0. || _zPosition <= 0. || _Dropradius <= 0)
-    {
-        global_log -> error() << "[Dropaccelerator] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
-        global_log -> error() << "[Dropaccelerator] HALTING SIMULATION" << std::endl;
-        _enabled = false;
-        // HALT SIM
-        Simulation::exit(1);
-        return;
-    }
+	if (_INTERVAL < 1 || _Steps <= 0 || _Veloc < 0 || _StartSimstep < 0 || _xPosition <= 0. || _yPosition <= 0. ||
+		_zPosition <= 0. || _Dropradius <= 0) {
+		global_log->error() << "[Dropaccelerator] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
+		global_log->error() << "[Dropaccelerator] HALTING SIMULATION" << std::endl;
+		_enabled = false;
+		// HALT SIM
+		Simulation::exit(1);
+		return;
+	}
 
-	global_log -> info() << "[Dropaccelerator] settings:" << std::endl;
-    global_log -> info() << "                  xposition: " << _xPosition << std::endl;
-    global_log -> info() << "                  yposition: " << _yPosition << std::endl;
-    global_log -> info() << "                  zposition: " << _zPosition << std::endl;
-	global_log -> info() << "                  dropradius: " << _Dropradius << std::endl;
-    global_log -> info() << "                  velocity: " << _Veloc << std::endl;
-    global_log->info() << "                  starttime: " << _StartSimstep << std::endl;
-    global_log->info() << "                  steps: " << _Steps << std::endl;
-    
+	global_log->info() << "[Dropaccelerator] settings:" << std::endl;
+	global_log->info() << "                  xposition: " << _xPosition << std::endl;
+	global_log->info() << "                  yposition: " << _yPosition << std::endl;
+	global_log->info() << "                  zposition: " << _zPosition << std::endl;
+	global_log->info() << "                  dropradius: " << _Dropradius << std::endl;
+	global_log->info() << "                  velocity: " << _Veloc << std::endl;
+	global_log->info() << "                  starttime: " << _StartSimstep << std::endl;
+	global_log->info() << "                  steps: " << _Steps << std::endl;
 }
 
-void Dropaccelerator::beforeForces(ParticleContainer* particleContainer,
-    DomainDecompBase* domainDecomp,
-    unsigned long simstep) {
+void Dropaccelerator::beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp,
+								   unsigned long simstep) {
+	double corrVeloc = -(_Veloc / _Steps);
 
-    double corrVeloc = -(_Veloc/_Steps);
+	if (_enabled) {
+		global_log->debug() << "[Dropaccelerator] before forces called" << std::endl;
 
-    if (_enabled) {
+		if ((simstep - 1) % _INTERVAL != 0) {
+			return;
+		}
 
-        global_log->debug() << "[Dropaccelerator] before forces called" << std::endl;
+		int numberparticles = 0;
 
-        if ((simstep - 1) % _INTERVAL != 0) {
-            return;
-        }
+		// ITERATE OVER PARTICLES AND CHOOSE AND MARK IF MOLECULE IN DROPLET OR NOT
+		if (simstep == _StartSimstep) {
+			global_log->info() << "Startsimstep =" << simstep << endl;
+			global_log->info() << "corrVeloc = " << corrVeloc << endl;
 
-        int numberparticles = 0;
+			for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+				double distanceSquared[3];
 
-        // ITERATE OVER PARTICLES AND CHOOSE AND MARK IF MOLECULE IN DROPLET OR NOT
-        if (simstep == _StartSimstep) {
+				tm->setDROP(false);
+				distanceSquared[0] = (_xPosition - tm->r(0)) * (_xPosition - tm->r(0));
+				distanceSquared[1] = (_yPosition - tm->r(1)) * (_yPosition - tm->r(1));
+				distanceSquared[2] = (_zPosition - tm->r(2)) * (_zPosition - tm->r(2));
 
-              
-              global_log->info() << "Startsimstep =" << simstep << endl;
-              global_log->info() << "corrVeloc = " << corrVeloc << endl;
+				if (distanceSquared[0] + distanceSquared[1] + distanceSquared[2] < _Dropradius * _Dropradius) {
+					tm->setDROP(true);
+					tm->vadd(0, corrVeloc, 0);
+					numberparticles++;
+				}
+			}
 
-            for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
-                double distanceSquared[3];
+			domainDecomp->collCommInit(1);
+			domainDecomp->collCommAppendInt(numberparticles);
+			domainDecomp->collCommAllreduceSum();
+			numberparticles = domainDecomp->collCommGetInt();
+			domainDecomp->collCommFinalize();
 
-               
+			global_log->info() << "Marked Particles (Start)=" << numberparticles << endl;
+		}
 
-                tm->setDROP(false);
-                distanceSquared[0] = (_xPosition - tm->r(0)) * (_xPosition - tm->r(0));
-                distanceSquared[1] = (_yPosition - tm->r(1)) * (_yPosition - tm->r(1));
-                distanceSquared[2] = (_zPosition - tm->r(2)) * (_zPosition - tm->r(2));
+		// ITERATE OVER PARTICLES AND ACCELERATE ONLY DROPMOLECULES
 
-                if (distanceSquared[0] + distanceSquared[1] + distanceSquared[2] < _Dropradius * _Dropradius) {
+		if (simstep > _StartSimstep && simstep < (_StartSimstep + _Steps)) {
+			global_log->info() << "Accelerationsimstep = " << simstep << endl;
 
-                    tm->setDROP(true);
-                    tm->vadd(0, corrVeloc, 0);
-                    numberparticles++;
-                }
-            }
+			for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+				if (tm->DROP() == true) {
+					tm->vadd(0, corrVeloc, 0);
+					numberparticles++;
+				}
+			}
 
-            domainDecomp->collCommInit(1);
-            domainDecomp->collCommAppendInt(numberparticles);
-            domainDecomp->collCommAllreduceSum();
-            numberparticles = domainDecomp->collCommGetInt();
-            domainDecomp->collCommFinalize();
+			domainDecomp->collCommInit(1);
+			domainDecomp->collCommAppendInt(numberparticles);
+			domainDecomp->collCommAllreduceSum();
+			numberparticles = domainDecomp->collCommGetInt();
+			domainDecomp->collCommFinalize();
 
-            global_log->info() << "Marked Particles (Start)=" << numberparticles << endl;
-        }
+			global_log->info() << "Marked Particles (Acceleration)=" << numberparticles << endl;
+		}
 
-        // ITERATE OVER PARTICLES AND ACCELERATE ONLY DROPMOLECULES
+		// CHECK IF VELOCITY HAS REACHED AND IF NOT ACCELERATE AGAIN
 
-        if (simstep > _StartSimstep && simstep < (_StartSimstep + _Steps)) {
+		if (simstep >= (_StartSimstep + _Steps) && simstep < (_StartSimstep + 2 * _Steps)) {
+			_VelocNOW = 0;
+			int Particles = 0;
+			double deltavelocity;
 
-            global_log->info() << "Accelerationsimstep = " << simstep << endl;
+			global_log->info() << "Postaccelerationsimstep = " << simstep << endl;
 
-            for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+			// GET VELOCITY IN Y-DIRECTION FOR EVERY PARTICLE IN DROPLET
 
-                if (tm->DROP() == true) {
+			for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+				double partVelocity = tm->v(1);
 
-                    tm->vadd(0, corrVeloc, 0);
-                    numberparticles++;
-                }
-            }
+				if (tm->DROP() == true) {
+					Particles += 1;
+					_VelocNOW += partVelocity;
+				}
+			}
 
-            domainDecomp->collCommInit(1);
-            domainDecomp->collCommAppendInt(numberparticles);
-            domainDecomp->collCommAllreduceSum();
-            numberparticles = domainDecomp->collCommGetInt();
-            domainDecomp->collCommFinalize();
+			// COMMUNICATION
 
-            global_log->info() << "Marked Particles (Acceleration)=" << numberparticles << endl;
-        }
+			domainDecomp->collCommInit(1);
+			domainDecomp->collCommAppendDouble(_VelocNOW);
+			domainDecomp->collCommAllreduceSum();
+			_VelocNOW = domainDecomp->collCommGetDouble();
+			domainDecomp->collCommFinalize();
 
-        // CHECK IF VELOCITY HAS REACHED AND IF NOT ACCELERATE AGAIN
+			domainDecomp->collCommInit(1);
+			domainDecomp->collCommAppendInt(Particles);
+			domainDecomp->collCommAllreduceSum();
+			Particles = domainDecomp->collCommGetInt();
+			domainDecomp->collCommFinalize();
 
-        if (simstep >= (_StartSimstep + _Steps) && simstep < (_StartSimstep + 2 * _Steps)) {
-            _VelocNOW = 0;
-            int Particles = 0;
-            double deltavelocity;
+			// CALCULATE AVERAGE SPEED
+			_VelocNOW = -(_VelocNOW / Particles);
 
-            global_log->info() << "Postaccelerationsimstep = " << simstep << endl;
+			global_log->info() << "_VelocNOW = " << _VelocNOW << endl;
+			global_log->info() << "_VelocNOW-_Veloc = " << _VelocNOW - _Veloc << endl;
+			global_log->info() << "corrVeloc = " << corrVeloc << endl;
+			global_log->info() << "Marked Particles (Postacceleration)=" << Particles << endl;
 
-            // GET VELOCITY IN Y-DIRECTION FOR EVERY PARTICLE IN DROPLET
+			// ACCELERATE IF TOO SLOW
 
-            for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
-                double partVelocity = tm->v(1);
+			if (_VelocNOW < _Veloc) {
+				global_log->info() << "ACCELERATION with DELTAvelocity" << endl;
+				deltavelocity = -(_Veloc - _VelocNOW);
 
-                if (tm->DROP() == true) {
-
-                    Particles += 1;
-                    _VelocNOW += partVelocity;
-                }
-
-            }
-
-
-            // COMMUNICATION
-
-            domainDecomp->collCommInit(1);
-            domainDecomp->collCommAppendDouble(_VelocNOW);
-            domainDecomp->collCommAllreduceSum();
-            _VelocNOW = domainDecomp->collCommGetDouble();
-            domainDecomp->collCommFinalize();
-
-            domainDecomp->collCommInit(1);
-            domainDecomp->collCommAppendInt(Particles);
-            domainDecomp->collCommAllreduceSum();
-            Particles = domainDecomp->collCommGetInt();
-            domainDecomp->collCommFinalize();
-
-            // CALCULATE AVERAGE SPEED
-            _VelocNOW = -(_VelocNOW / Particles);
-
-            global_log->info() << "_VelocNOW = " << _VelocNOW << endl;
-            global_log->info() << "_VelocNOW-_Veloc = " << _VelocNOW -_Veloc<< endl;
-            global_log->info() << "corrVeloc = " << corrVeloc << endl;
-            global_log->info() << "Marked Particles (Postacceleration)=" << Particles << endl;
-
-            // ACCELERATE IF TOO SLOW
-
-            if (_VelocNOW < _Veloc) {
-
-                global_log->info() << "ACCELERATION with DELTAvelocity"<< endl;
-                deltavelocity = -(_Veloc - _VelocNOW);
-
-                for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
-
-                    if (tm->DROP() == true) {
-
-                        tm->vadd(0, deltavelocity, 0);
-                    }
-                }
-            }
-        }
-    }
+				for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid();
+					 ++tm) {
+					if (tm->DROP() == true) {
+						tm->vadd(0, deltavelocity, 0);
+					}
+				}
+			}
+		}
+	}
 }
 
-void Dropaccelerator::endStep(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain,
-                         unsigned long simstep) {
-}
-
-        
+void Dropaccelerator::endStep(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain,
+							  unsigned long simstep) {}

--- a/src/plugins/Dropaccelerator.cpp
+++ b/src/plugins/Dropaccelerator.cpp
@@ -7,6 +7,10 @@
 
 #include "Dropaccelerator.h"
 
+#ifdef ENABLE_MPI
+#include "mpi.h"
+#endif
+
 //! @brief will be called to read configuration
 //!
 //!
@@ -61,6 +65,7 @@ void Dropaccelerator::beforeForces(ParticleContainer* particleContainer, DomainD
 			global_log->info() << "corrVeloc = " << corrVeloc << endl;
 
 			// resize first
+			_particleIsInDroplet.clear();
 			_particleIsInDroplet.resize(global_simulation->getDomain()->getglobalNumMolecules(), false);
 
 			for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
@@ -78,10 +83,9 @@ void Dropaccelerator::beforeForces(ParticleContainer* particleContainer, DomainD
 				}
 			}
 
-			// TODO: _particleIsInDroplet has to be communicated!
-
-
-			// END TODO
+#ifdef ENABLE_MPI
+			MPI_Allreduce(MPI_IN_PLACE, _particleIsInDroplet.data(), _particleIsInDroplet.size(), MPI_CHAR, MPI_LOR, domainDecomp->getCommunicator());
+#endif
 
 			domainDecomp->collCommInit(1);
 			domainDecomp->collCommAppendInt(numberparticles);

--- a/src/plugins/Dropaccelerator.cpp
+++ b/src/plugins/Dropaccelerator.cpp
@@ -1,0 +1,190 @@
+/*
+ * Dropaccelerator.h
+ *
+ *  Created on: 26 June 2020
+ *      Author: Koch
+ */
+
+#include "Dropaccelerator.h"
+
+//! @brief will be called to read configuration
+//!
+//!
+//!
+//! \param xmlconfig  read from config.xml
+void Dropaccelerator::readXML(XMLfileUnits& xmlconfig){
+
+    xmlconfig.getNodeValue("xposition", _xPosition);
+    xmlconfig.getNodeValue("yposition", _yPosition);
+    xmlconfig.getNodeValue("zposition", _zPosition);
+    xmlconfig.getNodeValue("dropradius", _Dropradius);
+    xmlconfig.getNodeValue("velocity", _Veloc);
+    xmlconfig.getNodeValue("starttime", _StartSimstep);
+    xmlconfig.getNodeValue("steps", _Steps);
+   
+
+	// SANITY CHECK
+    if(_INTERVAL < 1 || _Steps <= 0 || _Veloc < 0 || _StartSimstep < 0 || _xPosition <= 0. || _yPosition <= 0. || _zPosition <= 0. || _Dropradius <= 0)
+    {
+        global_log -> error() << "[Dropaccelerator] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
+        global_log -> error() << "[Dropaccelerator] HALTING SIMULATION" << std::endl;
+        _enabled = false;
+        // HALT SIM
+        Simulation::exit(1);
+        return;
+    }
+
+	global_log -> info() << "[Dropaccelerator] settings:" << std::endl;
+    global_log -> info() << "                  xposition: " << _xPosition << std::endl;
+    global_log -> info() << "                  yposition: " << _yPosition << std::endl;
+    global_log -> info() << "                  zposition: " << _zPosition << std::endl;
+	global_log -> info() << "                  dropradius: " << _Dropradius << std::endl;
+    global_log -> info() << "                  velocity: " << _Veloc << std::endl;
+    global_log->info() << "                  starttime: " << _StartSimstep << std::endl;
+    global_log->info() << "                  steps: " << _Steps << std::endl;
+    
+}
+
+void Dropaccelerator::beforeForces(ParticleContainer* particleContainer,
+    DomainDecompBase* domainDecomp,
+    unsigned long simstep) {
+
+    double corrVeloc = -(_Veloc/_Steps);
+
+    if (_enabled) {
+
+        global_log->debug() << "[Dropaccelerator] before forces called" << std::endl;
+
+        if ((simstep - 1) % _INTERVAL != 0) {
+            return;
+        }
+
+        int numberparticles = 0;
+
+        // ITERATE OVER PARTICLES AND CHOOSE AND MARK IF MOLECULE IN DROPLET OR NOT
+        if (simstep == _StartSimstep) {
+
+              
+              global_log->info() << "Startsimstep =" << simstep << endl;
+              global_log->info() << "corrVeloc = " << corrVeloc << endl;
+
+            for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+                double distanceSquared[3];
+
+               
+
+                tm->setDROP(false);
+                distanceSquared[0] = (_xPosition - tm->r(0)) * (_xPosition - tm->r(0));
+                distanceSquared[1] = (_yPosition - tm->r(1)) * (_yPosition - tm->r(1));
+                distanceSquared[2] = (_zPosition - tm->r(2)) * (_zPosition - tm->r(2));
+
+                if (distanceSquared[0] + distanceSquared[1] + distanceSquared[2] < _Dropradius * _Dropradius) {
+
+                    tm->setDROP(true);
+                    tm->vadd(0, corrVeloc, 0);
+                    numberparticles++;
+                }
+            }
+
+            domainDecomp->collCommInit(1);
+            domainDecomp->collCommAppendInt(numberparticles);
+            domainDecomp->collCommAllreduceSum();
+            numberparticles = domainDecomp->collCommGetInt();
+            domainDecomp->collCommFinalize();
+
+            global_log->info() << "Marked Particles (Start)=" << numberparticles << endl;
+        }
+
+        // ITERATE OVER PARTICLES AND ACCELERATE ONLY DROPMOLECULES
+
+        if (simstep > _StartSimstep && simstep < (_StartSimstep + _Steps)) {
+
+            global_log->info() << "Accelerationsimstep = " << simstep << endl;
+
+            for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+
+                if (tm->DROP() == true) {
+
+                    tm->vadd(0, corrVeloc, 0);
+                    numberparticles++;
+                }
+            }
+
+            domainDecomp->collCommInit(1);
+            domainDecomp->collCommAppendInt(numberparticles);
+            domainDecomp->collCommAllreduceSum();
+            numberparticles = domainDecomp->collCommGetInt();
+            domainDecomp->collCommFinalize();
+
+            global_log->info() << "Marked Particles (Acceleration)=" << numberparticles << endl;
+        }
+
+        // CHECK IF VELOCITY HAS REACHED AND IF NOT ACCELERATE AGAIN
+
+        if (simstep >= (_StartSimstep + _Steps) && simstep < (_StartSimstep + 2 * _Steps)) {
+            _VelocNOW = 0;
+            int Particles = 0;
+            double deltavelocity;
+
+            global_log->info() << "Postaccelerationsimstep = " << simstep << endl;
+
+            // GET VELOCITY IN Y-DIRECTION FOR EVERY PARTICLE IN DROPLET
+
+            for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+                double partVelocity = tm->v(1);
+
+                if (tm->DROP() == true) {
+
+                    Particles += 1;
+                    _VelocNOW += partVelocity;
+                }
+
+            }
+
+
+            // COMMUNICATION
+
+            domainDecomp->collCommInit(1);
+            domainDecomp->collCommAppendDouble(_VelocNOW);
+            domainDecomp->collCommAllreduceSum();
+            _VelocNOW = domainDecomp->collCommGetDouble();
+            domainDecomp->collCommFinalize();
+
+            domainDecomp->collCommInit(1);
+            domainDecomp->collCommAppendInt(Particles);
+            domainDecomp->collCommAllreduceSum();
+            Particles = domainDecomp->collCommGetInt();
+            domainDecomp->collCommFinalize();
+
+            // CALCULATE AVERAGE SPEED
+            _VelocNOW = -(_VelocNOW / Particles);
+
+            global_log->info() << "_VelocNOW = " << _VelocNOW << endl;
+            global_log->info() << "_VelocNOW-_Veloc = " << _VelocNOW -_Veloc<< endl;
+            global_log->info() << "corrVeloc = " << corrVeloc << endl;
+            global_log->info() << "Marked Particles (Postacceleration)=" << Particles << endl;
+
+            // ACCELERATE IF TOO SLOW
+
+            if (_VelocNOW < _Veloc) {
+
+                global_log->info() << "ACCELERATION with DELTAvelocity"<< endl;
+                deltavelocity = -(_Veloc - _VelocNOW);
+
+                for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+
+                    if (tm->DROP() == true) {
+
+                        tm->vadd(0, deltavelocity, 0);
+                    }
+                }
+            }
+        }
+    }
+}
+
+void Dropaccelerator::endStep(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain,
+                         unsigned long simstep) {
+}
+
+        

--- a/src/plugins/Dropaccelerator.h
+++ b/src/plugins/Dropaccelerator.h
@@ -1,0 +1,94 @@
+/*
+ * Dropaccelerator.h
+ *
+ *  Created on: 26 June 2020
+ *      Author: Koch
+ */
+
+#ifndef MARDYN_TRUNK_DROPACCELERATOR_H
+#define MARDYN_TRUNK_DROPACCELERATOR_H
+
+//class DropacceleratorTest;
+#include "PluginBase.h"
+#include "particleContainer/ParticleContainer.h"
+#include "Domain.h"
+#include "parallel/DomainDecompBase.h"
+
+/** @brief
+* Plugin: can be enabled via config.xml <br>
+*
+* Detects the undirected particle movement of every molecule in a spherical droplet and accelerates the droplet to a velocity in -y direction <br>
+* Acceleratiom happens once every interval-simsteps in determid time steps until the velocity has reached<br>
+* \code{.xml}
+*<plugin name="Dropaccelerator">
+*	<xposition>45.6701</xposition>
+*	<yposition>100</yposition>
+*	<zposition>45.6701</zposition>
+*	<dropradius>10</dropradius>
+*	<velocity>0.5</velocity>
+*   <starttime>100</starttime>
+*	<steps>100</steps>
+* </plugin>
+* \endcode
+*/
+
+class Dropaccelerator : public PluginBase{
+
+private:
+    //friend DropacceleratorTest;
+	
+	bool _enabled = true;
+
+	int _INTERVAL = 1;
+
+	double _motion[3];
+    double _balance[3];
+    double _mass = 0.0;
+    double _boxLength[3];
+	double _Dropradius;
+	double _xPosition;
+	double _yPosition;
+	double _zPosition;
+    double _Veloc;
+    double _Steps;
+    double _VelocNOW;
+    double _StartSimstep;
+
+public:
+ /*  Dropaccelerator(){
+	 // SETUP
+        for (unsigned d = 0; d < 3; d++) {
+            _balance[d] = 0.0;
+            _motion[d] = 0.0;
+        }
+    };
+    ~Dropaccelerator(){};*/
+
+	void init(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) override {
+        global_log -> debug() << "DropletAccelerator enabled" << std::endl;
+
+        for(unsigned d = 0; d < 3; d++){
+            _boxLength[d] = domain->getGlobalLength(d);
+        }
+    }
+
+	void readXML (XMLfileUnits& xmlconfig) override;
+
+    void beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, unsigned long simstep) override;
+
+    void endStep(
+            ParticleContainer *particleContainer, DomainDecompBase *domainDecomp,
+            Domain *domain, unsigned long simstep) override;
+
+
+    void finish(ParticleContainer *particleContainer,
+                DomainDecompBase *domainDecomp, Domain *domain) override {};
+
+    std::string getPluginName()override {return std::string("Dropaccelerator");}
+
+    static PluginBase* createInstance(){return new Dropaccelerator();}
+
+};
+
+
+#endif //MARDYN_TRUNK_DROPACCELERATOR_H

--- a/src/plugins/Dropaccelerator.h
+++ b/src/plugins/Dropaccelerator.h
@@ -8,87 +8,80 @@
 #ifndef MARDYN_TRUNK_DROPACCELERATOR_H
 #define MARDYN_TRUNK_DROPACCELERATOR_H
 
-//class DropacceleratorTest;
-#include "PluginBase.h"
-#include "particleContainer/ParticleContainer.h"
+// class DropacceleratorTest;
 #include "Domain.h"
+#include "PluginBase.h"
 #include "parallel/DomainDecompBase.h"
+#include "particleContainer/ParticleContainer.h"
 
 /** @brief
-* Plugin: can be enabled via config.xml <br>
-*
-* Detects the undirected particle movement of every molecule in a spherical droplet and accelerates the droplet to a velocity in -y direction <br>
-* Acceleratiom happens once every interval-simsteps in determid time steps until the velocity has reached<br>
-* \code{.xml}
-*<plugin name="Dropaccelerator">
-*	<xposition>45.6701</xposition>
-*	<yposition>100</yposition>
-*	<zposition>45.6701</zposition>
-*	<dropradius>10</dropradius>
-*	<velocity>0.5</velocity>
-*   <starttime>100</starttime>
-*	<steps>100</steps>
-* </plugin>
-* \endcode
-*/
+ * Plugin: can be enabled via config.xml <br>
+ *
+ * Detects the undirected particle movement of every molecule in a spherical droplet and accelerates the droplet to a
+ *velocity in -y direction <br> Acceleratiom happens once every interval-simsteps in determid time steps until the
+ *velocity has reached<br> \code{.xml} <plugin name="Dropaccelerator"> <xposition>45.6701</xposition>
+ *	<yposition>100</yposition>
+ *	<zposition>45.6701</zposition>
+ *	<dropradius>10</dropradius>
+ *	<velocity>0.5</velocity>
+ *   <starttime>100</starttime>
+ *	<steps>100</steps>
+ * </plugin>
+ * \endcode
+ */
 
-class Dropaccelerator : public PluginBase{
-
+class Dropaccelerator : public PluginBase {
 private:
-    //friend DropacceleratorTest;
-	
+	// friend DropacceleratorTest;
+
 	bool _enabled = true;
 
 	int _INTERVAL = 1;
 
 	double _motion[3];
-    double _balance[3];
-    double _mass = 0.0;
-    double _boxLength[3];
+	double _balance[3];
+	double _mass = 0.0;
+	double _boxLength[3];
 	double _Dropradius;
 	double _xPosition;
 	double _yPosition;
 	double _zPosition;
-    double _Veloc;
-    double _Steps;
-    double _VelocNOW;
-    double _StartSimstep;
+	double _Veloc;
+	double _Steps;
+	double _VelocNOW;
+	double _StartSimstep;
 
 public:
- /*  Dropaccelerator(){
-	 // SETUP
-        for (unsigned d = 0; d < 3; d++) {
-            _balance[d] = 0.0;
-            _motion[d] = 0.0;
-        }
-    };
-    ~Dropaccelerator(){};*/
+	/*  Dropaccelerator(){
+		// SETUP
+		   for (unsigned d = 0; d < 3; d++) {
+			   _balance[d] = 0.0;
+			   _motion[d] = 0.0;
+		   }
+	   };
+	   ~Dropaccelerator(){};*/
 
 	void init(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) override {
-        global_log -> debug() << "DropletAccelerator enabled" << std::endl;
+		global_log->debug() << "DropletAccelerator enabled" << std::endl;
 
-        for(unsigned d = 0; d < 3; d++){
-            _boxLength[d] = domain->getGlobalLength(d);
-        }
-    }
+		for (unsigned d = 0; d < 3; d++) {
+			_boxLength[d] = domain->getGlobalLength(d);
+		}
+	}
 
-	void readXML (XMLfileUnits& xmlconfig) override;
+	void readXML(XMLfileUnits& xmlconfig) override;
 
-    void beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, unsigned long simstep) override;
+	void beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp,
+					  unsigned long simstep) override;
 
-    void endStep(
-            ParticleContainer *particleContainer, DomainDecompBase *domainDecomp,
-            Domain *domain, unsigned long simstep) override;
+	void endStep(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain,
+				 unsigned long simstep) override;
 
+	void finish(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) override{};
 
-    void finish(ParticleContainer *particleContainer,
-                DomainDecompBase *domainDecomp, Domain *domain) override {};
+	std::string getPluginName() override { return std::string("Dropaccelerator"); }
 
-    std::string getPluginName()override {return std::string("Dropaccelerator");}
-
-    static PluginBase* createInstance(){return new Dropaccelerator();}
-
+	static PluginBase* createInstance() { return new Dropaccelerator(); }
 };
 
-
-#endif //MARDYN_TRUNK_DROPACCELERATOR_H
+#endif  // MARDYN_TRUNK_DROPACCELERATOR_H

--- a/src/plugins/Dropaccelerator.h
+++ b/src/plugins/Dropaccelerator.h
@@ -51,6 +51,8 @@ private:
 	double _VelocNOW;
 	double _StartSimstep;
 
+	std::vector<bool> _particleIsInDroplet;
+
 public:
 	/*  Dropaccelerator(){
 		// SETUP

--- a/src/plugins/Dropaccelerator.h
+++ b/src/plugins/Dropaccelerator.h
@@ -51,7 +51,7 @@ private:
 	double _VelocNOW;
 	double _StartSimstep;
 
-	std::vector<bool> _particleIsInDroplet;
+	std::vector<char> _particleIsInDroplet;
 
 public:
 	/*  Dropaccelerator(){

--- a/src/plugins/Dropaligner.cpp
+++ b/src/plugins/Dropaligner.cpp
@@ -12,113 +12,102 @@
 //!
 //!
 //! \param xmlconfig  read from config.xml
-void Dropaligner::readXML(XMLfileUnits& xmlconfig){
-
-    xmlconfig.getNodeValue("xpos", _xPos);
-    xmlconfig.getNodeValue("ypos", _yPos);
-    xmlconfig.getNodeValue("zpos", _zPos);
+void Dropaligner::readXML(XMLfileUnits& xmlconfig) {
+	xmlconfig.getNodeValue("xpos", _xPos);
+	xmlconfig.getNodeValue("ypos", _yPos);
+	xmlconfig.getNodeValue("zpos", _zPos);
 	xmlconfig.getNodeValue("radius", _radius);
-    xmlconfig.getNodeValue("interval", _interval);
-    xmlconfig.getNodeValue("correctionFactor", _alignmentCorrection);
+	xmlconfig.getNodeValue("interval", _interval);
+	xmlconfig.getNodeValue("correctionFactor", _alignmentCorrection);
 
 	// SANITY CHECK
-    if(_interval < 1 || _alignmentCorrection < 0 || _alignmentCorrection > 1 || _xPos <= 0. || _yPos <= 0. || _zPos <= 0. || _radius <= 0){
-        global_log -> error() << "[Dropaligner] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
-        global_log -> error() << "[Dropaligner] HALTING SIMULATION" << std::endl;
-        _enabled = false;
-        // HALT SIM
-        Simulation::exit(1);
-        return;
-    }
+	if (_interval < 1 || _alignmentCorrection < 0 || _alignmentCorrection > 1 || _xPos <= 0. || _yPos <= 0. ||
+		_zPos <= 0. || _radius <= 0) {
+		global_log->error() << "[Dropaligner] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
+		global_log->error() << "[Dropaligner] HALTING SIMULATION" << std::endl;
+		_enabled = false;
+		// HALT SIM
+		Simulation::exit(1);
+		return;
+	}
 
-	global_log -> info() << "[Dropaligner] settings:" << std::endl;
-    global_log -> info() << "                  xpos: " << _xPos << std::endl;
-    global_log -> info() << "                  ypos: " << _yPos << std::endl;
-    global_log -> info() << "                  zpos: " << _zPos << std::endl;
-	global_log -> info() << "                  radius: " << _radius << std::endl;
-    global_log -> info() << "                  interval: " << _interval << std::endl;
-    global_log -> info() << "                  correctionFactor: " << _alignmentCorrection << std::endl;
-
-
+	global_log->info() << "[Dropaligner] settings:" << std::endl;
+	global_log->info() << "                  xpos: " << _xPos << std::endl;
+	global_log->info() << "                  ypos: " << _yPos << std::endl;
+	global_log->info() << "                  zpos: " << _zPos << std::endl;
+	global_log->info() << "                  radius: " << _radius << std::endl;
+	global_log->info() << "                  interval: " << _interval << std::endl;
+	global_log->info() << "                  correctionFactor: " << _alignmentCorrection << std::endl;
 }
 
-void Dropaligner::beforeForces(ParticleContainer* particleContainer,
-                              DomainDecompBase* domainDecomp,
-                              unsigned long simstep) {
+void Dropaligner::beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp,
+							   unsigned long simstep) {
+	if (_enabled) {
+		global_log->debug() << "[Dropaligner] before forces called" << std::endl;
 
-    if(_enabled) {
+		if ((simstep - 1) % _interval != 0) {
+			return;
+		}
 
-        global_log->debug() << "[Dropaligner] before forces called" << std::endl;
+		// RESET
+		for (unsigned d = 0; d < 3; d++) {
+			_balance[d] = 0.0;
+			_motion[d] = 0.0;
+		}
+		_mass = 0.;
 
-        if ((simstep - 1) % _interval != 0) {
-            return;
-        }
-
-        // RESET
-        for (unsigned d = 0; d < 3; d++) {
-            _balance[d] = 0.0;
-            _motion[d] = 0.0;
-        }
-        _mass = 0.;
-
-        // ITERATE OVER PARTICLES
-        for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
-            double partMass = tm->mass();
+		// ITERATE OVER PARTICLES
+		for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+			double partMass = tm->mass();
 			double distanceSquared[3];
 
-			distanceSquared[0] = (_xPos - tm->r(0)) *  (_xPos - tm->r(0));
-			distanceSquared[1] = (_yPos - tm->r(1)) *  (_yPos - tm->r(1));
-			distanceSquared[2] = (_zPos - tm->r(2)) *  (_zPos - tm->r(2));
+			distanceSquared[0] = (_xPos - tm->r(0)) * (_xPos - tm->r(0));
+			distanceSquared[1] = (_yPos - tm->r(1)) * (_yPos - tm->r(1));
+			distanceSquared[2] = (_zPos - tm->r(2)) * (_zPos - tm->r(2));
 
 			if (distanceSquared[0] + distanceSquared[1] + distanceSquared[2] < _radius * _radius) {
-				
-            	_mass += partMass;
-            	for (int d = 0; d < 3; d++) {
-                	_balance[d] += tm->r(d) * partMass;
-            	}
-        	}
+				_mass += partMass;
+				for (int d = 0; d < 3; d++) {
+					_balance[d] += tm->r(d) * partMass;
+				}
+			}
 		}
 
 		// COMMUNICATION
-        domainDecomp->collCommInit(4);
-        for (int d = 0; d < 3; d++) {
-            domainDecomp->collCommAppendDouble(_balance[d]);
-        }
-        domainDecomp->collCommAppendDouble(_mass);
-        domainDecomp->collCommAllreduceSum();
-        for (int d = 0; d < 3; d++) {
-            _balance[d] = domainDecomp->collCommGetDouble();
-        }
-        _mass = domainDecomp->collCommGetDouble();
-        domainDecomp->collCommFinalize();
+		domainDecomp->collCommInit(4);
+		for (int d = 0; d < 3; d++) {
+			domainDecomp->collCommAppendDouble(_balance[d]);
+		}
+		domainDecomp->collCommAppendDouble(_mass);
+		domainDecomp->collCommAllreduceSum();
+		for (int d = 0; d < 3; d++) {
+			_balance[d] = domainDecomp->collCommGetDouble();
+		}
+		_mass = domainDecomp->collCommGetDouble();
+		domainDecomp->collCommFinalize();
 
 		// CALCULATE MOTION
-        
-        _motion[0] = -_alignmentCorrection * ((_balance[0] / _mass) - _xPos);
+
+		_motion[0] = -_alignmentCorrection * ((_balance[0] / _mass) - _xPos);
 		_motion[1] = -_alignmentCorrection * ((_balance[1] / _mass) - _yPos);
 		_motion[2] = -_alignmentCorrection * ((_balance[2] / _mass) - _zPos);
 
 		// MOVE
-        for(auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm){
-		
+		for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
 			double distanceSquared[3];
-		
-			distanceSquared[0] = (_xPos - tm->r(0)) *  (_xPos - tm->r(0));
-			distanceSquared[1] = (_yPos - tm->r(1)) *  (_yPos - tm->r(1));
-			distanceSquared[2] = (_zPos - tm->r(2)) *  (_zPos - tm->r(2));
+
+			distanceSquared[0] = (_xPos - tm->r(0)) * (_xPos - tm->r(0));
+			distanceSquared[1] = (_yPos - tm->r(1)) * (_yPos - tm->r(1));
+			distanceSquared[2] = (_zPos - tm->r(2)) * (_zPos - tm->r(2));
 
 			if (distanceSquared[0] + distanceSquared[1] + distanceSquared[2] < _radius * _radius) {
-
-            	for (unsigned d = 0; d < 3; d++) {
-            	    tm->move(d, _motion[d]);
-            	}
-        	}
+				for (unsigned d = 0; d < 3; d++) {
+					tm->move(d, _motion[d]);
+				}
+			}
 		}
 	}
-}		
-
-void Dropaligner::endStep(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain,
-                         unsigned long simstep) {
 }
 
-        
+void Dropaligner::endStep(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain,
+						  unsigned long simstep) {}

--- a/src/plugins/Dropaligner.cpp
+++ b/src/plugins/Dropaligner.cpp
@@ -1,0 +1,124 @@
+/*
+ * COMaligner.h
+ *
+ *  Created on: 22 June 2020
+ *      Author: Marx
+ */
+
+#include "Dropaligner.h"
+
+//! @brief will be called to read configuration
+//!
+//!
+//!
+//! \param xmlconfig  read from config.xml
+void Dropaligner::readXML(XMLfileUnits& xmlconfig){
+
+    xmlconfig.getNodeValue("xpos", _xPos);
+    xmlconfig.getNodeValue("ypos", _yPos);
+    xmlconfig.getNodeValue("zpos", _zPos);
+	xmlconfig.getNodeValue("radius", _radius);
+    xmlconfig.getNodeValue("interval", _interval);
+    xmlconfig.getNodeValue("correctionFactor", _alignmentCorrection);
+
+	// SANITY CHECK
+    if(_interval < 1 || _alignmentCorrection < 0 || _alignmentCorrection > 1 || _xPos <= 0. || _yPos <= 0. || _zPos <= 0. || _radius <= 0){
+        global_log -> error() << "[Dropaligner] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
+        global_log -> error() << "[Dropaligner] HALTING SIMULATION" << std::endl;
+        _enabled = false;
+        // HALT SIM
+        Simulation::exit(1);
+        return;
+    }
+
+	global_log -> info() << "[Dropaligner] settings:" << std::endl;
+    global_log -> info() << "                  xpos: " << _xPos << std::endl;
+    global_log -> info() << "                  ypos: " << _yPos << std::endl;
+    global_log -> info() << "                  zpos: " << _zPos << std::endl;
+	global_log -> info() << "                  radius: " << _radius << std::endl;
+    global_log -> info() << "                  interval: " << _interval << std::endl;
+    global_log -> info() << "                  correctionFactor: " << _alignmentCorrection << std::endl;
+
+
+}
+
+void Dropaligner::beforeForces(ParticleContainer* particleContainer,
+                              DomainDecompBase* domainDecomp,
+                              unsigned long simstep) {
+
+    if(_enabled) {
+
+        global_log->debug() << "[Dropaligner] before forces called" << std::endl;
+
+        if ((simstep - 1) % _interval != 0) {
+            return;
+        }
+
+        // RESET
+        for (unsigned d = 0; d < 3; d++) {
+            _balance[d] = 0.0;
+            _motion[d] = 0.0;
+        }
+        _mass = 0.;
+
+        // ITERATE OVER PARTICLES
+        for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+            double partMass = tm->mass();
+			double distanceSquared[3];
+
+			distanceSquared[0] = (_xPos - tm->r(0)) *  (_xPos - tm->r(0));
+			distanceSquared[1] = (_yPos - tm->r(1)) *  (_yPos - tm->r(1));
+			distanceSquared[2] = (_zPos - tm->r(2)) *  (_zPos - tm->r(2));
+
+			if (distanceSquared[0] + distanceSquared[1] + distanceSquared[2] < _radius * _radius) {
+				
+            	_mass += partMass;
+            	for (int d = 0; d < 3; d++) {
+                	_balance[d] += tm->r(d) * partMass;
+            	}
+        	}
+		}
+
+		// COMMUNICATION
+        domainDecomp->collCommInit(4);
+        for (int d = 0; d < 3; d++) {
+            domainDecomp->collCommAppendDouble(_balance[d]);
+        }
+        domainDecomp->collCommAppendDouble(_mass);
+        domainDecomp->collCommAllreduceSum();
+        for (int d = 0; d < 3; d++) {
+            _balance[d] = domainDecomp->collCommGetDouble();
+        }
+        _mass = domainDecomp->collCommGetDouble();
+        domainDecomp->collCommFinalize();
+
+		// CALCULATE MOTION
+        
+        _motion[0] = -_alignmentCorrection * ((_balance[0] / _mass) - _xPos);
+		_motion[1] = -_alignmentCorrection * ((_balance[1] / _mass) - _yPos);
+		_motion[2] = -_alignmentCorrection * ((_balance[2] / _mass) - _zPos);
+
+		// MOVE
+        for(auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm){
+		
+			double distanceSquared[3];
+		
+			distanceSquared[0] = (_xPos - tm->r(0)) *  (_xPos - tm->r(0));
+			distanceSquared[1] = (_yPos - tm->r(1)) *  (_yPos - tm->r(1));
+			distanceSquared[2] = (_zPos - tm->r(2)) *  (_zPos - tm->r(2));
+
+			if (distanceSquared[0] + distanceSquared[1] + distanceSquared[2] < _radius * _radius) {
+
+            	for (unsigned d = 0; d < 3; d++) {
+            	    tm->move(d, _motion[d]);
+            	}
+        	}
+		}
+	}
+}		
+
+void Dropaligner::endStep(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain,
+                         unsigned long simstep) {
+}
+
+        

--- a/src/plugins/Dropaligner.h
+++ b/src/plugins/Dropaligner.h
@@ -1,0 +1,86 @@
+/*
+ * Dropaligner.h
+ *
+ *  Created on: 22 June 2020
+ *      Author: Marx
+ */
+
+#ifndef MARDYN_TRUNK_DROPALIGNER_H
+#define MARDYN_TRUNK_DROPALIGNER_H
+
+//class DropalignerTest;
+#include "PluginBase.h"
+#include "particleContainer/ParticleContainer.h"
+#include "Domain.h"
+#include "parallel/DomainDecompBase.h"
+
+/** @brief
+* Plugin: can be enabled via config.xml <br>
+*
+* Calculates Center of mass of a spherical droplet and moves all particles to align with the desired center of mass<br>
+* Alignment happens once every interval-simsteps<br>
+* The correction factor can be set from 0-1<br>
+* 1 being full alignment -> 0 no alignment at all<br>
+* <b>HALO must not be present</b> for the alignment. Halo would lead to incorrect alignment.<br>
+* This is guarenteed by calling the alignment in the beforeForces step of the simulation
+* \code{.xml}
+* <plugin name="Dropaligner">
+*			<xpos>50</xpos>
+*			<ypos>60</ypos>
+*			<zpos>50</zpos>
+*           <radius>30</radius>
+*			<interval>1</interval>
+*			<correctionFactor>.5</correctionFactor>
+* </plugin>
+* \endcode
+*/
+
+class Dropaligner : public PluginBase{
+
+private:
+
+	
+	bool _enabled = true;
+
+	int _interval = 1;
+
+    double _alignmentCorrection = 1.0;
+	double _motion[3];
+    double _balance[3];
+    double _mass = 0.0;
+    double _boxLength[3];
+	double _radius;
+	double _xPos;
+	double _yPos;
+	double _zPos;
+
+public:
+
+	void init(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) override {
+        global_log -> debug() << "DropletRealignment enabled" << std::endl;
+
+        for(unsigned d = 0; d < 3; d++){
+            _boxLength[d] = domain->getGlobalLength(d);
+        }
+    }
+
+	void readXML (XMLfileUnits& xmlconfig) override;
+
+    void beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, unsigned long simstep) override;
+
+    void endStep(
+            ParticleContainer *particleContainer, DomainDecompBase *domainDecomp,
+            Domain *domain, unsigned long simstep) override;
+
+
+    void finish(ParticleContainer *particleContainer,
+                DomainDecompBase *domainDecomp, Domain *domain) override {};
+
+    std::string getPluginName()override {return std::string("Dropaligner");}
+
+    static PluginBase* createInstance(){return new Dropaligner();}
+
+};
+
+
+#endif //MARDYN_TRUNK_DROPALIGNER_H

--- a/src/plugins/Dropaligner.h
+++ b/src/plugins/Dropaligner.h
@@ -8,79 +8,71 @@
 #ifndef MARDYN_TRUNK_DROPALIGNER_H
 #define MARDYN_TRUNK_DROPALIGNER_H
 
-//class DropalignerTest;
-#include "PluginBase.h"
-#include "particleContainer/ParticleContainer.h"
+// class DropalignerTest;
 #include "Domain.h"
+#include "PluginBase.h"
 #include "parallel/DomainDecompBase.h"
+#include "particleContainer/ParticleContainer.h"
 
 /** @brief
-* Plugin: can be enabled via config.xml <br>
-*
-* Calculates Center of mass of a spherical droplet and moves all particles to align with the desired center of mass<br>
-* Alignment happens once every interval-simsteps<br>
-* The correction factor can be set from 0-1<br>
-* 1 being full alignment -> 0 no alignment at all<br>
-* <b>HALO must not be present</b> for the alignment. Halo would lead to incorrect alignment.<br>
-* This is guarenteed by calling the alignment in the beforeForces step of the simulation
-* \code{.xml}
-* <plugin name="Dropaligner">
-*			<xpos>50</xpos>
-*			<ypos>60</ypos>
-*			<zpos>50</zpos>
-*           <radius>30</radius>
-*			<interval>1</interval>
-*			<correctionFactor>.5</correctionFactor>
-* </plugin>
-* \endcode
-*/
+ * Plugin: can be enabled via config.xml <br>
+ *
+ * Calculates Center of mass of a spherical droplet and moves all particles to align with the desired center of mass<br>
+ * Alignment happens once every interval-simsteps<br>
+ * The correction factor can be set from 0-1<br>
+ * 1 being full alignment -> 0 no alignment at all<br>
+ * <b>HALO must not be present</b> for the alignment. Halo would lead to incorrect alignment.<br>
+ * This is guarenteed by calling the alignment in the beforeForces step of the simulation
+ * \code{.xml}
+ * <plugin name="Dropaligner">
+ *			<xpos>50</xpos>
+ *			<ypos>60</ypos>
+ *			<zpos>50</zpos>
+ *           <radius>30</radius>
+ *			<interval>1</interval>
+ *			<correctionFactor>.5</correctionFactor>
+ * </plugin>
+ * \endcode
+ */
 
-class Dropaligner : public PluginBase{
-
+class Dropaligner : public PluginBase {
 private:
-
-	
 	bool _enabled = true;
 
 	int _interval = 1;
 
-    double _alignmentCorrection = 1.0;
+	double _alignmentCorrection = 1.0;
 	double _motion[3];
-    double _balance[3];
-    double _mass = 0.0;
-    double _boxLength[3];
+	double _balance[3];
+	double _mass = 0.0;
+	double _boxLength[3];
 	double _radius;
 	double _xPos;
 	double _yPos;
 	double _zPos;
 
 public:
-
 	void init(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) override {
-        global_log -> debug() << "DropletRealignment enabled" << std::endl;
+		global_log->debug() << "DropletRealignment enabled" << std::endl;
 
-        for(unsigned d = 0; d < 3; d++){
-            _boxLength[d] = domain->getGlobalLength(d);
-        }
-    }
+		for (unsigned d = 0; d < 3; d++) {
+			_boxLength[d] = domain->getGlobalLength(d);
+		}
+	}
 
-	void readXML (XMLfileUnits& xmlconfig) override;
+	void readXML(XMLfileUnits& xmlconfig) override;
 
-    void beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, unsigned long simstep) override;
+	void beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp,
+					  unsigned long simstep) override;
 
-    void endStep(
-            ParticleContainer *particleContainer, DomainDecompBase *domainDecomp,
-            Domain *domain, unsigned long simstep) override;
+	void endStep(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain,
+				 unsigned long simstep) override;
 
+	void finish(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) override{};
 
-    void finish(ParticleContainer *particleContainer,
-                DomainDecompBase *domainDecomp, Domain *domain) override {};
+	std::string getPluginName() override { return std::string("Dropaligner"); }
 
-    std::string getPluginName()override {return std::string("Dropaligner");}
-
-    static PluginBase* createInstance(){return new Dropaligner();}
-
+	static PluginBase* createInstance() { return new Dropaligner(); }
 };
 
-
-#endif //MARDYN_TRUNK_DROPALIGNER_H
+#endif  // MARDYN_TRUNK_DROPALIGNER_H

--- a/src/plugins/FixRegion.cpp
+++ b/src/plugins/FixRegion.cpp
@@ -46,16 +46,16 @@ void FixRegion::init(ParticleContainer* particleContainer, DomainDecompBase* dom
 
 	_molCount = 0;
 
+	std::array<double, 3> min{_xMin, _yMin, _zMin};
+	std::array<double, 3> max{_xMax, _yMax, _zMax};
 	// ITERATE OVER PARTICLES
-	for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
-		if (tm->r(0) >= _xMin && tm->r(0) <= _xMax && tm->r(1) >= _yMin && tm->r(1) <= _yMax && tm->r(2) >= _zMin &&
-			tm->r(2) <= _zMax) {
-			for (unsigned i = 0; i < 3; i++) {
-				tm->setv(i, 0.0);
-				tm->setF(i, 0.0);
-			}
-			_molCount++;
+	for (auto tm = particleContainer->regionIterator(min.data(), max.data(), ParticleIterator::ONLY_INNER_AND_BOUNDARY);
+		 tm.isValid(); ++tm) {
+		for (unsigned i = 0; i < 3; i++) {
+			tm->setv(i, 0.0);
+			tm->setF(i, 0.0);
 		}
+		_molCount++;
 	}
 	domainDecomp->collCommInit(1);
 	domainDecomp->collCommAppendUnsLong(_molCount);
@@ -70,15 +70,15 @@ void FixRegion::beforeForces(ParticleContainer* particleContainer, DomainDecompB
 
 void FixRegion::afterForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp,
 							unsigned long simstep) {
+	std::array<double, 3> min{_xMin, _yMin, _zMin};
+	std::array<double, 3> max{_xMax, _yMax, _zMax};
 	// ITERATE OVER PARTICLES
-	for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
-		if (tm->r(0) >= _xMin && tm->r(0) <= _xMax && tm->r(1) >= _yMin && tm->r(1) <= _yMax && tm->r(2) >= _zMin &&
-			tm->r(2) <= _zMax) {
-			for (unsigned i = 0; i < 3; i++) {
-				tm->setv(i, 0.0);
-				tm->setF(i, 0.0);
-			}
+	for (auto tm = particleContainer->regionIterator(min.data(), max.data(), ParticleIterator::ONLY_INNER_AND_BOUNDARY);
+		 tm.isValid(); ++tm) {
+		for (unsigned i = 0; i < 3; i++) {
+			tm->setv(i, 0.0);
 		}
+		tm->clearFM();
 	}
 }
 

--- a/src/plugins/FixRegion.cpp
+++ b/src/plugins/FixRegion.cpp
@@ -1,0 +1,102 @@
+/*
+ * FixRegion.cpp
+ *
+ *  Created on: 9 July 2020
+ *      Author: Marx
+ */
+
+#include "FixRegion.h"
+
+//! @brief will be called to read configuration
+//!
+//!
+//!
+//! \param xmlconfig  read from config.xml
+void FixRegion::readXML(XMLfileUnits& xmlconfig){
+
+    xmlconfig.getNodeValue("xmin", _xMin);
+    xmlconfig.getNodeValue("ymin", _yMin);
+    xmlconfig.getNodeValue("zmin", _zMin);
+	xmlconfig.getNodeValue("xmax", _xMax);
+    xmlconfig.getNodeValue("ymax", _yMax);
+    xmlconfig.getNodeValue("zmax", _zMax);
+
+}
+
+void FixRegion::init(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) {
+
+	for(unsigned d = 0; d < 3; d++){
+    	_boxLength[d] = domain->getGlobalLength(d);
+    }
+
+
+	// SANITY CHECK
+    if(_xMin < 0. || _yMin < 0. || _zMin < 0. || _xMax > _boxLength[0] || _yMax > _boxLength[1] || _zMax > _boxLength[2] ){
+        global_log -> error() << "[FixRegion] INVALID INPUT!!! DISABLED!" << std::endl;
+        global_log -> error() << "[FixRegion] HALTING SIMULATION" << std::endl;
+        // HALT SIM
+        Simulation::exit(1);
+        return;
+    }
+
+	global_log -> info() << "[FixRegion] settings:" << std::endl;
+    global_log -> info() << "                  xmin: " << _xMin << std::endl;
+    global_log -> info() << "                  ymin: " << _yMin << std::endl;
+    global_log -> info() << "                  zmin: " << _zMin << std::endl;
+	global_log -> info() << "                  xmax: " << _xMax << std::endl;
+    global_log -> info() << "                  ymax: " << _yMax << std::endl;
+    global_log -> info() << "                  zmax: " << _zMax << std::endl;
+	
+	_molCount = 0;
+
+	// ITERATE OVER PARTICLES
+    for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+		if ( tm->r(0) >= _xMin && tm->r(0) <= _xMax && tm->r(1) >= _yMin && tm->r(1) <= _yMax && tm->r(2) >= _zMin && tm->r(2) <= _zMax ) {
+	
+			for (unsigned i = 0; i < 3; i++) {
+				tm->setv(i,0.0);
+				tm->setF(i,0.0);
+			}
+			_molCount++;
+		}
+			
+	}
+	domainDecomp->collCommInit(1);
+    domainDecomp->collCommAppendUnsLong(_molCount);
+    domainDecomp->collCommAllreduceSum();
+    _molCount = domainDecomp->collCommGetUnsLong();
+    domainDecomp->collCommFinalize();
+	global_log -> info() << _molCount << " molecules are inside a fixed region" << std::endl;
+
+}
+
+void FixRegion::beforeForces(ParticleContainer* particleContainer,
+                              DomainDecompBase* domainDecomp,
+                              unsigned long simstep) {
+
+}
+
+void FixRegion::afterForces(ParticleContainer* particleContainer,
+                              DomainDecompBase* domainDecomp,
+                              unsigned long simstep) {
+
+// ITERATE OVER PARTICLES
+    for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+		if ( tm->r(0) >= _xMin && tm->r(0) <= _xMax && tm->r(1) >= _yMin && tm->r(1) <= _yMax && tm->r(2) >= _zMin && tm->r(2) <= _zMax ) {
+	
+			for (unsigned i = 0; i < 3; i++) {
+				tm->setv(i,0.0);
+				tm->setF(i,0.0);
+			}
+		}
+			
+	}
+
+
+}
+
+void FixRegion::endStep(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain,
+                         unsigned long simstep) {
+}
+
+        

--- a/src/plugins/FixRegion.cpp
+++ b/src/plugins/FixRegion.cpp
@@ -12,91 +12,75 @@
 //!
 //!
 //! \param xmlconfig  read from config.xml
-void FixRegion::readXML(XMLfileUnits& xmlconfig){
-
-    xmlconfig.getNodeValue("xmin", _xMin);
-    xmlconfig.getNodeValue("ymin", _yMin);
-    xmlconfig.getNodeValue("zmin", _zMin);
+void FixRegion::readXML(XMLfileUnits& xmlconfig) {
+	xmlconfig.getNodeValue("xmin", _xMin);
+	xmlconfig.getNodeValue("ymin", _yMin);
+	xmlconfig.getNodeValue("zmin", _zMin);
 	xmlconfig.getNodeValue("xmax", _xMax);
-    xmlconfig.getNodeValue("ymax", _yMax);
-    xmlconfig.getNodeValue("zmax", _zMax);
-
+	xmlconfig.getNodeValue("ymax", _yMax);
+	xmlconfig.getNodeValue("zmax", _zMax);
 }
 
 void FixRegion::init(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) {
-
-	for(unsigned d = 0; d < 3; d++){
-    	_boxLength[d] = domain->getGlobalLength(d);
-    }
-
+	for (unsigned d = 0; d < 3; d++) {
+		_boxLength[d] = domain->getGlobalLength(d);
+	}
 
 	// SANITY CHECK
-    if(_xMin < 0. || _yMin < 0. || _zMin < 0. || _xMax > _boxLength[0] || _yMax > _boxLength[1] || _zMax > _boxLength[2] ){
-        global_log -> error() << "[FixRegion] INVALID INPUT!!! DISABLED!" << std::endl;
-        global_log -> error() << "[FixRegion] HALTING SIMULATION" << std::endl;
-        // HALT SIM
-        Simulation::exit(1);
-        return;
-    }
+	if (_xMin < 0. || _yMin < 0. || _zMin < 0. || _xMax > _boxLength[0] || _yMax > _boxLength[1] ||
+		_zMax > _boxLength[2]) {
+		global_log->error() << "[FixRegion] INVALID INPUT!!! DISABLED!" << std::endl;
+		global_log->error() << "[FixRegion] HALTING SIMULATION" << std::endl;
+		// HALT SIM
+		Simulation::exit(1);
+		return;
+	}
 
-	global_log -> info() << "[FixRegion] settings:" << std::endl;
-    global_log -> info() << "                  xmin: " << _xMin << std::endl;
-    global_log -> info() << "                  ymin: " << _yMin << std::endl;
-    global_log -> info() << "                  zmin: " << _zMin << std::endl;
-	global_log -> info() << "                  xmax: " << _xMax << std::endl;
-    global_log -> info() << "                  ymax: " << _yMax << std::endl;
-    global_log -> info() << "                  zmax: " << _zMax << std::endl;
-	
+	global_log->info() << "[FixRegion] settings:" << std::endl;
+	global_log->info() << "                  xmin: " << _xMin << std::endl;
+	global_log->info() << "                  ymin: " << _yMin << std::endl;
+	global_log->info() << "                  zmin: " << _zMin << std::endl;
+	global_log->info() << "                  xmax: " << _xMax << std::endl;
+	global_log->info() << "                  ymax: " << _yMax << std::endl;
+	global_log->info() << "                  zmax: " << _zMax << std::endl;
+
 	_molCount = 0;
 
 	// ITERATE OVER PARTICLES
-    for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
-		if ( tm->r(0) >= _xMin && tm->r(0) <= _xMax && tm->r(1) >= _yMin && tm->r(1) <= _yMax && tm->r(2) >= _zMin && tm->r(2) <= _zMax ) {
-	
+	for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+		if (tm->r(0) >= _xMin && tm->r(0) <= _xMax && tm->r(1) >= _yMin && tm->r(1) <= _yMax && tm->r(2) >= _zMin &&
+			tm->r(2) <= _zMax) {
 			for (unsigned i = 0; i < 3; i++) {
-				tm->setv(i,0.0);
-				tm->setF(i,0.0);
+				tm->setv(i, 0.0);
+				tm->setF(i, 0.0);
 			}
 			_molCount++;
 		}
-			
 	}
 	domainDecomp->collCommInit(1);
-    domainDecomp->collCommAppendUnsLong(_molCount);
-    domainDecomp->collCommAllreduceSum();
-    _molCount = domainDecomp->collCommGetUnsLong();
-    domainDecomp->collCommFinalize();
-	global_log -> info() << _molCount << " molecules are inside a fixed region" << std::endl;
-
+	domainDecomp->collCommAppendUnsLong(_molCount);
+	domainDecomp->collCommAllreduceSum();
+	_molCount = domainDecomp->collCommGetUnsLong();
+	domainDecomp->collCommFinalize();
+	global_log->info() << _molCount << " molecules are inside a fixed region" << std::endl;
 }
 
-void FixRegion::beforeForces(ParticleContainer* particleContainer,
-                              DomainDecompBase* domainDecomp,
-                              unsigned long simstep) {
+void FixRegion::beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp,
+							 unsigned long simstep) {}
 
-}
-
-void FixRegion::afterForces(ParticleContainer* particleContainer,
-                              DomainDecompBase* domainDecomp,
-                              unsigned long simstep) {
-
-// ITERATE OVER PARTICLES
-    for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
-		if ( tm->r(0) >= _xMin && tm->r(0) <= _xMax && tm->r(1) >= _yMin && tm->r(1) <= _yMax && tm->r(2) >= _zMin && tm->r(2) <= _zMax ) {
-	
+void FixRegion::afterForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp,
+							unsigned long simstep) {
+	// ITERATE OVER PARTICLES
+	for (auto tm = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tm.isValid(); ++tm) {
+		if (tm->r(0) >= _xMin && tm->r(0) <= _xMax && tm->r(1) >= _yMin && tm->r(1) <= _yMax && tm->r(2) >= _zMin &&
+			tm->r(2) <= _zMax) {
 			for (unsigned i = 0; i < 3; i++) {
-				tm->setv(i,0.0);
-				tm->setF(i,0.0);
+				tm->setv(i, 0.0);
+				tm->setF(i, 0.0);
 			}
 		}
-			
 	}
-
-
 }
 
-void FixRegion::endStep(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain,
-                         unsigned long simstep) {
-}
-
-        
+void FixRegion::endStep(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain,
+						unsigned long simstep) {}

--- a/src/plugins/FixRegion.h
+++ b/src/plugins/FixRegion.h
@@ -8,11 +8,11 @@
 #ifndef MARDYN_TRUNK_FIXREGION_H
 #define MARDYN_TRUNK_FIXREGION_H
 
-//class DropalignerTest;
-#include "PluginBase.h"
-#include "particleContainer/ParticleContainer.h"
+// class DropalignerTest;
 #include "Domain.h"
+#include "PluginBase.h"
 #include "parallel/DomainDecompBase.h"
+#include "particleContainer/ParticleContainer.h"
 
 //#include "parallel/DomainDecompBase.h"
 
@@ -33,10 +33,9 @@
 * \endcode
 */
 
-class FixRegion : public PluginBase{
-
+class FixRegion : public PluginBase {
 private:
-  	double _xMin;
+	double _xMin;
 	double _yMin;
 	double _zMin;
 	double _xMax;
@@ -46,42 +45,39 @@ private:
 	unsigned long _molCount;
 
 public:
- /*  Dropaligner(){
-	 // SETUP
-        for (unsigned d = 0; d < 3; d++) {
-            _balance[d] = 0.0;
-            _motion[d] = 0.0;
-        }
-    };
-    ~Dropaligner(){};*/
+	/*  Dropaligner(){
+		// SETUP
+		   for (unsigned d = 0; d < 3; d++) {
+			   _balance[d] = 0.0;
+			   _motion[d] = 0.0;
+		   }
+	   };
+	   ~Dropaligner(){};*/
 
 	void init(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) override;
-//        global_log -> debug() << "DropletRealignment enabled" << std::endl;
+	//        global_log -> debug() << "DropletRealignment enabled" << std::endl;
 
-  //      for(unsigned d = 0; d < 3; d++){
- //           _boxLength[d] = domain->getGlobalLength(d);
-//        }
-//    }
+	//      for(unsigned d = 0; d < 3; d++){
+	//           _boxLength[d] = domain->getGlobalLength(d);
+	//        }
+	//    }
 
-	void readXML (XMLfileUnits& xmlconfig) override;
+	void readXML(XMLfileUnits& xmlconfig) override;
 
-    void beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, unsigned long simstep) override;
+	void beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp,
+					  unsigned long simstep) override;
 
-	void afterForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, unsigned long simstep) override;
+	void afterForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp,
+					 unsigned long simstep) override;
 
-    void endStep(
-            ParticleContainer *particleContainer, DomainDecompBase *domainDecomp,
-            Domain *domain, unsigned long simstep) override;
+	void endStep(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain,
+				 unsigned long simstep) override;
 
+	void finish(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) override{};
 
-    void finish(ParticleContainer *particleContainer,
-                DomainDecompBase *domainDecomp, Domain *domain) override {};
+	std::string getPluginName() override { return std::string("FixRegion"); }
 
-    std::string getPluginName()override {return std::string("FixRegion");}
-
-    static PluginBase* createInstance(){return new FixRegion();}
-
+	static PluginBase* createInstance() { return new FixRegion(); }
 };
 
-
-#endif //MARDYN_TRUNK_FIXREGION_H
+#endif  // MARDYN_TRUNK_FIXREGION_H

--- a/src/plugins/FixRegion.h
+++ b/src/plugins/FixRegion.h
@@ -1,0 +1,87 @@
+/*
+ * FixRegion.h
+ *
+ *  Created on: 9 July 2020
+ *      Author: Marx
+ */
+
+#ifndef MARDYN_TRUNK_FIXREGION_H
+#define MARDYN_TRUNK_FIXREGION_H
+
+//class DropalignerTest;
+#include "PluginBase.h"
+#include "particleContainer/ParticleContainer.h"
+#include "Domain.h"
+#include "parallel/DomainDecompBase.h"
+
+//#include "parallel/DomainDecompBase.h"
+
+/** @brief
+* Plugin: can be enabled via config.xml <br>
+*
+* Fixes particles in a given region.<br>
+
+* \code{.xml}
+* <plugin name="FixRegion">
+*			<xmin>50</xmin>
+*			<ymin>60</ymin>
+*			<zmin>50</zmin>
+*			<xmax>50</xmax>
+*			<ymax>60</ymax>
+*			<zmax>50</zmax>
+* </plugin>
+* \endcode
+*/
+
+class FixRegion : public PluginBase{
+
+private:
+  	double _xMin;
+	double _yMin;
+	double _zMin;
+	double _xMax;
+	double _yMax;
+	double _zMax;
+	double _boxLength[3];
+	unsigned long _molCount;
+
+public:
+ /*  Dropaligner(){
+	 // SETUP
+        for (unsigned d = 0; d < 3; d++) {
+            _balance[d] = 0.0;
+            _motion[d] = 0.0;
+        }
+    };
+    ~Dropaligner(){};*/
+
+	void init(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, Domain* domain) override;
+//        global_log -> debug() << "DropletRealignment enabled" << std::endl;
+
+  //      for(unsigned d = 0; d < 3; d++){
+ //           _boxLength[d] = domain->getGlobalLength(d);
+//        }
+//    }
+
+	void readXML (XMLfileUnits& xmlconfig) override;
+
+    void beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, unsigned long simstep) override;
+
+	void afterForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, unsigned long simstep) override;
+
+    void endStep(
+            ParticleContainer *particleContainer, DomainDecompBase *domainDecomp,
+            Domain *domain, unsigned long simstep) override;
+
+
+    void finish(ParticleContainer *particleContainer,
+                DomainDecompBase *domainDecomp, Domain *domain) override {};
+
+    std::string getPluginName()override {return std::string("FixRegion");}
+
+    static PluginBase* createInstance(){return new FixRegion();}
+
+};
+
+
+#endif //MARDYN_TRUNK_FIXREGION_H

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -40,6 +40,7 @@
 // General plugins
 #include "plugins/COMaligner.h"
 #include "plugins/Dropaligner.h"
+#include "plugins/Dropaccelerator.h"
 #include "plugins/ExamplePlugin.h"
 #include "plugins/InMemoryCheckpointing.h"
 #include "plugins/MaxCheck.h"
@@ -73,6 +74,7 @@ void PluginFactory<PluginBase>::registerDefaultPlugins() {
 
 	REGISTER_PLUGIN(COMaligner);
 	REGISTER_PLUGIN(Dropaligner);
+	REGISTER_PLUGIN(Dropaccelerator);
 	REGISTER_PLUGIN(CavityWriter);
 	REGISTER_PLUGIN(CheckpointWriter);
 	REGISTER_PLUGIN(CommunicationPartnerWriter);

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -42,6 +42,7 @@
 #include "plugins/Dropaligner.h"
 #include "plugins/Dropaccelerator.h"
 #include "plugins/ExamplePlugin.h"
+#include "plugins/FixRegion.h"
 #include "plugins/InMemoryCheckpointing.h"
 #include "plugins/MaxCheck.h"
 #include "plugins/Mirror.h"
@@ -81,6 +82,7 @@ void PluginFactory<PluginBase>::registerDefaultPlugins() {
 	REGISTER_PLUGIN(DecompWriter);
 	REGISTER_PLUGIN(EnergyLogWriter);
 	REGISTER_PLUGIN(ExamplePlugin);
+	REGISTER_PLUGIN(FixRegion);
 	REGISTER_PLUGIN(FlopRateWriter);
 	REGISTER_PLUGIN(GammaWriter);
 	REGISTER_PLUGIN(HaloParticleWriter);

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -39,6 +39,7 @@
 
 // General plugins
 #include "plugins/COMaligner.h"
+#include "plugins/Dropaligner.h"
 #include "plugins/ExamplePlugin.h"
 #include "plugins/InMemoryCheckpointing.h"
 #include "plugins/MaxCheck.h"
@@ -71,6 +72,7 @@ void PluginFactory<PluginBase>::registerDefaultPlugins() {
 	global_log->debug() << "REGISTERING PLUGINS" << endl;
 
 	REGISTER_PLUGIN(COMaligner);
+	REGISTER_PLUGIN(Dropaligner);
 	REGISTER_PLUGIN(CavityWriter);
 	REGISTER_PLUGIN(CheckpointWriter);
 	REGISTER_PLUGIN(CommunicationPartnerWriter);


### PR DESCRIPTION
Dropaligner: This plugin is used to fix a liquid droplet within a vapor phase in its position.

It is designed in analogy with the COMaligner. The user specifies the desired center of mass and the radius within which the realignment takes place.

No known issues

Dropaccelerator:

This plugin is used to accelerate a spherical droplet. 
The user specifies the center of mass and radius of the droplet. 
All molecules within this sphere are then marked with the bool variable DROP = true in FullMolecule.
To this selection of molecules a velocity increment is added every time step for a specified amount of steps to speed up the drop to a desired velocity.
The drop velocity is tracked for some time and increased if the desired velocity wasn't reached within the specified time frame.

Issues: After acceleration, the velocity of the droplet is higher than the desired velocity. I observed that the number of particles marked as DROP == true is not constant, which should not be possible if the plugin was operating properly. Is this approach with marking particles using bool variables viable at all? I am also not certain whether beforeForces is the proper function to use here. At which point during a time step does it make the most sense to accelerate particles?

FixRegion:

FixRegion: 

Function: This plugin is supposed to keep particles within a specified volume from moving during simulation. The particles still interact with non-fixed particles via forces.
Specifically, this plugin is supposed to fix an atomistic wall, by immobilizing the bottom layers of the wall.
These bottom layers of the wall hold the rest of the wall in place via force interactions.

Implementation: Every time step the force and velocity of the particles within the specified volume is set to zero.

Problems: In test simulations of a sessile droplet on the wall, the droplet exhibits an unusual pressure profile.
I am not sure what causes this. I previously tried a similar approach as in the Dropaccelerator plugin, wherein I marked the particles of interest with a bool.
I then excluded these particles from the leapfrog integration. This approach also caused problems as the number of marked particles did not remain constant.
The current implementation however causes the aforementioned problems with the pressure. 
Is this way of realizing a fixed region sensible? At which point during a time step would it make the most sense to set velocities and forces to zero (if at all)?

