### PR TITLE
[WIP] Adds the possibility to store additional, optional data for molecules.

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -121,6 +121,7 @@ Simulation::Simulation()
 	_timeFromStart.start();
 	_ensemble = new CanonicalEnsemble();
 	initialize();
+	_optionalParticleData = std::make_unique<OptionalParticleData>();
 }
 
 Simulation::~Simulation() {

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -9,6 +9,11 @@
 #include "thermostats/VelocityScalingThermostat.h"
 
 // plugins
+#include <list>
+#include <string>
+#include <vector>
+#include "io/TaskTimingProfiler.h"
+#include "particleContainer/OptionalParticleData.h"
 #include "plugins/PluginFactory.h"
 
 #if !defined (SIMULATION_SRC) or defined (IN_IDE_PARSER)
@@ -24,11 +29,6 @@ class Ensemble;
 
 /** Reference to the global simulation object */
 #define _simulation (*global_simulation)
-
-#include <list>
-#include <vector>
-#include <string>
-#include <io/TaskTimingProfiler.h>
 
 #ifdef STEEREO
 class SteereoSimSteering;
@@ -352,6 +352,9 @@ private:
 
 	/** Datastructure for finding neighbours efficiently */
 	ParticleContainer* _moleculeContainer;
+
+	/** Dynamic  **/
+	std::unique_ptr<OptionalParticleData> _optionalParticleData;
 
 	/** Handler describing what action is to be done for each particle pair */
 	ParticlePairsHandler* _particlePairsHandler;

--- a/src/particleContainer/OptionalParticleData.cpp
+++ b/src/particleContainer/OptionalParticleData.cpp
@@ -1,0 +1,70 @@
+/**
+ * @file OptionalParticleData.cpp
+ * @author seckler
+ * @date 13.08.20
+ */
+
+#include <tuple>
+
+#include "OptionalParticleData.h"
+void OptionalParticleData::createMap(const std::string& dataName,
+									 OptionalParticleDataTypes::SupportedTypesVariant defaultValue) {
+	// Add default value and check whether it doesn't exist, yet.
+	auto [iterator, inserted] = _defaultValues.emplace(dataName, defaultValue);
+	if (not inserted) {
+		throw std::runtime_error("OptionalParticleData::createMap: map with key " + dataName + " already exists.");
+	}
+	std::visit(
+		[&](auto value) {
+			// Creates map with correct type.
+			_particleData.emplace(dataName, std::unordered_map<size_t, decltype(value)>(value));
+		},
+		defaultValue);
+}
+
+void OptionalParticleData::createParticleDataWithDefaultValues(size_t id) {
+	auto defaultValueIter = _defaultValues.begin();
+	auto mapIter = _particleData.begin();
+	for (; mapIter != _particleData.end(); ++mapIter, ++defaultValueIter) {
+		std::visit(
+			[=](auto& dataMap) {
+				using map_type = std::remove_reference_t<decltype(dataMap)>;
+				// Emplace default value with key id.
+				dataMap.emplace(id, std::get<typename map_type::mapped_type>(defaultValueIter->second));
+			},
+			mapIter->second);
+	}
+}
+
+void OptionalParticleData::removeParticleData(size_t id) {
+	auto defaultValueIter = _defaultValues.begin();
+	auto mapIter = _particleData.begin();
+	for (; mapIter != _particleData.end(); ++mapIter, ++defaultValueIter) {
+		std::visit(
+			[=](auto& dataMap) {
+				// Remove value with key id.
+				dataMap.erase(id);
+			},
+			mapIter->second);
+	}
+}
+
+OptionalParticleDataTypes::SupportedTypesVariant OptionalParticleData::getData(const std::string& dataName, size_t id) {
+	return std::visit(
+		[=](auto& dataMap) {
+			// Get value of map with key id.
+			return dataMap[id];
+		},
+		_particleData[dataName]);
+}
+
+void OptionalParticleData::setData(const std::string& dataName, size_t id,
+								   OptionalParticleDataTypes::SupportedTypesVariant value) {
+	std::visit(
+		[=](auto& dataMap) {
+			using map_type = std::remove_reference_t<decltype(dataMap)>;
+			// Set value of map with key id.
+			dataMap[id] = std::get<typename map_type::mapped_type>(value);
+		},
+		_particleData[dataName]);
+}

--- a/src/particleContainer/OptionalParticleData.h
+++ b/src/particleContainer/OptionalParticleData.h
@@ -1,0 +1,92 @@
+/**
+ * @file OptionalParticleData.h
+ * @author seckler
+ * @date 13.08.20
+ */
+
+#pragma once
+
+#include <any>
+#include <unordered_map>
+#include <variant>
+
+/**
+ * Helper class to generate valid types.
+ * @tparam SupportedTypes
+ */
+template <typename... SupportedTypes>
+struct OptionalParticleDataTypesWithTemplate {
+	/**
+	 * Internal type of the map from a particle ID to the data.
+	 * @note Here we choose an unordered_map for fast access.
+	 */
+	template <typename Type>
+	using ParticleIdToDataMap = std::unordered_map<size_t, Type>;
+
+	/**
+	 * Map From name of the data to ParticleIdToDataMap.
+	 */
+	using NameToParticleDataMap = std::unordered_map<std::string, std::variant<ParticleIdToDataMap<SupportedTypes>...>>;
+
+	/**
+	 * Variant for the basic types.
+	 */
+	using SupportedTypesVariant = std::variant<SupportedTypes...>;
+
+	/**
+	 * Map From name of the data to default value.
+	 */
+	using NameToDefaultValueMap = std::unordered_map<std::string, SupportedTypesVariant>;
+};
+
+// ADD a type here if you want more supported types:
+using OptionalParticleDataTypes = OptionalParticleDataTypesWithTemplate<double>;
+
+/**
+ * Class to store optional particle data.
+ *
+ * This class assumes that before any particles are added, all maps are created.
+ */
+class OptionalParticleData {
+public:
+	/**
+	 * Creates a map and associates a default value to it.
+	 * @param dataName
+	 * @param defaultValue
+	 */
+	void createMap(const std::string& dataName, OptionalParticleDataTypes::SupportedTypesVariant defaultValue);
+
+	/**
+	 * Creates default values for all present maps.
+	 * @param id
+	 * @note: do not use from plugin!
+	 */
+	void createParticleDataWithDefaultValues(size_t id);
+
+	/**
+	 * Removes the data of one particle.
+	 * @param id
+	 * @note: do not use from plugin!
+	 */
+	void removeParticleData(size_t id);
+
+	/**
+	 * Get the data of the data associated with dataName for one particle.
+	 * @param dataName The name of the data.
+	 * @param id The id of the particle.
+	 * @return Returns a variant of all supported values.
+	 */
+	OptionalParticleDataTypes::SupportedTypesVariant getData(const std::string& dataName, size_t id);
+
+	/**
+	 * Set the data associated with dataName for one particle.
+	 * @param dataName The name of the data.
+	 * @param id The id of the particle.
+	 * @param value The value to which the data should be set.
+	 */
+	void setData(const std::string& dataName, size_t id, OptionalParticleDataTypes::SupportedTypesVariant value);
+
+private:
+	OptionalParticleDataTypes::NameToParticleDataMap _particleData;
+	OptionalParticleDataTypes::NameToDefaultValueMap _defaultValues;
+};


### PR DESCRIPTION
**WARNING: not yet finished!**

# Description

Adds the possibility to store additional, optional data for molecules.
This is done by creating maps within the new `OptionalParticleData` class.


# TODOs
- [ ] The new data has to be communicated!
- [ ] Easy access through iterators.

# Problems
- [ ] The ID of particles is not unique (because of halo particles). 
    - Do we store it only for "owned" molecules?
    - If we don't how do we delete the information for halo particles?
    - If we don't delete it, memory might become an issue.
    - Possible solution: keep track of the number of particles with a specific id.
- the current implementation requires c++17. Do we want that?

## Resolved Issues

- [ ] ref #58 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Test that checks the behavior

