### PR TITLE
[DecompVTK] Add id info per cell

### DIFF
--- a/tools/decomp2vtkConverter.py
+++ b/tools/decomp2vtkConverter.py
@@ -93,7 +93,16 @@ for cell in celllist:
 
 f_out.write('CELL_TYPES ' + str(numcells) + '\n')
 for cell in celllist:
-    f_out.write('11\n')    
+    f_out.write('11\n')
+
+# add ids for every cell. They are not necessarily the same as the MPI Rank ID
+f_out.write('CELL_DATA ' + str(numcells) + '\n')
+f_out.write('SCALARS cell_scalars int 1\n')
+f_out.write('LOOKUP_TABLE default\n')
+i=0
+for cell in celllist:
+    f_out.write(str(i) + '\n')
+    i = i + 1
 
 f_in.close()
 f_out.close()


### PR DESCRIPTION
# Description

When converting the decomp files from the decomposition writer to VTKs add IDs so that ParaView can apply different colors to the cells.

