### PR TITLE
Removes endl from loops and replaces them with '\n'

### DIFF
--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -526,12 +526,12 @@ void Domain::writeCheckpointHeader(string filename,
 			*/
 			vector<Component>* components = _simulation.getEnsemble()->getComponents();
 			checkpointfilestream << " NumberOfComponents\t" << components->size() << endl;
-			for(vector<Component>::const_iterator pos=components->begin();pos!=components->end();++pos){
+			for(auto pos=components->begin();pos!=components->end();++pos){
 				pos->write(checkpointfilestream);
 			}
 			unsigned int numperline=_simulation.getEnsemble()->getComponents()->size();
 			unsigned int iout=0;
-			for(vector<double>::const_iterator pos=_mixcoeff.begin();pos!=_mixcoeff.end();++pos){
+			for(auto pos=_mixcoeff.begin();pos!=_mixcoeff.end();++pos){
 				checkpointfilestream << *pos;
 				iout++;
 				// 2 parameters (xi and eta)
@@ -548,7 +548,7 @@ void Domain::writeCheckpointHeader(string filename,
 				}
 			}
 			checkpointfilestream << _epsilonRF << endl;
-			for( map<int, bool>::iterator uutit = this->_universalUndirectedThermostat.begin();
+			for( auto uutit = this->_universalUndirectedThermostat.begin();
 					uutit != this->_universalUndirectedThermostat.end();
 					uutit++ )
 			{

--- a/src/io/PovWriter.cpp
+++ b/src/io/PovWriter.cpp
@@ -132,7 +132,7 @@ void PovWriter::endStep(ParticleContainer *particleContainer,
 			      << mrot[2][0] << "," << mrot[2][1] << "," << mrot[2][2] << ","
 			      << pos->r(0) << "," << pos->r(1) << "," << pos->r(2)
 			      << ">";
-			ostrm << "}" << endl;
+			ostrm << "}" << "\n";
 		}
 		ostrm.close();
 	}

--- a/src/io/XyzWriter.cpp
+++ b/src/io/XyzWriter.cpp
@@ -18,23 +18,23 @@ using namespace std;
 void XyzWriter::readXML(XMLfileUnits& xmlconfig) {
 	_writeFrequency = 1;
 	xmlconfig.getNodeValue("writefrequency", _writeFrequency);
-	global_log->info() << "Write frequency: " << _writeFrequency << endl;
+	global_log->info() << "Write frequency: " << _writeFrequency << std::endl;
 
 	_outputPrefix = "mardyn";
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
-	global_log->info() << "Output prefix: " << _outputPrefix << endl;
+	global_log->info() << "Output prefix: " << _outputPrefix << std::endl;
 
 	int incremental = 1;
 	xmlconfig.getNodeValue("incremental", incremental);
 	_incremental = (incremental != 0);
-	global_log->info() << "Incremental numbers: " << _incremental << endl;
+	global_log->info() << "Incremental numbers: " << _incremental << std::endl;
 
 	int appendTimestamp = 0;
 	xmlconfig.getNodeValue("appendTimestamp", appendTimestamp);
 	if(appendTimestamp > 0) {
 		_appendTimestamp = true;
 	}
-	global_log->info() << "Append timestamp: " << _appendTimestamp << endl;
+	global_log->info() << "Append timestamp: " << _appendTimestamp << std::endl;
 }
 
 void XyzWriter::init(ParticleContainer * /*particleContainer*/, DomainDecompBase * /*domainDecomp*/,
@@ -65,8 +65,8 @@ void XyzWriter::endStep(ParticleContainer *particleContainer, DomainDecompBase *
 			for (unsigned i=0; i< components->size(); i++){
 				number += (*components)[i].getNumMolecules()*((*components)[i].numLJcenters() + (*components)[i].numDipoles() + (*components)[i].numCharges() + (*components)[i].numQuadrupoles());
 			}
-			xyzfilestream << number << endl;
-			xyzfilestream << "comment line" << endl;
+			xyzfilestream << number << "\n";
+			xyzfilestream << "comment line" << "\n";
 			xyzfilestream.close();
 		}
 		for( int process = 0; process < domainDecomp->getNumProcs(); process++ ){
@@ -80,7 +80,7 @@ void XyzWriter::endStep(ParticleContainer *particleContainer, DomainDecompBase *
 						else if( tempMol->componentid() == 2 ) { xyzfilestream << "C ";}
 						else if( tempMol->componentid() == 3 ) { xyzfilestream << "O ";}
 						else { xyzfilestream << "H ";}
-						xyzfilestream << tempMol->r(0) + tempMol->ljcenter_d(i)[0] << "\t" << tempMol->r(1) + tempMol->ljcenter_d(i)[1] << "\t" << tempMol->r(2) + tempMol->ljcenter_d(i)[2] << endl;
+						xyzfilestream << tempMol->r(0) + tempMol->ljcenter_d(i)[0] << "\t" << tempMol->r(1) + tempMol->ljcenter_d(i)[1] << "\t" << tempMol->r(2) + tempMol->ljcenter_d(i)[2] << "\n";
 					}
 					for (unsigned i=0; i< tempMol->numDipoles(); i++){
 						if( tempMol->componentid() == 0) { xyzfilestream << "O ";}
@@ -88,7 +88,7 @@ void XyzWriter::endStep(ParticleContainer *particleContainer, DomainDecompBase *
 						else if( tempMol->componentid() == 2 ) { xyzfilestream << "Xe ";}
 						else if( tempMol->componentid() == 3 ) { xyzfilestream << "Ar ";}
 						else { xyzfilestream << "C ";}
-						xyzfilestream << tempMol->r(0) + tempMol->dipole_d(i)[0] << "\t" << tempMol->r(1) + tempMol->dipole_d(i)[1] << "\t" << tempMol->r(2) + tempMol->dipole_d(i)[2] << endl;
+						xyzfilestream << tempMol->r(0) + tempMol->dipole_d(i)[0] << "\t" << tempMol->r(1) + tempMol->dipole_d(i)[1] << "\t" << tempMol->r(2) + tempMol->dipole_d(i)[2] << "\n";
 					}
 					for (unsigned i=0; i< tempMol->numQuadrupoles(); i++){
 						if( tempMol->componentid() == 0) { xyzfilestream << "C ";}
@@ -96,7 +96,7 @@ void XyzWriter::endStep(ParticleContainer *particleContainer, DomainDecompBase *
 						else if( tempMol->componentid() == 2 ) { xyzfilestream << "H ";}
 						else if( tempMol->componentid() == 3 ) { xyzfilestream << "Xe ";}
 						else { xyzfilestream << "O ";}
-						xyzfilestream << tempMol->r(0) + tempMol->quadrupole_d(i)[0] << "\t" << tempMol->r(1) + tempMol->quadrupole_d(i)[1] << "\t" << tempMol->r(2) + tempMol->quadrupole_d(i)[2] << endl;
+						xyzfilestream << tempMol->r(0) + tempMol->quadrupole_d(i)[0] << "\t" << tempMol->r(1) + tempMol->quadrupole_d(i)[1] << "\t" << tempMol->r(2) + tempMol->quadrupole_d(i)[2] << "\n";
 					}
 					for (unsigned i=0; i< tempMol->numCharges(); i++){
 						if( tempMol->componentid() == 0) { xyzfilestream << "H ";}
@@ -104,7 +104,7 @@ void XyzWriter::endStep(ParticleContainer *particleContainer, DomainDecompBase *
 						else if( tempMol->componentid() == 2 ) { xyzfilestream << "Xe ";}
 						else if( tempMol->componentid() == 3 ) { xyzfilestream << "Ar ";}
 						else { xyzfilestream << "C ";}
-						xyzfilestream << tempMol->r(0) + tempMol->charge_d(i)[0] << "\t" << tempMol->r(1) + tempMol->charge_d(i)[1] << "\t" << tempMol->r(2) + tempMol->charge_d(i)[2] << endl;
+						xyzfilestream << tempMol->r(0) + tempMol->charge_d(i)[0] << "\t" << tempMol->r(1) + tempMol->charge_d(i)[1] << "\t" << tempMol->r(2) + tempMol->charge_d(i)[2] << "\n";
 					}
 				}
 				xyzfilestream.close();

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -208,19 +208,19 @@ void Component::write(std::ostream& ostrm) const {
 	ostrm << _ljcenters.size() << "\t" << _charges.size() << "\t"
 	      << _dipoles.size() << "\t" << _quadrupoles.size() << "\t"
 		  << 0 << "\n";  // the 0 indicates a zero amount of tersoff sites.
-	for (std::vector<LJcenter>::const_iterator pos = _ljcenters.begin(); pos != _ljcenters.end(); ++pos) {
+	for (auto pos = _ljcenters.cbegin(); pos != _ljcenters.end(); ++pos) {
 		pos->write(ostrm);
 		ostrm << endl;
 	}
-	for (std::vector<Charge>::const_iterator pos = _charges.begin(); pos != _charges.end(); ++pos) {
+	for (auto pos = _charges.cbegin(); pos != _charges.end(); ++pos) {
 		pos->write(ostrm);
 		ostrm << endl;
 	}
-	for (std::vector<Dipole>::const_iterator pos = _dipoles.begin(); pos != _dipoles.end(); ++pos) {
+	for (auto pos = _dipoles.cbegin(); pos != _dipoles.end(); ++pos) {
 		pos->write(ostrm);
 		ostrm << endl;
 	}
-	for (std::vector<Quadrupole>::const_iterator pos = _quadrupoles.begin(); pos != _quadrupoles.end(); ++pos) {
+	for (auto pos = _quadrupoles.cbegin(); pos != _quadrupoles.end(); ++pos) {
 		pos->write(ostrm);
 		ostrm << endl;
 	}
@@ -228,7 +228,7 @@ void Component::write(std::ostream& ostrm) const {
 }
 
 void Component::writeVIM(std::ostream& ostrm) {
-	for (std::vector<LJcenter>::const_iterator pos = _ljcenters.begin(); pos != _ljcenters.end(); ++pos) {
+	for (auto pos = _ljcenters.cbegin(); pos != _ljcenters.end(); ++pos) {
 		ostrm << "~ " << this->_id + 1 << " LJ " << setw(7) << pos->rx() << ' '
 		      << setw(7) << pos->ry() << ' ' << setw(7) << pos->rz() << ' '
 		      << setw(6) << pos->sigma() << ' ' << setw(2) << (1 + (this->_id % 9)) << "\n";

--- a/src/molecules/FullMolecule.cpp
+++ b/src/molecules/FullMolecule.cpp
@@ -445,7 +445,7 @@ void FullMolecule::write(ostream& ostrm) const {
 	      << _v[0] << " " << _v[1] << " " << _v[2] << "\t"
 	      << _q.qw() << " " << _q.qx() << " " << _q.qy() << " " << _q.qz() << "\t"
 	      << _L[0] << " " << _L[1] << " " << _L[2] << "\t"
-	      << endl;
+	      << "\n";
 }
 
 void FullMolecule::writeBinary(std::ostream& ostrm) const {

--- a/src/molecules/MoleculeRMM.cpp
+++ b/src/molecules/MoleculeRMM.cpp
@@ -118,7 +118,7 @@ void MoleculeRMM::write(std::ostream& ostrm) const {
 	ostrm << getID() << "\t"
 		  << r(0) << " " << r(1) << " " << r(2) << "\t"
 		  << v(0) << " " << v(1) << " " << v(2) << "\t"
-		  << endl;
+		  << "\n";
 }
 
 std::ostream& operator<<( std::ostream& os, const MoleculeRMM& m ) {


### PR DESCRIPTION
# Description

Replaces all `std::endl` with "\n" to reduce flushing.

Speedups (measured under WSL so maybe not really realistic...):
- XyzWriter -- speedup = 30x
- CheckpointWriter in ascii mode (final IO) -- speedup = 10x

