### PR TITLE
kdd adjustable minNumCellsPerDimension

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -310,7 +310,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			}
 			else if(parallelisationtype == "KDDecomposition") {
 				delete _domainDecomposition;
-				_domainDecomposition = new KDDecomposition(getcutoffRadius(), _domain, _ensemble->getComponents()->size());
+				_domainDecomposition = new KDDecomposition(getcutoffRadius(), _ensemble->getComponents()->size());
 			} else if (parallelisationtype == "GeneralDomainDecomposition") {
 				double skin = 0.;
 				// we need the skin here, so we extract it from the AutoPas container's xml,
@@ -353,6 +353,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			//_domainDecomposition = new DomainDecompBase();  // already set in initialize()
 		#endif
 			_domainDecomposition->readXML(xmlconfig);
+            if(auto kdd = dynamic_cast<KDDecomposition*>(_domainDecomposition)) {
+                kdd->init(_domain);
+			}
 
 			string loadTimerStr("SIMULATION_COMPUTATION");
 			xmlconfig.getNodeValue("timerForLoad", loadTimerStr);

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -353,9 +353,11 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			//_domainDecomposition = new DomainDecompBase();  // already set in initialize()
 		#endif
 			_domainDecomposition->readXML(xmlconfig);
+        #ifdef ENABLE_MPI
             if(auto kdd = dynamic_cast<KDDecomposition*>(_domainDecomposition)) {
                 kdd->init(_domain);
 			}
+        #endif
 
 			string loadTimerStr("SIMULATION_COMPUTATION");
 			xmlconfig.getNodeValue("timerForLoad", loadTimerStr);

--- a/src/parallel/KDDStaticValues.cpp
+++ b/src/parallel/KDDStaticValues.cpp
@@ -1,0 +1,4 @@
+
+#include "KDDStaticValues.h"
+
+unsigned int KDDStaticValues::minNumCellsPerDimension = 2u;

--- a/src/parallel/KDDStaticValues.h
+++ b/src/parallel/KDDStaticValues.h
@@ -1,0 +1,11 @@
+#pragma once
+
+
+/**
+ * Class to hold static values for kdd.
+ */
+class KDDStaticValues {
+public:
+	/// Minimal number of cells in one dimension
+	static unsigned int minNumCellsPerDimension;
+};

--- a/src/parallel/KDDecomposition.h
+++ b/src/parallel/KDDecomposition.h
@@ -55,8 +55,10 @@ class KDDecomposition: public DomainDecompMPIBase {
 	 * 	                  then it tests cuts in all Dimensions (not only the biggest) if a KDNode has less processors,
 	 * 	                  than the threshold
 	 */
-	KDDecomposition(double cutoffRadius, Domain* domain, int numParticleTypes, int updateFrequency = 100,  int fullSearchThreshold = 2, bool hetero=false,
+	KDDecomposition(double cutoffRadius, int numParticleTypes, int updateFrequency = 100,  int fullSearchThreshold = 2, bool hetero=false,
 			bool cutsmaller=false, bool forceRatio=false, int splitThresh = std::numeric_limits<int>::max());
+
+	void init(Domain* domain);
 
 	KDDecomposition();
 
@@ -81,6 +83,7 @@ class KDDecomposition: public DomainDecompMPIBase {
 		 <useExistingFiles>BOOL</useExistingFiles>
 		 <doMeasureLoadCalc>BOOL</doMeasureLoadCalc>
 		 <deviationReductionOperation>max OR sum</deviationReductionOperation>
+		 <minNumCellsPerDimension>UINT</minNumCellsPerDimension> <!--Has to be bigger than 0-->
 	   </parallelisation>
 	   \endcode
 	 */

--- a/src/parallel/KDNode.cpp
+++ b/src/parallel/KDNode.cpp
@@ -156,7 +156,7 @@ unsigned int KDNode::getNumMaxProcs() {
 
 void KDNode::split(int divDimension, int splitIndex, int numProcsLeft) {
 	mardyn_assert(_numProcs > 1);
-	mardyn_assert(splitIndex >= _lowCorner[divDimension] + (KDDStaticValues::minNumCellsPerDimension-1));
+	mardyn_assert(splitIndex >= _lowCorner[divDimension] + (KDDStaticValues::minNumCellsPerDimension - 1));
 	mardyn_assert(splitIndex < _highCorner[divDimension]);
 
 	bool coversAll[KDDIM];

--- a/src/parallel/KDNode.cpp
+++ b/src/parallel/KDNode.cpp
@@ -8,6 +8,7 @@
 #include "io/vtk/VTKGridVertex.h"
 #include "io/vtk/VTKGridCell.h"
 #endif
+#include "KDDStaticValues.h"
 #include "utils/Logger.h"
 
 #include <algorithm> /* for min and max ?*/
@@ -145,17 +146,17 @@ bool KDNode::isResolvable() {
 }
 
 unsigned int KDNode::getNumMaxProcs() {
-	// we need at least 2 cells in each dimension per process (
+	// we need at least KDDStaticValues::minNumCellsPerDimension cells in each dimension per process.
 	unsigned int maxProcs = 1;
 	for (int dim = 0; dim < 3; dim++) {
-		maxProcs *= (_highCorner[dim] - _lowCorner[dim] + 1) / 2;
+		maxProcs *= (_highCorner[dim] - _lowCorner[dim] + 1) / KDDStaticValues::minNumCellsPerDimension;
 	}
 	return maxProcs;
 }
 
 void KDNode::split(int divDimension, int splitIndex, int numProcsLeft) {
 	mardyn_assert(_numProcs > 1);
-	mardyn_assert(splitIndex > _lowCorner[divDimension]);
+	mardyn_assert(splitIndex >= _lowCorner[divDimension] + (KDDStaticValues::minNumCellsPerDimension-1));
 	mardyn_assert(splitIndex < _highCorner[divDimension]);
 
 	bool coversAll[KDDIM];

--- a/src/parallel/KDNode.h
+++ b/src/parallel/KDNode.h
@@ -165,7 +165,8 @@ public:
 	 *
 	 * @param dimension the dimension \in [0;KDDIM-1] along which this node is split
 	 * @param splitIndex the index of the corner cell for the new left child
-	 *        (note: must be in ] _lowCorner[dimension]; _highCorner[dimension] [.
+	 *        (note: must be in bigger or equal to _lowCorner[divDimension] + (KDDStaticValues::minNumCellsPerDimension-1)
+	 *        and smaller than _highCorner[dimension].
 	 * @param numProcsLeft the number of processors for the left child. The number
 	 *        of processors for the right child is calculated.
 	 */
@@ -245,7 +246,7 @@ public:
 	 */
 	double _deviation;
 
-	// level of this node (at root node, level = 0)
+	/// level of this node (at root node, level = 0)
 	int _level;
 
 private:

--- a/src/parallel/tests/KDDecompositionTest.cpp
+++ b/src/parallel/tests/KDDecompositionTest.cpp
@@ -35,7 +35,8 @@ void KDDecompositionTest::testNoDuplicatedParticlesFilename(
 	_domain->setGlobalLength(0, domainLength);
 	_domain->setGlobalLength(1, domainLength);
 	_domain->setGlobalLength(2, domainLength);
-	kdd = new KDDecomposition(cutoff, _domain, 3, 1, 4);
+	kdd = new KDDecomposition(cutoff, 3, 1, 4);
+	kdd->init(_domain);
 	_domainDecomposition = kdd;
 	_rank = kdd->_rank;
 	ParticleContainer* container = initializeFromFile(
@@ -79,7 +80,8 @@ void KDDecompositionTest::testHaloCorrect() {
 	_domain->setGlobalLength(1, globalLength);
 	_domain->setGlobalLength(2, globalLength);
 	double cutoff = 2.5;
-	kdd = new KDDecomposition(cutoff, _domain, 1, 5, 4);
+	kdd = new KDDecomposition(cutoff, 1, 5, 4);
+	kdd->init(_domain);
 	_domainDecomposition = kdd;
 	_rank = kdd->_rank;
 
@@ -154,7 +156,8 @@ void KDDecompositionTest::testNoLostParticlesFilename(const char * filename,
 	_domain->setGlobalLength(0, domainLength);
 	_domain->setGlobalLength(1, domainLength);
 	_domain->setGlobalLength(2, domainLength);
-	kdd = new KDDecomposition(cutoff, _domain, 3, 1, 4);
+	kdd = new KDDecomposition(cutoff, 3, 1, 4);
+    kdd->init(_domain);
 	_domainDecomposition = kdd;
 	_rank = kdd->_rank;
 
@@ -312,7 +315,8 @@ void KDDecompositionTest::testCompleteTreeInfo() {
 				0, 0, coversAll, 0);
 		result.buildKDTree();
 
-		KDDecomposition decomposition(1.0, _domain, 1, 1.0, 10);
+		KDDecomposition decomposition(1.0, 1, 1.0, 10);
+        decomposition.init(_domain);
 		KDNode * toCleanUp = root;
 		decomposition.completeTreeInfo(root, ownArea);
 		delete toCleanUp;
@@ -339,7 +343,8 @@ void KDDecompositionTest::testRebalancingDeadlocks() {
 		_domain->setGlobalLength(0, boxL);
 		_domain->setGlobalLength(1, boxL);
 		_domain->setGlobalLength(2, boxL);
-		kdd = new KDDecomposition(cutOff, _domain, 1, 1, fullSearchThreshold);
+		kdd = new KDDecomposition(cutOff, 1, 1, fullSearchThreshold);
+        kdd->init(_domain);
 
 		double bBoxMin[3];
 		double bBoxMax[3];
@@ -445,7 +450,8 @@ void KDDecompositionTest::testbalanceAndExchange() {
 	inputReader.setPhaseSpaceFile(fileName2.c_str());
 	inputReader.readPhaseSpaceHeader(_domain, 1.0);
 
-	kdd = new KDDecomposition(cutOff, _domain, 1, 1, fullSearchThreshold);
+	kdd = new KDDecomposition(cutOff, 1, 1, fullSearchThreshold);
+	kdd->init(_domain);
 	_domainDecomposition = kdd;
 
 	_rank = kdd->_rank;

--- a/src/parallel/tests/KDDecompositionTest.cpp
+++ b/src/parallel/tests/KDDecompositionTest.cpp
@@ -157,7 +157,7 @@ void KDDecompositionTest::testNoLostParticlesFilename(const char * filename,
 	_domain->setGlobalLength(1, domainLength);
 	_domain->setGlobalLength(2, domainLength);
 	kdd = new KDDecomposition(cutoff, 3, 1, 4);
-    kdd->init(_domain);
+	kdd->init(_domain);
 	_domainDecomposition = kdd;
 	_rank = kdd->_rank;
 
@@ -316,7 +316,7 @@ void KDDecompositionTest::testCompleteTreeInfo() {
 		result.buildKDTree();
 
 		KDDecomposition decomposition(1.0, 1, 1.0, 10);
-        decomposition.init(_domain);
+		decomposition.init(_domain);
 		KDNode * toCleanUp = root;
 		decomposition.completeTreeInfo(root, ownArea);
 		delete toCleanUp;
@@ -344,7 +344,7 @@ void KDDecompositionTest::testRebalancingDeadlocks() {
 		_domain->setGlobalLength(1, boxL);
 		_domain->setGlobalLength(2, boxL);
 		kdd = new KDDecomposition(cutOff, 1, 1, fullSearchThreshold);
-        kdd->init(_domain);
+		kdd->init(_domain);
 
 		double bBoxMin[3];
 		double bBoxMax[3];

--- a/src/particleContainer/TraversalTuner.h
+++ b/src/particleContainer/TraversalTuner.h
@@ -152,8 +152,11 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 	else
 		global_log->warning() << "Using unknown traversal." << endl;
 
-	mardyn_assert(_optimalTraversal->maxCellsInCutoff() >= _cellsInCutoff);
-
+	if (_optimalTraversal->maxCellsInCutoff() < _cellsInCutoff) {
+		global_log->error() << "Traversal supports up to " << _optimalTraversal->maxCellsInCutoff()
+							<< " cells in cutoff, but value is chosen as " << _cellsInCutoff << std::endl;
+		Simulation::exit(45);
+	}
 }
 
 template<class CellTemplate>

--- a/src/particleContainer/TraversalTuner.h
+++ b/src/particleContainer/TraversalTuner.h
@@ -152,7 +152,7 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 	else
 		global_log->warning() << "Using unknown traversal." << endl;
 
-	if (_optimalTraversal->maxCellsInCutoff() < _cellsInCutoff) {
+	if (_cellsInCutoff > _optimalTraversal->maxCellsInCutoff()) {
 		global_log->error() << "Traversal supports up to " << _optimalTraversal->maxCellsInCutoff()
 							<< " cells in cutoff, but value is chosen as " << _cellsInCutoff << std::endl;
 		Simulation::exit(45);

--- a/src/particleContainer/TraversalTuner.h
+++ b/src/particleContainer/TraversalTuner.h
@@ -129,18 +129,18 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 	_optimalTraversal = _traversals[selectedTraversal].first;
 
 	// log traversal
-    if (dynamic_cast<HalfShellTraversal<CellTemplate> *>(_optimalTraversal))
-    	global_log->info() << "Using HalfShellTraversal." << endl;
-    else if (dynamic_cast<OriginalCellPairTraversal<CellTemplate> *>(_optimalTraversal))
-        global_log->info() << "Using OriginalCellPairTraversal." << endl;
-    else if (dynamic_cast<C08CellPairTraversal<CellTemplate> *>(_optimalTraversal))
-        global_log->info() << "Using C08CellPairTraversal without eighthShell." << endl;
-    else if (dynamic_cast<C08CellPairTraversal<CellTemplate, true> *>(_optimalTraversal))
-	    global_log->info() << "Using C08CellPairTraversal with eighthShell." << endl;
-    else if (dynamic_cast<C04CellPairTraversal<CellTemplate> *>(_optimalTraversal))
-    	global_log->info() << "Using C04CellPairTraversal." << endl;
-    else if (dynamic_cast<MidpointTraversal<CellTemplate> *>(_optimalTraversal))
-        global_log->info() << "Using MidpointTraversal." << endl;
+	if (dynamic_cast<HalfShellTraversal<CellTemplate> *>(_optimalTraversal))
+		global_log->info() << "Using HalfShellTraversal." << endl;
+	else if (dynamic_cast<OriginalCellPairTraversal<CellTemplate> *>(_optimalTraversal))
+		global_log->info() << "Using OriginalCellPairTraversal." << endl;
+	else if (dynamic_cast<C08CellPairTraversal<CellTemplate> *>(_optimalTraversal))
+		global_log->info() << "Using C08CellPairTraversal without eighthShell." << endl;
+	else if (dynamic_cast<C08CellPairTraversal<CellTemplate, true> *>(_optimalTraversal))
+		global_log->info() << "Using C08CellPairTraversal with eighthShell." << endl;
+	else if (dynamic_cast<C04CellPairTraversal<CellTemplate> *>(_optimalTraversal))
+		global_log->info() << "Using C04CellPairTraversal." << endl;
+	else if (dynamic_cast<MidpointTraversal<CellTemplate> *>(_optimalTraversal))
+		global_log->info() << "Using MidpointTraversal." << endl;
 	else if (dynamic_cast<QuickschedTraversal<CellTemplate> *>(_optimalTraversal)) {
 		global_log->info() << "Using QuickschedTraversal." << endl;
 #ifndef QUICKSCHED
@@ -151,7 +151,6 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 		global_log->info() << "Using SlicedCellPairTraversal." << endl;
 	else
 		global_log->warning() << "Using unknown traversal." << endl;
-
 
 	mardyn_assert(_optimalTraversal->maxCellsInCutoff() >= _cellsInCutoff);
 
@@ -174,22 +173,21 @@ void TraversalTuner<CellTemplate>::readXML(XMLfileUnits &xmlconfig) {
 	else if (traversalType.find("c08") != string::npos)
 		selectedTraversal = C08;
 	else if (traversalType.find("c04") != string::npos)
-			selectedTraversal = C04;
+		selectedTraversal = C04;
 	else if (traversalType.find("qui") != string::npos)
 		selectedTraversal = QSCHED;
 	else if (traversalType.find("slice") != string::npos)
 		selectedTraversal = SLICED;
 	else if (traversalType.find("ori") != string::npos)
 		selectedTraversal = ORIGINAL;
-    else if (traversalType.find("hs") != string::npos)
-        selectedTraversal = HS;
-    else if (traversalType.find("mp") != string::npos)
-        selectedTraversal = MP;
-    else if (traversalType.find("nt") != string::npos){
-        global_log->error() << "nt method not yet properly implemented. please select a different method." << std::endl;
+	else if (traversalType.find("hs") != string::npos)
+		selectedTraversal = HS;
+	else if (traversalType.find("mp") != string::npos)
+		selectedTraversal = MP;
+	else if (traversalType.find("nt") != string::npos) {
+		global_log->error() << "nt method not yet properly implemented. please select a different method." << std::endl;
 		Simulation::exit(1);
-    }
-	else {
+	} else {
 		// selector already set in constructor, just print a warning here
 		if (mardyn_get_max_threads() > 1) {
 			global_log->warning() << "No traversal type selected. Defaulting to c08 traversal." << endl;


### PR DESCRIPTION
# Description

Adds adjustable minNumCellsPerDimension for KDDecomposition.

Makes it possible for the minimal cells per dimension to be adjustable.

Especially, using just one cell per dimension is possible.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Locally with a scenario containing 8 cells -- kdd is now able to simulate using up to 8 mpi ranks.