### PR TITLE
Bugfix regionsampling

### DIFF
--- a/src/plugins/NEMD/MettDeamon.cpp
+++ b/src/plugins/NEMD/MettDeamon.cpp
@@ -565,7 +565,7 @@ void MettDeamon::prepare_start(DomainDecompBase* domainDecomp, ParticleContainer
 {
 	int ownRank = domainDecomp->getRank();
 
-	//_feedrate.feed.actual = _feedrate.feed.init; // already set before when connected to MD-Feedrate-Director
+	_feedrate.feed.actual = _feedrate.feed.init;
 
 	_reservoir->readParticleData(domainDecomp);
 	if(_reservoir->getDensity(0) < 0.000000001)

--- a/src/plugins/NEMD/MettDeamon.cpp
+++ b/src/plugins/NEMD/MettDeamon.cpp
@@ -565,7 +565,7 @@ void MettDeamon::prepare_start(DomainDecompBase* domainDecomp, ParticleContainer
 {
 	int ownRank = domainDecomp->getRank();
 
-	_feedrate.feed.actual = _feedrate.feed.init;
+	//_feedrate.feed.actual = _feedrate.feed.init; // already set before when connected to MD-Feedrate-Director
 
 	_reservoir->readParticleData(domainDecomp);
 	if(_reservoir->getDensity(0) < 0.000000001)

--- a/src/plugins/NEMD/MettDeamon.h
+++ b/src/plugins/NEMD/MettDeamon.h
@@ -234,7 +234,7 @@ public:
 
 	// connection to other general plugins
 	void setActualFeedrate(const double& feed_actual) {_feedrate.feed.actual = feed_actual;
-	global_log->info() << "[MettDeamon]: Set new feedrate by MDFRD to vf= " << feed_actual << std::endl;}
+	global_log->info() << "[MettDeamon]: Set new feedrate by MDFRD to vf= " << _feedrate.feed.actual << std::endl;}
 	double getInvDensityArea() {return _dInvDensityArea;}
 
 private:

--- a/src/plugins/NEMD/MettDeamon.h
+++ b/src/plugins/NEMD/MettDeamon.h
@@ -233,8 +233,14 @@ public:
 	void StoreValuesCV(const double& dDensity, const double& dVolume) {_dDensityTarget = dDensity; _dVolumeCV = dVolume;}
 
 	// connection to other general plugins
-	void setActualFeedrate(const double& feed_actual) {_feedrate.feed.actual = feed_actual; _feedrate.feed.init = feed_actual;
-	global_log->info() << "[MettDeamon]: Set new feedrate by MDFRD to vf= " << _feedrate.feed.actual << std::endl;}
+	void setActualFeedrate(const double& feed_actual) {
+		_feedrate.feed.actual = feed_actual;
+		global_log->info() << "[MettDeamon]: Set new feedrate by MDFRD to vf= " << _feedrate.feed.actual << std::endl;
+	}
+	void setInitFeedrate(const double& feed_init) {
+		_feedrate.feed.init = feed_init;
+		global_log->info() << "[MettDeamon]: Set init feedrate by MDFRD to vf= " << _feedrate.feed.init << std::endl;
+	}
 	double getInvDensityArea() {return _dInvDensityArea;}
 
 private:

--- a/src/plugins/NEMD/MettDeamon.h
+++ b/src/plugins/NEMD/MettDeamon.h
@@ -233,7 +233,7 @@ public:
 	void StoreValuesCV(const double& dDensity, const double& dVolume) {_dDensityTarget = dDensity; _dVolumeCV = dVolume;}
 
 	// connection to other general plugins
-	void setActualFeedrate(const double& feed_actual) {_feedrate.feed.actual = feed_actual;
+	void setActualFeedrate(const double& feed_actual) {_feedrate.feed.actual = feed_actual; _feedrate.feed.init = feed_actual;
 	global_log->info() << "[MettDeamon]: Set new feedrate by MDFRD to vf= " << _feedrate.feed.actual << std::endl;}
 	double getInvDensityArea() {return _dInvDensityArea;}
 

--- a/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
+++ b/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
@@ -100,7 +100,7 @@ void MettDeamonFeedrateDirector::readXML(XMLfileUnits& xmlconfig)
 	cout << endl;
 #endif
 	// init actual feed rate
-	_feedrate.actual = *_feedrate.list.end();
+	_feedrate.actual = _feedrate.list.back();
 
 //	_forceConstant = 100.;
 //	xmlconfig.getNodeValue("forceConstant", _forceConstant);

--- a/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
+++ b/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
@@ -50,11 +50,13 @@ void MettDeamonFeedrateDirector::init(ParticleContainer* particleContainer, Doma
 			mettDeamon = dynamic_cast<MettDeamon*>(pit);
 	}
 	if(nullptr != mettDeamon) {
-		mettDeamon->setActualFeedrate(_feedrate.actual);
 		// init _feedrate.sum
 		_feedrate.sum = 0;
-		for (std::list<double>::iterator it=_feedrate.list.begin(); it != _feedrate.list.end(); ++it)
+		for (std::list<double>::iterator it=_feedrate.list.begin(); it != _feedrate.list.end(); ++it) {
 			_feedrate.sum += *it;
+		}
+		_feedrate.avg = _feedrate.sum * 1./(double)(_feedrate.list.size());
+		mettDeamon->setActualFeedrate(_feedrate.avg);
 	}
 }
 

--- a/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
+++ b/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
@@ -52,7 +52,7 @@ void MettDeamonFeedrateDirector::init(ParticleContainer* particleContainer, Doma
 	if(nullptr != mettDeamon) {
 		// init _feedrate.sum
 		_feedrate.sum = 0;
-		for (std::list<double>::iterator it=_feedrate.list.begin(); it != _feedrate.list.end(); ++it) {
+		for (auto it=_feedrate.list.begin(); it != _feedrate.list.end(); ++it) {
 			_feedrate.sum += *it;
 		}
 		_feedrate.avg = _feedrate.sum * 1./(double)(_feedrate.list.size());

--- a/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
+++ b/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
@@ -56,7 +56,7 @@ void MettDeamonFeedrateDirector::init(ParticleContainer* particleContainer, Doma
 			_feedrate.sum += *it;
 		}
 		_feedrate.avg = _feedrate.sum * 1./(double)(_feedrate.list.size());
-		mettDeamon->setActualFeedrate(_feedrate.avg);
+		mettDeamon->setInitFeedrate(_feedrate.avg);
 	}
 }
 

--- a/src/plugins/NEMD/RegionSampling.cpp
+++ b/src/plugins/NEMD/RegionSampling.cpp
@@ -1517,7 +1517,7 @@ void SampleRegion::writeDataProfiles(DomainDecompBase* domainDecomp, unsigned lo
 	if( simstep <= _initSamplingProfiles )
 		return;
 
-	if ( (simstep - _initSamplingProfiles) % _writeFrequencyProfiles != 0 )
+	if( (simstep - _initSamplingProfiles) % _writeFrequencyProfiles != 0 )
 		return;
 
 	if( simstep == global_simulation->getNumInitTimesteps() ) // do not write data directly after (re)start
@@ -1680,7 +1680,7 @@ void SampleRegion::writeDataVDF(DomainDecompBase* domainDecomp, unsigned long si
 	if( simstep <= _initSamplingVDF )
 		return;
 
-	if ( (simstep - _initSamplingVDF) % _writeFrequencyVDF != 0 )
+	if( (simstep - _initSamplingVDF) % _writeFrequencyVDF != 0 )
 		return;
 
 	if( simstep == global_simulation->getNumInitTimesteps() ) // do not write data directly after (re)start
@@ -1805,7 +1805,7 @@ void SampleRegion::writeDataFieldYR(DomainDecompBase* domainDecomp, unsigned lon
 	if( simstep <= _initSamplingFieldYR )
 		return;
 
-	if ( (simstep - _initSamplingFieldYR) % _writeFrequencyFieldYR != 0 )
+	if( (simstep - _initSamplingFieldYR) % _writeFrequencyFieldYR != 0 )
 		return;
 
 	if( simstep == global_simulation->getNumInitTimesteps() ) // do not write data directly after (re)start

--- a/src/plugins/NEMD/RegionSampling.cpp
+++ b/src/plugins/NEMD/RegionSampling.cpp
@@ -1513,11 +1513,14 @@ void SampleRegion::writeDataProfiles(DomainDecompBase* domainDecomp, unsigned lo
 	if(not _SamplingEnabledProfiles)
 		return;
 
-	// sampling starts after initial timestep (_initSamplingVDF) and with respect to write frequency (_writeFrequencyVDF)
+	// sampling starts after initial timestep (_initSamplingVDF) and with respect to write frequency (_writeFrequencyProfiles)
 	if( simstep <= _initSamplingProfiles )
 		return;
 
 	if ( (simstep - _initSamplingProfiles) % _writeFrequencyProfiles != 0 )
+		return;
+
+	if( simstep == global_simulation->getNumInitTimesteps() ) // do not write data directly after (re)start
 		return;
 
 	// calc global values
@@ -1680,6 +1683,9 @@ void SampleRegion::writeDataVDF(DomainDecompBase* domainDecomp, unsigned long si
 	if ( (simstep - _initSamplingVDF) % _writeFrequencyVDF != 0 )
 		return;
 
+	if( simstep == global_simulation->getNumInitTimesteps() ) // do not write data directly after (re)start
+		return;
+
 	// calc global values
 	this->calcGlobalValuesVDF();  // calculate global velocity distribution sums
 
@@ -1800,6 +1806,9 @@ void SampleRegion::writeDataFieldYR(DomainDecompBase* domainDecomp, unsigned lon
 		return;
 
 	if ( (simstep - _initSamplingFieldYR) % _writeFrequencyFieldYR != 0 )
+		return;
+
+	if( simstep == global_simulation->getNumInitTimesteps() ) // do not write data directly after (re)start
 		return;
 
 	// calc global values

--- a/src/plugins/NEMD/RegionSampling.cpp
+++ b/src/plugins/NEMD/RegionSampling.cpp
@@ -1513,7 +1513,7 @@ void SampleRegion::writeDataProfiles(DomainDecompBase* domainDecomp, unsigned lo
 	if(not _SamplingEnabledProfiles)
 		return;
 
-	// sampling starts after initial timestep (_initSamplingVDF) and with respect to write frequency (_writeFrequencyProfiles)
+	// sampling starts after initial timestep (_initSamplingProfiles) and with respect to write frequency (_writeFrequencyProfiles)
 	if( simstep <= _initSamplingProfiles )
 		return;
 
@@ -1801,7 +1801,7 @@ void SampleRegion::writeDataFieldYR(DomainDecompBase* domainDecomp, unsigned lon
 	if(not _SamplingEnabledFieldYR)
 		return;
 
-	// sampling starts after initial timestep (_initSamplingVDF) and with respect to write frequency (_writeFrequencyVDF)
+	// sampling starts after initial timestep (_initSamplingFieldYR) and with respect to write frequency (_writeFrequencyFieldYR)
 	if( simstep <= _initSamplingFieldYR )
 		return;
 


### PR DESCRIPTION
# Description

Fixing a bug in the RegionSampling plugin.
Currently, when (re)starting a simulation with a timestep > 0, the RS plugin writes out files at the very beginning of the simulation. Those files contain trash data of only one timestep but may overwrite old files. Eg. when conducting a simulation until timestep = 300000, it will write out a valid file at the very last timestep. When restarting from 300000, the RS plugin will overwrite the old file...

Such behaviour is now fixed.

### Remaining issues:
- When restarting from eg. 28000 and writing profiles every 10000 timesteps (starting at timestep 0), the files written at 30000 will contain unexpected data, too. Fixing this could lead to unwanted behaviour, eg. "Why is no file written at 30000?" or leading to a different statistic of that one file compared to the other files (only averaged over 2000 timesteps vs averaged over 10000)
- The method "global_simulation->getNumInitTimesteps()" is called almost every timestep but returns a constant values during the whole simulation. This could be fixed by changing the order of the plugin initialization and setting the initial timestep in "Simulation.cpp", eg. moving line 864 ahead of the plugin initialization. I dont know if this is possible and doesnt have any bad side effects. Afterwards, the aforementioned method could be called once, when the plugin is initialized.


Minor fixes of the MettDaemon(FeedrateDirector)-plugin
