### PR TITLE
Fix deadlock in Simulation::refreshParticleIDs()

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -1330,33 +1330,14 @@ CellProcessor *Simulation::getCellProcessor() const {
 
 void Simulation::refreshParticleIDs()
 {
-	uint64_t prevMaxID = 0;  // max ID of previous process
-	int ownRank = _domainDecomposition->getRank();
-
+    unsigned long start_ID = 0;
 #ifdef ENABLE_MPI
-	int numProcs = _domainDecomposition->getNumProcs();
-	if (ownRank != 0) {
-		MPI_Recv(&prevMaxID, 1, MPI_UNSIGNED_LONG, (ownRank-1), 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
-#ifndef NDEBUG
-		cout << "Process " << ownRank << " received maxID=" << prevMaxID << " from process " << (ownRank-1) << "." << endl;
-#endif
-	}
+    unsigned long num_molecules_local = _moleculeContainer->getNumberOfParticles();
+    MPI_Exscan(&num_molecules_local, &start_ID, 1, MPI_UNSIGNED_LONG, MPI_SUM, MPI_COMM_WORLD);
 #endif
 
-	uint64_t tmpID = prevMaxID;
-
-#ifdef ENABLE_MPI
-	if(ownRank < (numProcs-1) ) {
-		prevMaxID += _moleculeContainer->getNumberOfParticles();
-		MPI_Send(&prevMaxID, 1, MPI_UNSIGNED_LONG, (ownRank+1), 0, MPI_COMM_WORLD);
-	}
-#endif
-
-#ifndef NDEBUG
-	cout << "["<<ownRank<<"]tmpID=" << tmpID << endl;
-#endif
 	for (auto pit = _moleculeContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); pit.isValid(); ++pit)
 	{
-		pit->setid(++tmpID);
+		pit->setid(++start_ID);
 	}
 }


### PR DESCRIPTION
# Description

Fixes #159 : Replace wrong Recv/Send based implementation of an exclusive reduction
over all processes with MPI_Exscan.

## Resolved Issues

- [*] #159 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [*] Followed instructions for reproduction with the provided info for HAWK in #159 