### PR TITLE
Removes periodicity in Cubic Grid Generator

### DIFF
--- a/src/io/CubicGridGeneratorInternal.cpp
+++ b/src/io/CubicGridGeneratorInternal.cpp
@@ -248,9 +248,11 @@ void CubicGridGeneratorInternal::removeMomentum(ParticleContainer* particleConta
 	double v_sub2 = momentum_sum2 / mass_sum;
 	{
 		auto iter = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY);
-		Log::global_log->info() << "v_sub: " << v_sub0 << " " << v_sub1 << " " << v_sub2 << std::endl;
-		Log::global_log->info() << "m1 v: " << std::setprecision(10) << iter->v(0) << " " << iter->v(1) << " "
-								<< iter->v(2) << std::endl;
+		if(iter.isValid()) {
+			Log::global_log->info() << "v_sub: " << v_sub0 << " " << v_sub1 << " " << v_sub2 << std::endl;
+			Log::global_log->info() << "m1 v: " << std::setprecision(10) << iter->v(0) << " " << iter->v(1) << " "
+									<< iter->v(2) << std::endl;
+		}
 	}
 	#if defined(_OPENMP)
 	#pragma omp parallel
@@ -263,8 +265,10 @@ void CubicGridGeneratorInternal::removeMomentum(ParticleContainer* particleConta
 	}
 	{
 		auto iter = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY);
-		Log::global_log->info() << "m1 v: " << iter->v(0) << " " << iter->v(1) << " " << iter->v(2)
-								<< std::setprecision(5) << std::endl;
+		if(iter.isValid()) {
+			Log::global_log->info() << "m1 v: " << iter->v(0) << " " << iter->v(1) << " " << iter->v(2)
+									<< std::setprecision(5) << std::endl;
+		}
 	}
 #ifndef NDEBUG
 	//test

--- a/src/io/CubicGridGeneratorInternal.cpp
+++ b/src/io/CubicGridGeneratorInternal.cpp
@@ -82,9 +82,8 @@ unsigned long CubicGridGeneratorInternal::readPhaseSpace(ParticleContainer *part
 		global_simulation->getEnsemble()->getComponents()->at(1).updateMassInertia();
 	}
 
-	unsigned long int id = 0;
-
-    id = particleContainer->initCubicGrid(numMoleculesPerDim, simBoxLength, domainDecomp->getRank()*mardyn_get_max_threads());
+	unsigned long int id = particleContainer->initCubicGrid(
+		numMoleculesPerDim, simBoxLength, static_cast<size_t>(domainDecomp->getRank()) * mardyn_get_max_threads());
 
 	Log::global_log->info() << "Finished reading molecules: 100%" << std::endl;
 

--- a/src/io/CubicGridGeneratorInternal.cpp
+++ b/src/io/CubicGridGeneratorInternal.cpp
@@ -84,7 +84,7 @@ unsigned long CubicGridGeneratorInternal::readPhaseSpace(ParticleContainer *part
 
 	unsigned long int id = 0;
 
-    id = particleContainer->initCubicGrid(numMoleculesPerDim, simBoxLength);
+    id = particleContainer->initCubicGrid(numMoleculesPerDim, simBoxLength, domainDecomp->getRank()*mardyn_get_max_threads());
 
 	Log::global_log->info() << "Finished reading molecules: 100%" << std::endl;
 
@@ -109,7 +109,7 @@ unsigned long CubicGridGeneratorInternal::readPhaseSpace(ParticleContainer *part
 	//std::cout << domainDecomp->getRank()<<": offset:" << idOffset << std::endl;
 
 	Log::global_log->info() << "CGG: remove momentum" << std::endl;
-	removeMomentum(particleContainer, *(global_simulation->getEnsemble()->getComponents()));
+	removeMomentum(particleContainer, *(global_simulation->getEnsemble()->getComponents()), domainDecomp);
 	Log::global_log->info() << "CGG: momentum done" << std::endl;
 	domain->evaluateRho(particleContainer->getNumberOfParticles(), domainDecomp);
 	Log::global_log->info() << "Calculated Rho=" << domain->getglobalRho() << std::endl;
@@ -220,7 +220,7 @@ std::array<unsigned long, 3> CubicGridGeneratorInternal::determineMolsPerDimensi
 //}
 
 void CubicGridGeneratorInternal::removeMomentum(ParticleContainer* particleContainer,
-		const std::vector<Component>& components) {
+		const std::vector<Component>& components, DomainDecompBase* domainDecomp) {
 	double mass_sum = 0.;
 	//double momentum_sum[3] = { 0., 0., 0. };
 	double momentum_sum0 = 0.;
@@ -241,6 +241,19 @@ void CubicGridGeneratorInternal::removeMomentum(ParticleContainer* particleConta
 			momentum_sum2 += mass * molecule->v(2);
 		}
 	}
+
+	domainDecomp->collCommInit(4);
+	domainDecomp->collCommAppendDouble(mass_sum);
+	domainDecomp->collCommAppendDouble(momentum_sum0);
+	domainDecomp->collCommAppendDouble(momentum_sum1);
+	domainDecomp->collCommAppendDouble(momentum_sum2);
+	domainDecomp->collCommAllreduceSum();
+	mass_sum = domainDecomp->collCommGetDouble();
+	momentum_sum0 = domainDecomp->collCommGetDouble();
+	momentum_sum1 = domainDecomp->collCommGetDouble();
+	momentum_sum2 = domainDecomp->collCommGetDouble();
+	domainDecomp->collCommFinalize();
+
 	Log::global_log->info() << "momentumsum: " << momentum_sum0 << " " << momentum_sum1<< " " << momentum_sum2 << std::endl;
 	Log::global_log->info() << "mass_sum: " << mass_sum << std::endl;
 	double v_sub0 = momentum_sum0 / mass_sum;

--- a/src/io/CubicGridGeneratorInternal.h
+++ b/src/io/CubicGridGeneratorInternal.h
@@ -52,7 +52,7 @@ private:
 	std::array<unsigned long, 3> determineMolsPerDimension(unsigned long targetTotalNumMols, std::array<double, 3> boxLength) const;
 
 //	bool addMolecule(double x, double y, double z, unsigned long id, ParticleContainer* particleContainer);
-	void removeMomentum(ParticleContainer* particleContainer, const std::vector<Component>& components);
+	void removeMomentum(ParticleContainer* particleContainer, const std::vector<Component>& components, DomainDecompBase* domainDecomp);
 	/**
 	 * create a random number between a and b (inclusive)
 	 */

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -416,7 +416,7 @@ bool AutoPasContainer::getMoleculeAtPosition(const double *pos, Molecule **resul
 }
 
 unsigned long AutoPasContainer::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
-											  std::array<double, 3> simBoxLength) {
+											  std::array<double, 3> simBoxLength, size_t seed_offset) {
 	throw std::runtime_error("AutoPasContainer::initCubicGrid() not yet implemented");
 }
 

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -110,7 +110,7 @@ public:
 	bool getMoleculeAtPosition(const double pos[3], Molecule **result) override;
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
-								std::array<double, 3> simBoxLength) override;
+								std::array<double, 3> simBoxLength, size_t seed_offset) override;
 
 	double *getCellLength() override;
 

--- a/src/particleContainer/LinkedCells.cpp
+++ b/src/particleContainer/LinkedCells.cpp
@@ -888,7 +888,7 @@ void LinkedCells::getCellIndicesOfRegion(const double startRegion[3], const doub
 	endIndex = getCellIndexOfPoint(endRegion);
 }
 
-unsigned long LinkedCells::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength) {
+unsigned long LinkedCells::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength, size_t seed_offset) {
 	const unsigned long numCells = _cells.size();
 
 	std::vector<unsigned long> numMoleculesPerThread;
@@ -902,10 +902,10 @@ unsigned long LinkedCells::initCubicGrid(std::array<unsigned long, 3> numMolecul
 		const int myID = mardyn_get_thread_num();
 		const unsigned long myStart = numCells * myID / numThreads;
 		const unsigned long myEnd = numCells * (myID + 1) / numThreads;
-		const int seed = myID;
+		const int seed = seed_offset + myID;
 
 		unsigned long numMoleculesByThisThread = 0;
-		Random threadPrivateRNG = Random(seed);
+		Random threadPrivateRNG{seed};
 
 		// manual "static" scheduling important, because later this thread needs to traverse the same cells
 		for (unsigned long cellIndex = myStart; cellIndex < myEnd; ++cellIndex) {

--- a/src/particleContainer/LinkedCells.h
+++ b/src/particleContainer/LinkedCells.h
@@ -236,7 +236,7 @@ public:
 	bool requiresForceExchange() const override; // new
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
-								std::array<double, 3> simBoxLength) override;
+								std::array<double, 3> simBoxLength, size_t seed_offset) override;
 
 	std::vector<unsigned long> getParticleCellStatistics() override;
 

--- a/src/particleContainer/ParticleContainer.h
+++ b/src/particleContainer/ParticleContainer.h
@@ -228,13 +228,13 @@ public:
 	 * @param result Molecule will be returned by this pointer if found
 	 * @return Molecule was found?
 	 */
-	virtual bool getMoleculeAtPosition(const double pos[3], Molecule** result) = 0; // new
+	virtual bool getMoleculeAtPosition(const double pos[3], Molecule** result) = 0;
 
 	// @brief Should the domain decomposition exchange calculated forces at the boundaries,
 	// or does this particle container calculate all forces.
-	virtual bool requiresForceExchange() const {return false;} // new
+	virtual bool requiresForceExchange() const {return false;}
         
-	virtual unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength, size_t seed_offset) = 0; // new
+	virtual unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength, size_t seed_offset) = 0;
 
 	virtual double* getCellLength() = 0;
 

--- a/src/particleContainer/ParticleContainer.h
+++ b/src/particleContainer/ParticleContainer.h
@@ -234,7 +234,7 @@ public:
 	// or does this particle container calculate all forces.
 	virtual bool requiresForceExchange() const {return false;} // new
         
-	virtual unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength) = 0; // new
+	virtual unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength, size_t seed_offset) = 0; // new
 
 	virtual double* getCellLength() = 0;
 

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -117,7 +117,7 @@ public:
 							   Molecule** result) override { return false; } // pure virtual in particleContainer.h
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
-								std::array<double, 3> simBoxLength) override { return 0; }
+								std::array<double, 3> simBoxLength, size_t seed_offset) override { return 0; }
 
 	size_t getTotalSize() override { return _basis.numMolecules() * sizeof(Molecule); }
 


### PR DESCRIPTION
# Description

CGG used the same random number seeds on all ranks, leading to repeated velocity values on the different ranks.
This PR removes this periodicity by using unique seeds for each rank.

## Resolved Issues

- fixes periodicity
- fixes cubic_grid_generator causing errors if there is one rank with zero particles.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] locally (with more ranks than particles 🤣)
