### PR TITLE
Speedup of force exchange + force exchange debug mode fix

### DIFF
--- a/examples/force-exchange/cube-dense-fs.xml
+++ b/examples/force-exchange/cube-dense-fs.xml
@@ -57,7 +57,7 @@
       	<CommunicationScheme>indirect</CommunicationScheme>
       </parallelisation>
       <datastructure type="LinkedCells">
-      	  <traversalSelector>ori</traversalSelector>
+      	  <traversalSelector>c08</traversalSelector>
           <cellsInCutoffRadius>1</cellsInCutoffRadius>
       </datastructure>
       <cutoffs type="CenterOfMass" >

--- a/examples/force-exchange/cube-dense-nt.xml
+++ b/examples/force-exchange/cube-dense-nt.xml
@@ -1,0 +1,105 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<mardyn version="20100525" >
+
+  <simulation type="MD" >
+    <integrator type="Leapfrog" >
+      <!-- MD ODE integrator -->
+      <timestep unit="reduced" >0.002</timestep>
+    </integrator>
+
+    <run>
+      <currenttime>0</currenttime>
+      <production>
+        <steps>100</steps>
+      </production>
+    </run>
+
+    <ensemble type="NVT">
+      <!-- Nparticles determined by the input file -->
+      <temperature unit="reduced" >0.95</temperature>
+      <domain type="box">
+          <lx>80.0</lx>
+          <ly>80.0</ly>
+          <lz>80.0</lz>
+      </domain>
+
+      <components>
+          <moleculetype id="1" name="Argon">
+            <site type="LJ126" id="1" >
+              <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
+              <mass>1.0</mass>
+              <sigma>1.0</sigma>
+              <epsilon>1.0</epsilon>
+            </site>
+          </moleculetype>
+      </components>
+
+      <phasespacepoint>
+        <generator name="mkTcTS">
+          <layer1>
+            <density>1</density>
+          </layer1>
+          <layer2>
+            <density>1</density>
+          </layer2>
+        </generator>
+      </phasespacepoint>
+    </ensemble>
+
+    <algorithm>
+      <!--
+      <parallelisation type="KDDecomposition">
+        <updateFrequency>10</updateFrequency>
+        <fullSearchThreshold>2</fullSearchThreshold>
+      </parallelisation>
+      -->
+      <parallelisation type="DomainDecomposition">
+      	<CommunicationScheme>indirect</CommunicationScheme>
+      </parallelisation>
+      <datastructure type="LinkedCells">
+      	  <traversalSelector>nt</traversalSelector>
+          <cellsInCutoffRadius>2</cellsInCutoffRadius>
+      </datastructure>
+      <cutoffs type="CenterOfMass" >
+        <radiusLJ unit="reduced" >5.0</radiusLJ>
+      </cutoffs>
+      <electrostatic type="ReactionField" >
+        <epsilon>1.0e+10</epsilon>
+      </electrostatic>
+
+      <!--
+      <thermostats>
+        <thermostat type="VelocityScaling" componentName="Argon">
+          <temperature>1</temperature>
+        </thermostat>
+      </thermostats>
+      -->
+    </algorithm>
+
+    <output>
+    <!--
+      <outputplugin name="SysMonOutput">
+        <expression>procloadavg:loadavg1</expression>
+        <expression label="Free+BufferRAM [MB]">sysinfo:freeram sysinfo:bufferram + sysinfo:mem_unit * float 1048576 /</expression>
+        <expression>procselfstatm:size 1048576. /</expression>
+        <writefrequency>10</writefrequency>
+      </outputplugin>
+      -->
+      <!-- <outputplugin name="Resultwriter">
+        <writefrequency>1</writefrequency>
+        <outputprefix>mkTcTS</outputprefix>
+      </outputplugin> -->
+      <!--
+      <outputplugin name="CheckpointWriter">
+        <writefrequency>10</writefrequency>
+        <outputprefix>mkTcTS</outputprefix>
+      </outputplugin>
+      -->
+      <!--<outputplugin name="PovWriter">
+        <writefrequency>10</writefrequency>
+        <outputprefix>mkTcTS</outputprefix>
+      </outputplugin> -->
+    </output>
+
+  </simulation>
+</mardyn>

--- a/makefile/Makefile
+++ b/makefile/Makefile
@@ -157,7 +157,7 @@ else
 endif
 
 SOURCES_COMMON = $(shell find ./ -name "*.cpp" | grep -E -v "(parallel/|/tests/|/vtk/|/fft/|AutoPas)")
-SOURCES_SEQ = $(shell find parallel/ -name "*.cpp" | grep "DomainDecompBase\|LoadCalc\|Zonal" | grep -E -v "/tests/")
+SOURCES_SEQ = $(shell find parallel/ -name "*.cpp" | grep "DomainDecompBase\|LoadCalc\|Zonal\|ForceHelper" | grep -E -v "/tests/")
 SOURCES_PAR = $(shell find parallel/ -name "*.cpp" | grep -E -v "(/tests/|/vtk/|ALLL)")
 SOURCES = $(SOURCES_COMMON) $(SOURCES_$(PARTYPE))
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT ENABLE_MPI)
 
     # but include DomainDecompBase* and LoadCalc*
     list(FILTER MY_SRC_BACK INCLUDE REGEX "/parallel/")
-    list(FILTER MY_SRC_BACK INCLUDE REGEX "DomainDecompBase|LoadCalc|Zonal")
+    list(FILTER MY_SRC_BACK INCLUDE REGEX "DomainDecompBase|LoadCalc|Zonal|ForceHelper")
     list(APPEND MY_SRC ${MY_SRC_BACK})
 else()
     if(NOT ENABLE_ALLLBL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,7 @@ endif ()
 # add the executable
 ADD_EXECUTABLE(MarDyn
         ${MY_SRC}
-        )
+        parallel/ForceHelper.h)
 
 # dependencies for lz4
 if (ENABLE_LZ4)

--- a/src/molecules/FullMolecule.h
+++ b/src/molecules/FullMolecule.h
@@ -348,7 +348,7 @@ protected:
     unsigned long _id;  /**< IDentification number of that molecule */
 
 	double _m; /**< total mass */
-	double _I[3],_invI[3];  // moment of inertia for principal axes and it's inverse
+	double _I[3]{0.,0.,0.},_invI[3]{0.,0.,0.};  // moment of inertia for principal axes and it's inverse
 
 	/* absolute positions are stored in the soa. Work-arounds to get the relative ones*/
 	CellDataSoA * _soa;

--- a/src/parallel/CommunicationBuffer.cpp
+++ b/src/parallel/CommunicationBuffer.cpp
@@ -107,9 +107,8 @@ void CommunicationBuffer::resizeForAppendingForceMolecules(unsigned long numForc
 	// maybe some assert
 	size_t numBytes = sizeof(_numForces) + _numForces * _numBytesForces;
 	resizeForRawBytes(numBytes);
-	
-	size_t i_runningByte = 0;
-	i_runningByte = emplaceValue(i_runningByte, _numForces);
+
+	// Do NOT write the number of force molecules, here! It is assumed at other places, that they are NOT exchanged!
 }
 
 void CommunicationBuffer::addLeavingMolecule(size_t indexOfMolecule, const Molecule& m) { 
@@ -386,8 +385,8 @@ size_t CommunicationBuffer::getStartPosition(ParticleType_t type, size_t indexOf
 	} else if(type == ParticleType_t::HALO) {
 		ret += _numLeaving * _numBytesLeaving + indexOfMolecule * _numBytesHalo;
 	} else if(type == ParticleType_t::FORCE) {
-		// ??? - does the force exchange happen on its own or with the other bytes?
-		ret = indexOfMolecule * _numBytesForces; // assumed on its own.
+		// the number of forces is NOT stored in the buffer, as they are sent on their own!
+		ret = indexOfMolecule * _numBytesForces;
 		//additionally no leaving or halo molecules are transmitted, thus _numLeaving, _numHalo are zero!
 	}
 

--- a/src/parallel/CommunicationPartner.cpp
+++ b/src/parallel/CommunicationPartner.cpp
@@ -361,12 +361,13 @@ bool CommunicationPartner::testRecv(ParticleContainer* moleculeContainer, bool r
 					Molecule m;
 					_recvBuf.readForceMolecule(i, m);
 					//mols[i] = m;
-					Molecule* m_target;
 					const double position[3] = { m.r(0), m.r(1), m.r(2) };
-					moleculeContainer->getMoleculeAtPosition(position, &m_target);
-					m_target->Fadd(m.F_arr().data());
-					m_target->Madd(m.M_arr().data());
-					m_target->Viadd(m.Vi_arr().data());
+					auto m_target_iter = moleculeContainer->getMoleculeAtPosition(position);
+					std::visit([&m](auto m_target_iter) {
+						m_target_iter->Fadd(m.F_arr().data());
+						m_target_iter->Madd(m.M_arr().data());
+						m_target_iter->Viadd(m.Vi_arr().data());
+					}, m_target_iter);
 				}
 
 				//moleculeContainer->addParticles(mols, removeRecvDuplicates);

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -135,19 +135,21 @@ void DomainDecompBase::handleForceExchange(unsigned dim, ParticleContainer* mole
 				shiftedPosition[2] = molHalo.r(2);
 				shiftedPosition[dim] += shift;
 
-				Molecule* original;
+				auto originalIter = moleculeContainer->getMoleculeAtPosition(shiftedPosition);
 
-				if (!moleculeContainer->getMoleculeAtPosition(shiftedPosition, &original)) {
-					// This should not happen
-					std::cout << "Original molecule not found";
-					mardyn_exit(1);
-				}
+				std::visit([&](auto originalIter) {
+					if (not originalIter.isValid()) {
+						// This should not happen
+						std::cout << "Original molecule not found";
+						mardyn_exit(1);
+					}
 
-				mardyn_assert(original->getID() == molHalo.getID());
+					mardyn_assert(originalIter->getID() == molHalo.getID());
 
-				original->Fadd(molHalo.F_arr().data());
-				original->Madd(molHalo.M_arr().data());
-				original->Viadd(molHalo.Vi_arr().data());
+					originalIter->Fadd(molHalo.F_arr().data());
+					originalIter->Madd(molHalo.M_arr().data());
+					originalIter->Viadd(molHalo.Vi_arr().data());
+				}, originalIter);
 			}
 		}
 	}
@@ -176,19 +178,21 @@ void DomainDecompBase::handleForceExchangeDirect(const HaloRegion& haloRegion, P
 			for (int dim = 0; dim < 3; dim++) {
 				shiftedPosition[dim] = molHalo.r(dim) + shift[dim];
 			}
-			Molecule* original;
+			auto originalIter = moleculeContainer->getMoleculeAtPosition(shiftedPosition);
 
-			if (!moleculeContainer->getMoleculeAtPosition(shiftedPosition, &original)) {
-				// This should not happen
-				std::cout << "Original molecule not found";
-				mardyn_exit(1);
-			}
+			std::visit([&](auto originalIter) {
+				if (not originalIter.isValid()) {
+					// This should not happen
+					std::cout << "Original molecule not found";
+					mardyn_exit(1);
+				}
 
-			mardyn_assert(original->getID() == molHalo.getID());
+				mardyn_assert(originalIter->getID() == molHalo.getID());
 
-			original->Fadd(molHalo.F_arr().data());
-			original->Madd(molHalo.M_arr().data());
-			original->Viadd(molHalo.Vi_arr().data());
+				originalIter->Fadd(molHalo.F_arr().data());
+				originalIter->Madd(molHalo.M_arr().data());
+				originalIter->Viadd(molHalo.Vi_arr().data());
+			}, originalIter);
 		}
 	}
 

--- a/src/parallel/DomainDecompBase.h
+++ b/src/parallel/DomainDecompBase.h
@@ -7,12 +7,14 @@
 #ifdef ENABLE_MPI
 #include <mpi.h>
 #endif
+#include <particleContainer/RegionParticleIterator.h>
 #include <iostream>
+#include <variant>
 
-#include "molecules/MoleculeForwardDeclaration.h"
-#include "utils/Logger.h" // is this used?
-#include "io/MemoryProfiler.h"
 #include "HaloRegion.h"
+#include "io/MemoryProfiler.h"
+#include "molecules/MoleculeForwardDeclaration.h"
+#include "utils/Logger.h"  // is this used?
 
 class Component;
 class Domain;

--- a/src/parallel/ForceHelper.cpp
+++ b/src/parallel/ForceHelper.cpp
@@ -7,35 +7,40 @@ std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> addValuesAndGet
 	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> previousIterator,
 	Molecule& haloMolecule) {
 	// Reuse the previous iterator in case the particles match.
-	bool found = false;
+	bool usePreviousIterator = false;
 	std::visit(
 		[&](auto& previousIter) {
 			if (previousIter.isValid()) {
+				// Increment pointer!
 				++previousIter;
+
 				if (previousIter.isValid()) {
 					const double epsi = moleculeContainer->getCutoff() * 1e-6;
+					// If the particle pointed to by previousIter is close to the given position, use it.
 					if (fabs(previousIter->r(0) - position[0]) <= epsi and
 						fabs(previousIter->r(1) - position[1]) <= epsi and
 						fabs(previousIter->r(2) - position[2]) <= epsi) {
-						found = true;
+						usePreviousIterator = true;
 					}
 				}
 			}
 		},
 		previousIterator);
+
 	// If the previousIterator matches, use it!
-	auto originalIter = found ? previousIterator : moleculeContainer->getMoleculeAtPosition(position);
+	auto originalIter = usePreviousIterator ? previousIterator : moleculeContainer->getMoleculeAtPosition(position);
 
 	std::visit(
 		[&](auto originalIter) {
 			if (not originalIter.isValid()) {
 				// This should not happen
-				std::cout << "Original molecule not found";
+				std::cout << "Original molecule not usePreviousIterator";
 				mardyn_exit(1);
 			}
 
 			mardyn_assert(originalIter->getID() == haloMolecule.getID());
 
+			// Add the force values.
 			originalIter->Fadd(haloMolecule.F_arr().data());
 			originalIter->Madd(haloMolecule.M_arr().data());
 			originalIter->Viadd(haloMolecule.Vi_arr().data());

--- a/src/parallel/ForceHelper.cpp
+++ b/src/parallel/ForceHelper.cpp
@@ -1,0 +1,45 @@
+#include <particleContainer/ParticleContainer.h>
+#include <particleContainer/ParticleIterator.h>
+#include <variant>
+
+std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> addValuesAndGetIterator(
+	ParticleContainer* moleculeContainer, const double* position,
+	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> previousIterator,
+	Molecule& haloMolecule) {
+	// Reuse the previous iterator in case the particles match.
+	bool found = false;
+	std::visit(
+		[&](auto& previousIter) {
+			if (previousIter.isValid()) {
+				++previousIter;
+				if (previousIter.isValid()) {
+					const double epsi = moleculeContainer->getCutoff() * 1e-6;
+					if (fabs(previousIter->r(0) - position[0]) <= epsi and
+						fabs(previousIter->r(1) - position[1]) <= epsi and
+						fabs(previousIter->r(2) - position[2]) <= epsi) {
+						found = true;
+					}
+				}
+			}
+		},
+		previousIterator);
+	// If the previousIterator matches, use it!
+	auto originalIter = found ? previousIterator : moleculeContainer->getMoleculeAtPosition(position);
+
+	std::visit(
+		[&](auto originalIter) {
+			if (not originalIter.isValid()) {
+				// This should not happen
+				std::cout << "Original molecule not found";
+				mardyn_exit(1);
+			}
+
+			mardyn_assert(originalIter->getID() == haloMolecule.getID());
+
+			originalIter->Fadd(haloMolecule.F_arr().data());
+			originalIter->Madd(haloMolecule.M_arr().data());
+			originalIter->Viadd(haloMolecule.Vi_arr().data());
+		},
+		originalIter);
+	return originalIter;
+}

--- a/src/parallel/ForceHelper.h
+++ b/src/parallel/ForceHelper.h
@@ -3,14 +3,15 @@
 #include <variant>
 
 /**
- *
- * @param moleculeContainer
- * @param position
- * @param previousIterator
- * @param haloMolecule
- * @return
+ * Adds the force values (force (F), torque (M) and virial (Vi)) of haloMolecule to the particle at the given position.
+ * The function will reuse the previousIterator if after an increment it points to a particle at the given position.
+ * @param moleculeContainer The molecule container.
+ * @param position The position of the particle to which the force values will be added.
+ * @param previousIterator Can be used to speed up the force exchange. The iterator returned from this function should
+ * be used for this.
+ * @param haloMolecule The molecule whose force values will be added to the particle at the given position.
+ * @return Iterator to the current particle. Can be used in the next iteration as previousIterator.
  */
 std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> addValuesAndGetIterator(
 	ParticleContainer* moleculeContainer, const double* position,
-	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> previousIterator,
-	Molecule& haloMolecule);
+	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> previousIterator, Molecule& haloMolecule);

--- a/src/parallel/ForceHelper.h
+++ b/src/parallel/ForceHelper.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <variant>
+
+/**
+ *
+ * @param moleculeContainer
+ * @param position
+ * @param previousIterator
+ * @param haloMolecule
+ * @return
+ */
+std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> addValuesAndGetIterator(
+	ParticleContainer* moleculeContainer, const double* position,
+	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> previousIterator,
+	Molecule& haloMolecule);

--- a/src/parallel/tests/KDDecompositionTest.cpp
+++ b/src/parallel/tests/KDDecompositionTest.cpp
@@ -128,9 +128,8 @@ void KDDecompositionTest::testHaloCorrect() {
 					// inside, so normal molecule
 					continue;
 				}
-				Molecule* m;
-				bool found = container->getMoleculeAtPosition(pos, &m);
-				ASSERT_TRUE_MSG("halo molecule not present", found);
+				auto iter = container->getMoleculeAtPosition(pos);
+				std::visit([](auto iter) { ASSERT_TRUE_MSG("halo molecule not present", iter.isValid()); }, iter);
 			}
 		}
 	}

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -404,15 +404,14 @@ void AutoPasContainer::updateMoleculeCaches() {
 	// nothing needed
 }
 
-bool AutoPasContainer::getMoleculeAtPosition(const double *pos, Molecule **result) {
+std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> AutoPasContainer::getMoleculeAtPosition(const double *pos) {
 	std::array<double, 3> pos_arr{pos[0], pos[1], pos[2]};
 	for (auto iter = this->iterator(ParticleIterator::ALL_CELLS); iter.isValid(); ++iter) {
 		if (iter->getR() == pos_arr) {
-			*result = &(*iter);
-			return true;
+			return iter;
 		}
 	}
-	return false;
+	return {};  // default initialized iter is invalid.
 }
 
 unsigned long AutoPasContainer::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -107,7 +107,7 @@ public:
 
 	void updateMoleculeCaches() override;
 
-	bool getMoleculeAtPosition(const double pos[3], Molecule **result) override;
+	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> getMoleculeAtPosition(const double pos[3]) override;
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
 								std::array<double, 3> simBoxLength, size_t seed_offset) override;

--- a/src/particleContainer/LinkedCells.cpp
+++ b/src/particleContainer/LinkedCells.cpp
@@ -1126,7 +1126,7 @@ std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> LinkedCells::ge
 		}
 	}
 	// not found -> return default initialized iter.
-	return ParticleIterator{};
+	return {};
 }
 
 bool LinkedCells::requiresForceExchange() const {return _traversalTuner->getCurrentOptimalTraversal()->requiresForceExchange();}

--- a/src/particleContainer/LinkedCells.cpp
+++ b/src/particleContainer/LinkedCells.cpp
@@ -1,20 +1,20 @@
 #include <cmath>
 #include "particleContainer/LinkedCells.h"
 
-
+#include <algorithm>
+#include <array>
+#include <variant>
 #include "Domain.h"
-#include "parallel/DomainDecompBase.h"
-#include "particleContainer/adapter/ParticlePairs2PotForceAdapter.h"
-#include "particleContainer/handlerInterfaces/ParticlePairsHandler.h"
-#include "particleContainer/adapter/CellProcessor.h"
-#include "particleContainer/adapter/LegacyCellProcessor.h"
 #include "ParticleCell.h"
 #include "molecules/Molecule.h"
+#include "parallel/DomainDecompBase.h"
+#include "particleContainer/adapter/CellProcessor.h"
+#include "particleContainer/adapter/LegacyCellProcessor.h"
+#include "particleContainer/adapter/ParticlePairs2PotForceAdapter.h"
+#include "particleContainer/handlerInterfaces/ParticlePairsHandler.h"
 #include "utils/Logger.h"
-#include "utils/mardyn_assert.h"
 #include "utils/Random.h"
-#include <array>
-#include <algorithm>
+#include "utils/mardyn_assert.h"
 
 #include "particleContainer/TraversalTuner.h"
 
@@ -1108,26 +1108,25 @@ std::string LinkedCells::getName() {
 	return "LinkedCells";
 }
 
-bool LinkedCells::getMoleculeAtPosition(const double pos[3], Molecule** result) {
+std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> LinkedCells::getMoleculeAtPosition(const double pos[3]) {
 	const double epsi = this->_cutoffRadius * 1e-6;
 	auto index = getCellIndexOfPoint(pos);
 	auto& cell = _cells.at(index);
 
 	// iterate through cell and compare position of molecules with given position
 
-	SingleCellIterator<ParticleCell> begin1 = cell.iterator();
 
-	for (SingleCellIterator<ParticleCell> it1 = begin1; it1.isValid(); ++it1) {
-		auto& mol = *it1;
+	for (auto cellIterator = cell.iterator(); cellIterator.isValid(); ++cellIterator) {
+		auto& mol = *cellIterator;
 
-		if (fabs(mol.r(0) - pos[0]) <= epsi && fabs(mol.r(1) - pos[1]) <= epsi && fabs(mol.r(2) - pos[2]) <= epsi) {
+		if (fabs(cellIterator->r(0) - pos[0]) <= epsi && fabs(cellIterator->r(1) - pos[1]) <= epsi &&
+			fabs(cellIterator->r(2) - pos[2]) <= epsi) {
 			// found
-			*result = &mol;
-			return true;
+			return cellIterator;
 		}
 	}
-	// not found
-	return false;
+	// not found -> return default initialized iter.
+	return ParticleIterator{};
 }
 
 bool LinkedCells::requiresForceExchange() const {return _traversalTuner->getCurrentOptimalTraversal()->requiresForceExchange();}

--- a/src/particleContainer/LinkedCells.h
+++ b/src/particleContainer/LinkedCells.h
@@ -189,7 +189,7 @@ public:
 	 * @param result Molecule will be returned by this pointer if found
 	 * @return Molecule was found?
 	 */
-	bool getMoleculeAtPosition(const double pos[3], Molecule** result) override;
+	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> getMoleculeAtPosition(const double pos[3]) override;
 
 	//! @brief Get the index in the cell vector to which this Molecule belongs
 	//!

--- a/src/particleContainer/ParticleContainer.h
+++ b/src/particleContainer/ParticleContainer.h
@@ -21,11 +21,14 @@
 #define PARTICLECONTAINER_H_
 
 #include <list>
+#include <variant>
 #include <vector>
+#include "ParticleCell.h"
 #include "ParticleIterator.h"
 #include "RegionParticleIterator.h"
-#include "molecules/MoleculeForwardDeclaration.h"
 #include "io/MemoryProfiler.h"
+#include "molecules/MoleculeForwardDeclaration.h"
+
 class CellProcessor;
 class ParticlePairsHandler;
 class XMLfileUnits;
@@ -225,10 +228,9 @@ public:
 	/**
 	 * @brief Gets a molecule by its position.
 	 * @param pos Molecule position
-	 * @param result Molecule will be returned by this pointer if found
-	 * @return Molecule was found?
+	 * @return Iterator to the molecule. The iterator is invalid if no molecule was found.
 	 */
-	virtual bool getMoleculeAtPosition(const double pos[3], Molecule** result) = 0;
+	virtual std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> getMoleculeAtPosition(const double pos[3]) = 0;
 
 	// @brief Should the domain decomposition exchange calculated forces at the boundaries,
 	// or does this particle container calculate all forces.

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -113,8 +113,9 @@ public:
 
 	void updateMoleculeCaches() override {}
 
-	bool getMoleculeAtPosition(const double pos[3],
-							   Molecule** result) override { return false; } // pure virtual in particleContainer.h
+	// Pure virtual in ParticleContainer.h
+	// Returns invalid iterator.
+	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> getMoleculeAtPosition(const double pos[3]) override { return ParticleIterator{}; }
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
 								std::array<double, 3> simBoxLength, size_t seed_offset) override { return 0; }

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -115,7 +115,7 @@ public:
 
 	// Pure virtual in ParticleContainer.h
 	// Returns invalid iterator.
-	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> getMoleculeAtPosition(const double pos[3]) override { return ParticleIterator{}; }
+	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> getMoleculeAtPosition(const double pos[3]) override { return {}; }
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
 								std::array<double, 3> simBoxLength, size_t seed_offset) override { return 0; }


### PR DESCRIPTION
# Description

Introduces a speedup to the force exchange:
- Instead of searching for every particle within a cell, the iterator is now reused when possible.

BugFix(es):
- Fixes first bytes of force buffer containing `_numForces`, even though they are assumed not to be there. (previously assertions were thrown in debug mode when multiple halo regions exist for one communication partner).

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Run tests locally to check correctness.

# Performance impact

20k particles

Before:

num_cpu | time_es | time_fs | time_hs
----------- | -------- | -------- | ------
1 |  28.447 | 34.067 | 35.94
2 | 15.894 | 18.864 | 22.127
4 | 8.9616 | 10.257 | 14.189
8 | 5.2629 | 5.6653 | 8.7165

After:
num_cpu | time_es | time_fs | time_hs
----------- | -------- | -------- | ------
1 | 22.82 | 33.678 | 23.267
2 | 11.726 | 18.838 | 12.353
4 | 6.0614 | 10.247 | 6.6284
8 | 3.1293 | 5.5981 | 3.5631

- no change for fs (as expected)
- significant speedup for ES, HS.

Plots:

- use FS as reference (it  remains almost unchanged!)

unoptimized;
![zonal_methods_20k_loop](https://user-images.githubusercontent.com/38119442/104563670-3a437480-564a-11eb-8260-f42ae576426e.png)

optimized;
![zonal_methods_20k_loop](https://user-images.githubusercontent.com/38119442/104563694-43ccdc80-564a-11eb-9982-939179164508.png)

