### PR TITLE
Limit stop value of MMPLD Writer

### DIFF
--- a/src/io/MmpldWriter.cpp
+++ b/src/io/MmpldWriter.cpp
@@ -75,6 +75,7 @@ void MmpldWriter::readXML(XMLfileUnits& xmlconfig)
 	xmlconfig.getNodeValue("writecontrol/start", _startTimestep);
 	xmlconfig.getNodeValue("writecontrol/writefrequency", _writeFrequency);
 	xmlconfig.getNodeValue("writecontrol/stop", _stopTimestep);
+	_stopTimestep = std::min(_stopTimestep, global_simulation->getNumTimesteps());
 	xmlconfig.getNodeValue("writecontrol/framesperfile", _numFramesPerFile);
 	xmlconfig.getNodeValue("writecontrol/writeBufferSize", _writeBufferSize);
 	global_log->info() << "[MMPLD Writer] Start sampling from simstep: " << _startTimestep << endl;


### PR DESCRIPTION
For a changing number of time steps from simulation to simulation it is comfortable to not always have to change the stop value of the MMPLD writer. Right now, if set to a very high number, the mmpld file is quite big and the initialization of the plugin takes quite some time.

With the minimum calculation, the stop value can be set to a very high number without worrying about big files.

Tested by setting the stop value to a greater number than the time step. This leads to the desired limiting.