### PR TITLE
GDD optionally latches to grid

### DIFF
--- a/examples/Argon/200K_18mol_l/config_autopas_allOptions.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_allOptions.xml
@@ -37,6 +37,7 @@
 		  <initialPhaseTime>10000</initialPhaseTime>
 		  <comment>initialPhaseTime specifies for how many time steps the initial rebalancing phase should last, in which initialPhaseFrequency is applied instead of updateFrequency.</comment>
           <initialPhaseFrequency>500</initialPhaseFrequency><comment>initialPhaseFrequency specifies how often a rebalancing will occur within the initial rebalancing phase.</comment>
+          <gridSize>34</gridSize><comment>gridSize can be used to fix process boundaries to a grid. Either one value or three comma separated values (e.g., '34,34.5,34.6') are possible.</comment>
           <comment>choose one of the following:</comment>
           <loadBalancer type="ALL"></loadBalancer>
       </parallelisation>

--- a/examples/Argon/200K_18mol_l/config_autopas_allOptions.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_allOptions.xml
@@ -31,12 +31,16 @@
     </ensemble>
     <algorithm>
       <parallelisation type="DomainDecomposition"/>
-      <!--<parallelisation type="GeneralDomainDecomposition">
+      <!--
+      <parallelisation type="GeneralDomainDecomposition">
 		  <updateFrequency>1000</updateFrequency><comment>updateFrequency specifies how often a rebalancing will occur.</comment>
 		  <initialPhaseTime>10000</initialPhaseTime>
 		  <comment>initialPhaseTime specifies for how many time steps the initial rebalancing phase should last, in which initialPhaseFrequency is applied instead of updateFrequency.</comment>
           <initialPhaseFrequency>500</initialPhaseFrequency><comment>initialPhaseFrequency specifies how often a rebalancing will occur within the initial rebalancing phase.</comment>
-      </parallelisation>-->
+          <comment>choose one of the following:</comment>
+          <loadBalancer type="ALL"></loadBalancer>
+      </parallelisation>
+      -->
       <datastructure type="AutoPas">
         <allowedTraversals>c01, c08, c04, c18, sliced, verlet-lists, verlet-sliced, verlet-c01, verlet-c18, c01-combined-SoA, verlet-clusters, var-verlet-lists-as-build,verlet-clusters-coloring, c04SoA, directSum, verlet-cluster-cells, verlet-clusters-static</allowedTraversals>
         <allowedContainers>DirectSum,LinkedCells, VerletLists, VerletListsCells, VerletClusterLists,VarVerletListsAsBuild,VerletClusterCells</allowedContainers>

--- a/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
@@ -31,7 +31,7 @@
         </ensemble>
         <algorithm>
             <parallelisation type="GeneralDomainDecomposition">
-                <updateFrequency>5</updateFrequency>
+                <updateFrequency>10000</updateFrequency>
                 <!--<gridSize>7,5,9</gridSize>-->
                 <loadBalancer type="ALL">
 
@@ -45,7 +45,7 @@
                 <skin>1.</skin><!--roughly 10% of cutoff-->
             </datastructure>
             <cutoffs type="CenterOfMass">
-                <radiusLJ unit="reduced">3</radiusLJ>
+                <radiusLJ unit="reduced">33.0702</radiusLJ>
             </cutoffs>
             <electrostatic type="ReactionField">
                 <epsilon>1.0e+10</epsilon>

--- a/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
@@ -31,7 +31,9 @@
     </ensemble>
     <algorithm>
 	    <parallelisation type="GeneralDomainDecomposition">
-		    <updateFrequency>1000</updateFrequency>
+		  <updateFrequency>1000</updateFrequency>
+          <!--<loadBalancer type="ALL"></loadBalancer>-->
+            <loadBalancer type="ALL"></loadBalancer>
 	    </parallelisation>
       <datastructure type="AutoPas">
         <allowedContainers>linkedCells</allowedContainers>

--- a/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
@@ -1,81 +1,89 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mardyn version="20100525">
-  <refunits type="SI">
-    <length unit="nm">0.0529177</length>
-    <mass unit="u">1000</mass>
-    <energy unit="eV">27.2126</energy>
-  </refunits>
-  <simulation type="MD">
-    <integrator type="Leapfrog">
-      <timestep unit="reduced">0.0667516</timestep>
-    </integrator>
-    <run>
-      <currenttime>0</currenttime>
-      <production>
-        <steps>100000</steps>
-      </production>
-    </run>
-    <ensemble type="NVT">
-      <temperature unit="reduced">0.000633363365</temperature>
-      <domain type="box">
-        <lx>108.43455</lx>
-        <ly>108.43455</ly>
-        <lz>108.43455</lz>
-      </domain>
-      <components>
-        <include query="/components/moleculetype">../components.xml</include>
-      </components>
-      <phasespacepoint>
-        <file type="ASCII">Argon_200K_18mol_l.inp</file>
-      </phasespacepoint>
-    </ensemble>
-    <algorithm>
-	    <parallelisation type="GeneralDomainDecomposition">
-		  <updateFrequency>1000</updateFrequency>
-          <gridSize>7,5,9</gridSize>
-            <loadBalancer type="ALL"></loadBalancer>
-	    </parallelisation>
-      <datastructure type="AutoPas">
-        <allowedContainers>linkedCells</allowedContainers>
-        <tuningInterval>10000</tuningInterval>
-        <tuningSamples>10</tuningSamples>
-        <rebuildFrequency>10</rebuildFrequency>
-        <skin>1.</skin><!--roughly 10% of cutoff-->
-      </datastructure>
-      <cutoffs type="CenterOfMass">
-        <radiusLJ unit="reduced">33.0702</radiusLJ>
-      </cutoffs>
-      <electrostatic type="ReactionField">
-        <epsilon>1.0e+10</epsilon>
-      </electrostatic>
-    </algorithm>
-    <output>
-      <!--<outputplugin name="MmpldWriter" type="simple">
-        <include query="/spheres">../sphereparams_argon.xml</include>
-        <writecontrol>
-          <start>0</start>
-          <writefrequency>100</writefrequency>
-          <stop>1000000000</stop>
-          <framesperfile>0</framesperfile>
-        </writecontrol>
-        <outputprefix>megamol</outputprefix>
-      </outputplugin>-->
-      <!-- <outputplugin name="ResultWriter"> -->
-        <!-- <writefrequency>5</writefrequency> -->
-        <!-- <outputprefix>Argon</outputprefix> -->
-      <!-- </outputplugin> -->
-      <!--<outputplugin name="SysMonOutput">
-        <writefrequency>10000</writefrequency>
-        <expression label="LoadAvg1">procloadavg:loadavg1</expression>
-        <expression label="Free+BufferRAM [MB]">sysinfo:freeram sysinfo:bufferram + sysinfo:mem_unit * float 1048576 /</expression>
-      </outputplugin>-->
-      <!--<outputplugin name="VTKMoleculeWriter">
-        <outputprefix>vtkOutput</outputprefix>
-        <writefrequency>1</writefrequency>
-      </outputplugin>-->
-    </output>
-	<!--<plugin name="TestPlugin">
-		<writefrequency>1</writefrequency>
-	</plugin>-->
-  </simulation>
+    <refunits type="SI">
+        <length unit="nm">0.0529177</length>
+        <mass unit="u">1000</mass>
+        <energy unit="eV">27.2126</energy>
+    </refunits>
+    <simulation type="MD">
+        <integrator type="Leapfrog">
+            <timestep unit="reduced">0.0667516</timestep>
+        </integrator>
+        <run>
+            <currenttime>0</currenttime>
+            <production>
+                <steps>100000</steps>
+            </production>
+        </run>
+        <ensemble type="NVT">
+            <temperature unit="reduced">0.000633363365</temperature>
+            <domain type="box">
+                <lx>108.43455</lx>
+                <ly>108.43455</ly>
+                <lz>108.43455</lz>
+            </domain>
+            <components>
+                <include query="/components/moleculetype">../components.xml</include>
+            </components>
+            <phasespacepoint>
+                <file type="ASCII">Argon_200K_18mol_l.inp</file>
+            </phasespacepoint>
+        </ensemble>
+        <algorithm>
+            <parallelisation type="GeneralDomainDecomposition">
+                <updateFrequency>5</updateFrequency>
+                <!--<gridSize>7,5,9</gridSize>-->
+                <loadBalancer type="ALL">
+
+                </loadBalancer>
+            </parallelisation>
+            <datastructure type="AutoPas">
+                <allowedContainers>linkedCells</allowedContainers>
+                <tuningInterval>10000</tuningInterval>
+                <tuningSamples>10</tuningSamples>
+                <rebuildFrequency>10</rebuildFrequency>
+                <skin>1.</skin><!--roughly 10% of cutoff-->
+            </datastructure>
+            <cutoffs type="CenterOfMass">
+                <radiusLJ unit="reduced">3</radiusLJ>
+            </cutoffs>
+            <electrostatic type="ReactionField">
+                <epsilon>1.0e+10</epsilon>
+            </electrostatic>
+        </algorithm>
+        <output>
+            <outputplugin name="DecompWriter">
+                <writefrequency>5</writefrequency>
+                <outputprefix>decomp</outputprefix>
+                <incremental>1</incremental>
+                <appendTimestamp>0</appendTimestamp>
+            </outputplugin>
+            <!--<outputplugin name="MmpldWriter" type="simple">
+              <include query="/spheres">../sphereparams_argon.xml</include>
+              <writecontrol>
+                <start>0</start>
+                <writefrequency>100</writefrequency>
+                <stop>1000000000</stop>
+                <framesperfile>0</framesperfile>
+              </writecontrol>
+              <outputprefix>megamol</outputprefix>
+            </outputplugin>-->
+            <!-- <outputplugin name="ResultWriter"> -->
+            <!-- <writefrequency>5</writefrequency> -->
+            <!-- <outputprefix>Argon</outputprefix> -->
+            <!-- </outputplugin> -->
+            <!--<outputplugin name="SysMonOutput">
+              <writefrequency>10000</writefrequency>
+              <expression label="LoadAvg1">procloadavg:loadavg1</expression>
+              <expression label="Free+BufferRAM [MB]">sysinfo:freeram sysinfo:bufferram + sysinfo:mem_unit * float 1048576 /</expression>
+            </outputplugin>-->
+            <!--<outputplugin name="VTKMoleculeWriter">
+              <outputprefix>vtkOutput</outputprefix>
+              <writefrequency>1</writefrequency>
+            </outputplugin>-->
+        </output>
+        <!--<plugin name="TestPlugin">
+            <writefrequency>1</writefrequency>
+        </plugin>-->
+    </simulation>
 </mardyn>

--- a/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
@@ -32,7 +32,7 @@
     <algorithm>
 	    <parallelisation type="GeneralDomainDecomposition">
 		  <updateFrequency>1000</updateFrequency>
-          <!--<loadBalancer type="ALL"></loadBalancer>-->
+          <gridSize>7,5,9</gridSize>
             <loadBalancer type="ALL"></loadBalancer>
 	    </parallelisation>
       <datastructure type="AutoPas">

--- a/src/parallel/ALLLoadBalancer.cpp
+++ b/src/parallel/ALLLoadBalancer.cpp
@@ -7,7 +7,7 @@
 #include "ALLLoadBalancer.h"
 ALLLoadBalancer::ALLLoadBalancer(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double gamma,
 								 MPI_Comm comm, std::array<size_t, 3> globalSize,
-								 std::array<size_t, 3> localCoordinates, double minimalPartitionSize)
+								 std::array<size_t, 3> localCoordinates, std::array<double, 3> minimalPartitionSize)
 	: _all(3 /*dim*/, gamma) {
 	std::vector<Point> points;
 	points.emplace_back(3, boxMin.data());
@@ -27,8 +27,7 @@ ALLLoadBalancer::ALLLoadBalancer(std::array<double, 3> boxMin, std::array<double
 std::tuple<std::array<double, 3>, std::array<double, 3>> ALLLoadBalancer::rebalance(double work) {
 	_all.set_work(work);
 	_all.setup(ALL_LB_t::STAGGERED);
-	std::array<double, 3> minDomainSize{_minimalPartitionSize, _minimalPartitionSize, _minimalPartitionSize};
-	_all.set_min_domain_size(ALL_LB_t::STAGGERED, minDomainSize.data());
+	_all.set_min_domain_size(ALL_LB_t::STAGGERED, _minimalPartitionSize.data());
 	_all.balance(ALL_LB_t::STAGGERED);
 	auto resultVertices = _all.get_result_vertices();
 	std::array<double, 3> boxMin{resultVertices[0].x(0), resultVertices[0].x(1), resultVertices[0].x(2)};

--- a/src/parallel/ALLLoadBalancer.cpp
+++ b/src/parallel/ALLLoadBalancer.cpp
@@ -20,6 +20,8 @@ ALLLoadBalancer::ALLLoadBalancer(std::array<double, 3> boxMin, std::array<double
 	_all.set_proc_grid_params(coords.data(), global_size.data());
 	_all.set_communicator(comm);
 
+	_coversWholeDomain = {globalSize[0] == 1, global_size[1] == 1, global_size[2] == 1};
+
 	_minimalPartitionSize = minimalPartitionSize;
 }
 std::tuple<std::array<double, 3>, std::array<double, 3>> ALLLoadBalancer::rebalance(double work) {

--- a/src/parallel/ALLLoadBalancer.h
+++ b/src/parallel/ALLLoadBalancer.h
@@ -13,7 +13,7 @@ class ALLLoadBalancer : public LoadBalancer {
 public:
 	ALLLoadBalancer(std::array<double, 3> boxMin, std::array<double, 3> boxMax, double gamma, MPI_Comm comm,
 					std::array<size_t, 3> globalSize, std::array<size_t, 3> localCoordinates,
-					double minimalPartitionSize);
+					std::array<double, 3> minimalPartitionSize);
 
 	~ALLLoadBalancer() override = default;
 	std::tuple<std::array<double, 3>, std::array<double, 3>> rebalance(double work) override;
@@ -26,7 +26,7 @@ public:
 private:
 	ALL<double, double> _all;
 	using Point = ALL_Point<double>;
-	double _minimalPartitionSize{};
+	std::array<double, 3> _minimalPartitionSize{};
 	std::array<bool, 3> _coversWholeDomain{};
 };
 #endif

--- a/src/parallel/ALLLoadBalancer.h
+++ b/src/parallel/ALLLoadBalancer.h
@@ -17,10 +17,16 @@ public:
 
 	~ALLLoadBalancer() override = default;
 	std::tuple<std::array<double, 3>, std::array<double, 3>> rebalance(double work) override;
+	void readXML(XMLfileUnits& xmlconfig) override {
+		// nothing yet.
+	}
+
+	std::array<bool, 3> getCoversWholeDomain() override { return _coversWholeDomain; }
 
 private:
 	ALL<double, double> _all;
 	using Point = ALL_Point<double>;
 	double _minimalPartitionSize{};
+	std::array<bool, 3> _coversWholeDomain{};
 };
 #endif

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -13,26 +13,27 @@
 #include "NeighbourCommunicationScheme.h"
 
 GeneralDomainDecomposition::GeneralDomainDecomposition(double interactionLength, Domain* domain)
-	: _boxMin{0.}, _boxMax{0.} {
-	std::array<double, 3> domainLength = {domain->getGlobalLength(0), domain->getGlobalLength(1),
-										  domain->getGlobalLength(2)};
+	: _boxMin{0.},
+	  _boxMax{0.},
+	  _domainLength{domain->getGlobalLength(0), domain->getGlobalLength(1), domain->getGlobalLength(2)},
+	  _interactionLength{interactionLength} {}
 
-	auto gridSize = getOptimalGrid(domainLength, this->getNumProcs());
+void GeneralDomainDecomposition::initializeALL() {
+	global_log->info() << "initializing ALL load balancer..." << std::endl;
+	auto gridSize = getOptimalGrid(_domainLength, this->getNumProcs());
 	auto gridCoords = getCoordsFromRank(gridSize, _rank);
-	_coversWholeDomain = {gridSize[0] == 1, gridSize[1] == 1, gridSize[2] == 1};
 	global_log->info() << "gridSize:" << gridSize[0] << ", " << gridSize[1] << ", " << gridSize[2] << std::endl;
 	global_log->info() << "gridCoords:" << gridCoords[0] << ", " << gridCoords[1] << ", " << gridCoords[2] << std::endl;
-	std::tie(_boxMin, _boxMax) = initializeRegularGrid(domainLength, gridSize, gridCoords);
+	std::tie(_boxMin, _boxMax) = initializeRegularGrid(_domainLength, gridSize, gridCoords);
 #ifdef ENABLE_ALLLBL
 	// Increased slightly to prevent rounding errors.
-	double minimalDomainSize{interactionLength * (1. + 1.e-10)};
+	double minimalDomainSize{_interactionLength * (1. + 1.e-10)};
 	_loadBalancer = std::make_unique<ALLLoadBalancer>(_boxMin, _boxMax, 4 /*gamma*/, this->getCommunicator(), gridSize,
 													  gridCoords, minimalDomainSize);
 #else
 	global_log->error() << "ALL load balancing library not enabled. Aborting." << std::endl;
 	Simulation::exit(24235);
 #endif
-
 	global_log->info() << "GeneralDomainDecomposition initial box: [" << _boxMin[0] << ", " << _boxMax[0] << "] x ["
 					   << _boxMin[1] << ", " << _boxMax[1] << "] x [" << _boxMin[2] << ", " << _boxMax[2] << "]"
 					   << std::endl;
@@ -211,9 +212,10 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 
 void GeneralDomainDecomposition::initCommPartners(ParticleContainer* moleculeContainer,
 												  Domain* domain) {  // init communication partners
+	auto coversWholeDomain = _loadBalancer->getCoversWholeDomain();
 	for (int d = 0; d < DIMgeom; ++d) {
 		// this needs to be updated for proper initialization of the neighbours
-		_neighbourCommunicationScheme->setCoverWholeDomain(d, _coversWholeDomain[d]);
+		_neighbourCommunicationScheme->setCoverWholeDomain(d, coversWholeDomain[d]);
 	}
 	_neighbourCommunicationScheme->initCommunicationPartners(moleculeContainer->getCutoff(), domain, this,
 															 moleculeContainer);
@@ -235,6 +237,27 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 	xmlconfig.getNodeValue("initialPhaseFrequency", _initFrequency);
 	global_log->info() << "GeneralDomainDecomposition frequency for initial rebalancing phase: " << _initFrequency
 					   << endl;
+
+	if(xmlconfig.changecurrentnode("loadBalancer")) {
+		std::string loadBalancerString = "None";
+		xmlconfig.getNodeValue("@type", loadBalancerString);
+		global_log->info() << "Chosen Load Balancer: " << loadBalancerString << std::endl;
+
+		std::transform(loadBalancerString.begin(), loadBalancerString.end(), loadBalancerString.begin(), ::tolower);
+
+		if (loadBalancerString.find("all") != std::string::npos) {
+			initializeALL();
+		} else {
+			global_log->error() << "GeneralDomainDecomposition: Unknown load balancer " << loadBalancerString
+			                    << ". Aborting! Please select a valid option! Valid options: ALL";
+			Simulation::exit(1);
+		}
+		_loadBalancer->readXML(xmlconfig);
+	} else{
+		global_log->error() << "loadBalancer section missing! Aborting!" << std::endl;
+	}
+	xmlconfig.changecurrentnode("..");
+
 }
 
 /**

--- a/src/parallel/GeneralDomainDecomposition.h
+++ b/src/parallel/GeneralDomainDecomposition.h
@@ -194,6 +194,10 @@ private:
 	size_t _initPhase{0};
 	size_t _initFrequency{500};
 
+	/**
+	 * Optionally safe a given grid size on which the process boundaries are bound/latched.
+	 * If no value is given, it is not used.
+	 */
 	std::optional<std::array<double, 3>> _gridSize{};
 
 	std::unique_ptr<LoadBalancer> _loadBalancer{nullptr};

--- a/src/parallel/GeneralDomainDecomposition.h
+++ b/src/parallel/GeneralDomainDecomposition.h
@@ -160,6 +160,13 @@ private:
 	void migrateParticles(Domain* domain, ParticleContainer* particleContainer, std::array<double, 3> newMin,
 						  std::array<double, 3> newMax);
 
+	/**
+	 * Latches domain boundaries (given as boxMin and boxMax) to a grid, which is defined by _gridSize.
+	 * If boxMax matches the top boundary, it is not changed.
+	 * @param boxMin
+	 * @param boxMax
+	 * @return The new boundaries.
+	 */
 	std::pair<std::array<double, 3>, std::array<double, 3>> latchToGridSize(std::array<double, 3> boxMin,
 																			std::array<double, 3> boxMax) {
 		for (size_t ind = 0; ind < 3; ++ind) {

--- a/src/parallel/GeneralDomainDecomposition.h
+++ b/src/parallel/GeneralDomainDecomposition.h
@@ -32,6 +32,10 @@ public:
 		  <updateFrequency>INTEGER</updateFrequency>
 		  <initialPhaseTime>INTEGER</initialPhaseTime><!--time for initial rebalancing phase-->
 		  <initialPhaseFrequency>INTEGER</initialPhaseFrequency><!--frequency for initial rebalancing phase-->
+		  <loadBalancer type="STRING"> <!--STRING...type of the load balancer, currently supported: ALL-->
+		    <!--options for the load balancer-->
+			<!--for detailed information see the readXML functions from ALLLoadBalancer.-->
+		  </loadBalancer>
 	   </parallelisation>
 	   \endcode
 	 */
@@ -86,6 +90,11 @@ public:
 	}
 
 private:
+	/**
+	 * Method that initializes the ALLLoadBalancer
+	 */
+	void initializeALL();
+
 	/**
 	 * Get the optimal grid for the given dimensions of the box and the number of processes.
 	 * The grid is produced, s.t., the number of grid[0] * grid[1] * grid[2] == numProcs
@@ -152,7 +161,8 @@ private:
 	std::array<double, 3> _boxMin;
 	std::array<double, 3> _boxMax;
 
-	std::array<bool, 3> _coversWholeDomain{};
+	std::array<double, 3> _domainLength;
+	double _interactionLength;
 
 	size_t _steps{0};
 	size_t _rebuildFrequency{10000};

--- a/src/parallel/GeneralDomainDecomposition.h
+++ b/src/parallel/GeneralDomainDecomposition.h
@@ -32,7 +32,8 @@ public:
 		  <updateFrequency>INTEGER</updateFrequency>
 		  <initialPhaseTime>INTEGER</initialPhaseTime><!--time for initial rebalancing phase-->
 		  <initialPhaseFrequency>INTEGER</initialPhaseFrequency><!--frequency for initial rebalancing phase-->
-		  <loadBalancer type="STRING"> <!--STRING...type of the load balancer, currently supported: ALL-->
+		  <gridSize>DOUBLE</gridSize><!--default: 0; if non-zero, the process boundaries are fixed to multiples of gridSize.-->
+		  <loadBalancer type="STRING"><!--STRING...type of the load balancer, currently supported: ALL-->
 		    <!--options for the load balancer-->
 			<!--for detailed information see the readXML functions from ALLLoadBalancer.-->
 		  </loadBalancer>
@@ -169,6 +170,8 @@ private:
 
 	size_t _initPhase{0};
 	size_t _initFrequency{500};
+
+	double _gridSize{0.};
 
 	std::unique_ptr<LoadBalancer> _loadBalancer{nullptr};
 

--- a/src/parallel/LoadBalancer.h
+++ b/src/parallel/LoadBalancer.h
@@ -7,6 +7,7 @@
 #pragma once
 #include <array>
 #include <tuple>
+#include "utils/xmlfileUnits.h"
 
 /**
  * LoadBalancer class for the usage of arbitrary load balancing classes that are handled by GeneralDomainDecomposition.
@@ -20,12 +21,25 @@ public:
 
 	/**
 	 * The rebalancing call.
-	 * Based on the current domain and the work for that domain this function determines a new 
+	 * Based on the current domain and the work for that domain this function determines a new
 	 * domain decomposition that provides a better load balancing.
 	 * This call will normally include communication and exchange of information with other processes.
 	 * @param work Arbitrary unit of work, e.g., time for the current process
-	 * @return New domain boundaries for the current process. First entry is the new boxMin, 
+	 * @return New domain boundaries for the current process. First entry is the new boxMin,
 	 * second the new boxMax.
 	 */
 	virtual std::tuple<std::array<double, 3>, std::array<double, 3>> rebalance(double work) = 0;
+
+	/**
+	 * Read Config file
+	 * @param xmlconfig
+	 */
+	virtual void readXML(XMLfileUnits& xmlconfig) = 0;
+
+	/**
+	 * Get the information in which direction this process covers the entire domain.
+	 * @return array of bools, for each dimension one value: true, iff the domain is filled only be the current process,
+	 * i.e, the process spans the entire domain.
+	 */
+	virtual std::array<bool, 3> getCoversWholeDomain() = 0;
 };

--- a/src/utils/String_utils.h
+++ b/src/utils/String_utils.h
@@ -48,4 +48,16 @@ static std::string trim(const std::string& str, const std::string &whitespace = 
 	return str.substr(strBegin, strRange);
 }
 
+static std::vector<std::string> split(const std::string& input, const char delimiter ){
+	size_t last = 0;
+	size_t next = 0;
+	std::vector<std::string> output;
+	while ((next = input.find(delimiter, last)) != std::string::npos) {
+		output.emplace_back(input.substr(last, next - last));
+		last = next + 1;
+	}
+	output.emplace_back(input.substr(last));
+	return output;
+}
+
 }  // namespace string_utils

--- a/src/utils/String_utils.h
+++ b/src/utils/String_utils.h
@@ -48,6 +48,12 @@ static std::string trim(const std::string& str, const std::string &whitespace = 
 	return str.substr(strBegin, strRange);
 }
 
+/**
+ * Split a given input string using a delimiter into a vector of substrings.
+ * @param input The input string.
+ * @param delimiter The delimiter.
+ * @return Vector of substrings.
+ */
 static std::vector<std::string> split(const std::string& input, const char delimiter ){
 	size_t last = 0;
 	size_t next = 0;


### PR DESCRIPTION
# Description

Makes it possible for GDD to latch to a grid:

Add the xml-entry `<gridSize>STRING</gridSize>` to the parallelisation tag (only GDD). STRING can be either one double or three, which specify the grid sizes in the different dimensions.

## Related Pull Requests

- includes changes from #167, so should be merged after it.

## Resolved Issues

- [x] fixes #166 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Ran locally
- [ ] Ran on Cluster
