### PR TITLE
Enable ALL without AutoPas + Adds Averaged Load Balance for LoadBalanceWriter

### DIFF
--- a/examples/Argon/200K_18mol_l/config_noAP_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_noAP_ALL.xml
@@ -1,85 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mardyn version="20100525">
-    <refunits type="SI">
-        <length unit="nm">0.0529177</length>
-        <mass unit="u">1000</mass>
-        <energy unit="eV">27.2126</energy>
-    </refunits>
-    <simulation type="MD">
-        <integrator type="Leapfrog">
-            <timestep unit="reduced">0.0667516</timestep>
-        </integrator>
-        <run>
-            <currenttime>0</currenttime>
-            <production>
-                <steps>100000</steps>
-            </production>
-        </run>
-        <ensemble type="NVT">
-            <temperature unit="reduced">0.000633363365</temperature>
-            <domain type="box">
-                <lx>108.43455</lx>
-                <ly>108.43455</ly>
-                <lz>108.43455</lz>
-            </domain>
-            <components>
-                <include query="/components/moleculetype">../components.xml</include>
-            </components>
-            <phasespacepoint>
-                <file type="ASCII">Argon_200K_18mol_l.inp</file>
-            </phasespacepoint>
-        </ensemble>
-        <algorithm>
-            <parallelisation type="GeneralDomainDecomposition">
-                <updateFrequency>10000</updateFrequency>
-                <!--<gridSize>7,5,9</gridSize>-->
-                <loadBalancer type="ALL">
+	<refunits type="SI">
+		<length unit="nm">0.0529177</length>
+		<mass unit="u">1000</mass>
+		<energy unit="eV">27.2126</energy>
+	</refunits>
+	<simulation type="MD">
+		<integrator type="Leapfrog">
+			<timestep unit="reduced">0.0667516</timestep>
+		</integrator>
+		<run>
+			<currenttime>0</currenttime>
+			<production>
+				<steps>100000</steps>
+			</production>
+		</run>
+		<ensemble type="NVT">
+			<temperature unit="reduced">0.000633363365</temperature>
+			<domain type="box">
+				<lx>108.43455</lx>
+				<ly>108.43455</ly>
+				<lz>108.43455</lz>
+			</domain>
+			<components>
+				<include query="/components/moleculetype">../components.xml</include>
+			</components>
+			<phasespacepoint>
+				<file type="ASCII">Argon_200K_18mol_l.inp</file>
+			</phasespacepoint>
+		</ensemble>
+		<algorithm>
+			<parallelisation type="GeneralDomainDecomposition">
+				<updateFrequency>10000</updateFrequency>
+				<!--<gridSize>7,5,9</gridSize>-->
+				<loadBalancer type="ALL">
 
-                </loadBalancer>
-            </parallelisation>
-            <datastructure type="LinkedCells">
-                <cellsInCutoffRadius>1</cellsInCutoffRadius>
-            </datastructure>
-            <cutoffs type="CenterOfMass">
-                <radiusLJ unit="reduced">33.0702</radiusLJ>
-            </cutoffs>
-            <electrostatic type="ReactionField">
-                <epsilon>1.0e+10</epsilon>
-            </electrostatic>
-        </algorithm>
-        <output>
-            <outputplugin name="DecompWriter">
-                <writefrequency>5</writefrequency>
-                <outputprefix>decomp</outputprefix>
-                <incremental>1</incremental>
-                <appendTimestamp>0</appendTimestamp>
-            </outputplugin>
-            <!--<outputplugin name="MmpldWriter" type="simple">
-              <include query="/spheres">../sphereparams_argon.xml</include>
-              <writecontrol>
-                <start>0</start>
-                <writefrequency>100</writefrequency>
-                <stop>1000000000</stop>
-                <framesperfile>0</framesperfile>
-              </writecontrol>
-              <outputprefix>megamol</outputprefix>
-            </outputplugin>-->
-            <!-- <outputplugin name="ResultWriter"> -->
-            <!-- <writefrequency>5</writefrequency> -->
-            <!-- <outputprefix>Argon</outputprefix> -->
-            <!-- </outputplugin> -->
-            <!--<outputplugin name="SysMonOutput">
-              <writefrequency>10000</writefrequency>
-              <expression label="LoadAvg1">procloadavg:loadavg1</expression>
-              <expression label="Free+BufferRAM [MB]">sysinfo:freeram sysinfo:bufferram + sysinfo:mem_unit * float 1048576 /</expression>
-            </outputplugin>-->
-            <!--<outputplugin name="VTKMoleculeWriter">
-              <outputprefix>vtkOutput</outputprefix>
-              <writefrequency>1</writefrequency>
-            </outputplugin>-->
-        </output>
-        <!--<plugin name="TestPlugin">
-            <writefrequency>1</writefrequency>
-        </plugin>-->
-    </simulation>
+				</loadBalancer>
+			</parallelisation>
+			<datastructure type="LinkedCells">
+				<cellsInCutoffRadius>1</cellsInCutoffRadius>
+			</datastructure>
+			<cutoffs type="CenterOfMass">
+				<radiusLJ unit="reduced">33.0702</radiusLJ>
+			</cutoffs>
+			<electrostatic type="ReactionField">
+				<epsilon>1.0e+10</epsilon>
+			</electrostatic>
+		</algorithm>
+		<output>
+			<outputplugin name="DecompWriter">
+				<writefrequency>5</writefrequency>
+				<outputprefix>decomp</outputprefix>
+				<incremental>1</incremental>
+				<appendTimestamp>0</appendTimestamp>
+			</outputplugin>
+		</output>
+	</simulation>
 </mardyn>

--- a/examples/Argon/200K_18mol_l/config_noAP_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_noAP_ALL.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mardyn version="20100525">
+    <refunits type="SI">
+        <length unit="nm">0.0529177</length>
+        <mass unit="u">1000</mass>
+        <energy unit="eV">27.2126</energy>
+    </refunits>
+    <simulation type="MD">
+        <integrator type="Leapfrog">
+            <timestep unit="reduced">0.0667516</timestep>
+        </integrator>
+        <run>
+            <currenttime>0</currenttime>
+            <production>
+                <steps>100000</steps>
+            </production>
+        </run>
+        <ensemble type="NVT">
+            <temperature unit="reduced">0.000633363365</temperature>
+            <domain type="box">
+                <lx>108.43455</lx>
+                <ly>108.43455</ly>
+                <lz>108.43455</lz>
+            </domain>
+            <components>
+                <include query="/components/moleculetype">../components.xml</include>
+            </components>
+            <phasespacepoint>
+                <file type="ASCII">Argon_200K_18mol_l.inp</file>
+            </phasespacepoint>
+        </ensemble>
+        <algorithm>
+            <parallelisation type="GeneralDomainDecomposition">
+                <updateFrequency>10000</updateFrequency>
+                <!--<gridSize>7,5,9</gridSize>-->
+                <loadBalancer type="ALL">
+
+                </loadBalancer>
+            </parallelisation>
+            <datastructure type="LinkedCells">
+                <cellsInCutoffRadius>1</cellsInCutoffRadius>
+            </datastructure>
+            <cutoffs type="CenterOfMass">
+                <radiusLJ unit="reduced">33.0702</radiusLJ>
+            </cutoffs>
+            <electrostatic type="ReactionField">
+                <epsilon>1.0e+10</epsilon>
+            </electrostatic>
+        </algorithm>
+        <output>
+            <outputplugin name="DecompWriter">
+                <writefrequency>5</writefrequency>
+                <outputprefix>decomp</outputprefix>
+                <incremental>1</incremental>
+                <appendTimestamp>0</appendTimestamp>
+            </outputplugin>
+            <!--<outputplugin name="MmpldWriter" type="simple">
+              <include query="/spheres">../sphereparams_argon.xml</include>
+              <writecontrol>
+                <start>0</start>
+                <writefrequency>100</writefrequency>
+                <stop>1000000000</stop>
+                <framesperfile>0</framesperfile>
+              </writecontrol>
+              <outputprefix>megamol</outputprefix>
+            </outputplugin>-->
+            <!-- <outputplugin name="ResultWriter"> -->
+            <!-- <writefrequency>5</writefrequency> -->
+            <!-- <outputprefix>Argon</outputprefix> -->
+            <!-- </outputplugin> -->
+            <!--<outputplugin name="SysMonOutput">
+              <writefrequency>10000</writefrequency>
+              <expression label="LoadAvg1">procloadavg:loadavg1</expression>
+              <expression label="Free+BufferRAM [MB]">sysinfo:freeram sysinfo:bufferram + sysinfo:mem_unit * float 1048576 /</expression>
+            </outputplugin>-->
+            <!--<outputplugin name="VTKMoleculeWriter">
+              <outputprefix>vtkOutput</outputprefix>
+              <writefrequency>1</writefrequency>
+            </outputplugin>-->
+        </output>
+        <!--<plugin name="TestPlugin">
+            <writefrequency>1</writefrequency>
+        </plugin>-->
+    </simulation>
+</mardyn>

--- a/examples/Argon/200K_18mol_l/config_temp_control.xml
+++ b/examples/Argon/200K_18mol_l/config_temp_control.xml
@@ -86,11 +86,6 @@
         <writefrequency>5</writefrequency>
         <outputprefix>Argon</outputprefix>
       </outputplugin>
-<!--<outputplugin name="FlopRateWriter">
-        <writefrequency>1</writefrequency>
-        <outputprefix>Argon_FLOPS</outputprefix>
-        <mode>stdout</mode>
-      </outputplugin>-->
       <outputplugin name="SysMonOutput">
         <writefrequency>10000</writefrequency>
         <expression label="LoadAvg1">procloadavg:loadavg1</expression>
@@ -107,7 +102,6 @@
         <timers> <!-- additional timers -->
           <timer> <name>LoadbalanceWriter_default</name> <warninglevel>2</warninglevel> </timer>
           <timer> <name>SIMULATION_FORCE_CALCULATION</name> <warninglevel>2</warninglevel> <incremental>1</incremental> </timer>
-          <!-- ... -->
         </timers>
       </outputplugin>
     </output>

--- a/examples/Argon/200K_18mol_l/config_temp_control.xml
+++ b/examples/Argon/200K_18mol_l/config_temp_control.xml
@@ -100,6 +100,16 @@
         <outputprefix>vtkOutput</outputprefix>
         <writefrequency>1</writefrequency>
       </outputplugin>
+      <outputplugin name="LoadbalanceWriter">
+        <writefrequency>10</writefrequency>
+        <averageLength>50</averageLength>
+        <outputfilename>lb.dat</outputfilename>
+        <timers> <!-- additional timers -->
+          <timer> <name>LoadbalanceWriter_default</name> <warninglevel>2</warninglevel> </timer>
+          <timer> <name>SIMULATION_FORCE_CALCULATION</name> <warninglevel>2</warninglevel> <incremental>1</incremental> </timer>
+          <!-- ... -->
+        </timers>
+      </outputplugin>
     </output>
 	<plugin name="TestPlugin">
 		<writefrequency>1</writefrequency>

--- a/examples/Generators/cubic_grid_generator/config_fs.xml
+++ b/examples/Generators/cubic_grid_generator/config_fs.xml
@@ -61,7 +61,9 @@
                 <splitThreshold>10000000</splitThreshold>
                 <generateNewFiles>False</generateNewFiles>
                 <useExistingFiles>False</useExistingFiles>
-                <doMeasureLoadCalc>False</doMeasureLoadCalc>
+                <doMeasureLoadCalc>True</doMeasureLoadCalc>
+                <measureLoadAlwaysUseInterpolation>False</measureLoadAlwaysUseInterpolation>
+                <measureLoadIncreasingTimeValues>True</measureLoadIncreasingTimeValues>
                 <deviationReductionOperation>max</deviationReductionOperation>
                 <CommunicationScheme>direct-pp</CommunicationScheme>
                 <minNumCellsPerDimension>1</minNumCellsPerDimension>
@@ -72,7 +74,7 @@
                 <cellsInCutoffRadius>1</cellsInCutoffRadius>
             </datastructure>
             <cutoffs type="CenterOfMass">
-                <radiusLJ unit="reduced">3.5</radiusLJ>
+                <radiusLJ unit="reduced">1.5</radiusLJ>
             </cutoffs>
             <electrostatic type="ReactionField">
                 <epsilon>1.0e+10</epsilon>

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -186,7 +186,9 @@
           <!-- select traversal algorithm
           possible values are:
             - original
+            - c04
             - c08        (default for >1 threads)
+            - c08es      (eight-shell)
             - quicksched
             - sliced     (default for <2 threads)
             - hs         (half shell method)

--- a/examples/surface-tension_LRC/2CLJ/vle/T0-979/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T0-979/run03/config.xml
@@ -51,30 +51,10 @@
 		</ensemble>
 
 		<algorithm>
-			<c><parallelisation type="DomainDecomposition">
-				 <!-- structure handled by DomainDecompMPIBase -->
+			<parallelisation type="DomainDecomposition">
+				<!-- structure handled by DomainDecompMPIBase -->
 				<MPIGridDims> <x>2</x> <y>2</y> <z>2</z> </MPIGridDims>
-			</parallelisation></c>
-			<parallelisation type="KDDecomposition">
-                <timerForLoad>SIMULATION_FORCE_CALCULATION</timerForLoad>
-                <updateFrequency>10000</updateFrequency>
-                <fullSearchThreshold>3</fullSearchThreshold>
-                <heterogeneousSystems>False</heterogeneousSystems>
-                <useVectorizationTuner>False</useVectorizationTuner>
-                <clusterHetSys>False</clusterHetSys>
-                <splitBiggestDimension>False</splitBiggestDimension>
-                <forceRatio>False</forceRatio>
-                <rebalanceLimit>0</rebalanceLimit>
-                <splitThreshold>10000000</splitThreshold>
-                <generateNewFiles>False</generateNewFiles>
-                <useExistingFiles>False</useExistingFiles>
-                <doMeasureLoadCalc>True</doMeasureLoadCalc>
-                <measureLoadAlwaysUseInterpolation>False</measureLoadAlwaysUseInterpolation>
-                <measureLoadIncreasingTimeValues>True</measureLoadIncreasingTimeValues>
-                <deviationReductionOperation>max</deviationReductionOperation>
-                <CommunicationScheme>direct-pp</CommunicationScheme>
-                <minNumCellsPerDimension>1</minNumCellsPerDimension>
-            </parallelisation>
+			</parallelisation>
 			<datastructure type="LinkedCells">
 				<cellsInCutoffRadius>1</cellsInCutoffRadius>
 			</datastructure>

--- a/examples/surface-tension_LRC/2CLJ/vle/T0-979/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T0-979/run03/config.xml
@@ -51,27 +51,36 @@
 		</ensemble>
 
 		<algorithm>
-			<parallelisation type="DomainDecomposition">
+			<c><parallelisation type="DomainDecomposition">
 				 <!-- structure handled by DomainDecompMPIBase -->
 				<MPIGridDims> <x>2</x> <y>2</y> <z>2</z> </MPIGridDims>
-			</parallelisation>
-<!--
+			</parallelisation></c>
 			<parallelisation type="KDDecomposition">
-				<CommunicationScheme>direct</CommunicationScheme>
-				<updateFrequency>100000</updateFrequency>
-				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
-			</parallelisation>
--->
+                <timerForLoad>SIMULATION_FORCE_CALCULATION</timerForLoad>
+                <updateFrequency>10000</updateFrequency>
+                <fullSearchThreshold>3</fullSearchThreshold>
+                <heterogeneousSystems>False</heterogeneousSystems>
+                <useVectorizationTuner>False</useVectorizationTuner>
+                <clusterHetSys>False</clusterHetSys>
+                <splitBiggestDimension>False</splitBiggestDimension>
+                <forceRatio>False</forceRatio>
+                <rebalanceLimit>0</rebalanceLimit>
+                <splitThreshold>10000000</splitThreshold>
+                <generateNewFiles>False</generateNewFiles>
+                <useExistingFiles>False</useExistingFiles>
+                <doMeasureLoadCalc>True</doMeasureLoadCalc>
+                <measureLoadAlwaysUseInterpolation>False</measureLoadAlwaysUseInterpolation>
+                <measureLoadIncreasingTimeValues>True</measureLoadIncreasingTimeValues>
+                <deviationReductionOperation>max</deviationReductionOperation>
+                <CommunicationScheme>direct-pp</CommunicationScheme>
+                <minNumCellsPerDimension>1</minNumCellsPerDimension>
+            </parallelisation>
 			<datastructure type="LinkedCells">
 				<cellsInCutoffRadius>1</cellsInCutoffRadius>
 			</datastructure>
 			<cutoffs type="CenterOfMass" >
-				<defaultCutoff unit="reduced" >4.0</defaultCutoff> <!-- sigma=1.0 => 3*sigma=3.0, 4*sigma=4.0, 5*sigma=5.0 -->
-				<radiusLJ unit="reduced" >4.0</radiusLJ>
+				<defaultCutoff unit="reduced" >2.0</defaultCutoff> <!-- sigma=1.0 => 3*sigma=3.0, 4*sigma=4.0, 5*sigma=5.0 -->
+				<radiusLJ unit="reduced" >2.0</radiusLJ>
 			</cutoffs>
 			<electrostatic type="ReactionField" >
 				<epsilon>1.0e+10</epsilon>

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -313,7 +313,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 				_domainDecomposition = new KDDecomposition(getcutoffRadius(), _ensemble->getComponents()->size());
 			} else if (parallelisationtype == "GeneralDomainDecomposition") {
 				double skin = 0.;
-				bool forceGrid = false;
+				bool forceLatchingToRegularGrid = false;
 				// we need the skin here, so we extract it from the AutoPas container's xml,
 				// because the ParticleContainer needs to be instantiated later. :/
 				xmlconfig.changecurrentnode("..");
@@ -323,15 +323,15 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 					if (datastructuretype == "AutoPas" or datastructuretype == "AutoPasContainer") {
 						xmlconfig.getNodeValue("skin", skin);
 					} else {
-						global_log->warning() << "Using the GeneralDomainDecomposition without AutoPas is not widely "
-												 "tested and considered BETA."
+						global_log->warning() << "Using the GeneralDomainDecomposition without AutoPas is not "
+												 "thoroughly tested and considered BETA."
 											  << endl;
 						// Force grid! This is needed, as the linked cells container assumes a grid and the calculation
 						// of global values will be faulty without one!
-						global_log->warning() << "Forcing a grid for the GeneralDomainDecomposition! This is required "
+						global_log->info() << "Forcing a grid for the GeneralDomainDecomposition! This is required "
 												 "to get correct global values!"
 											  << endl;
-						forceGrid = true;
+						forceLatchingToRegularGrid = true;
 					}
 					global_log->info() << "Using skin = " << skin << " for the GeneralDomainDecomposition." << std::endl;
 				} else {
@@ -343,7 +343,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 					Simulation::exit(1);
 				}
 				delete _domainDecomposition;
-				_domainDecomposition = new GeneralDomainDecomposition(getcutoffRadius() + skin, _domain, forceGrid);
+				_domainDecomposition = new GeneralDomainDecomposition(getcutoffRadius() + skin, _domain, forceLatchingToRegularGrid);
 			} else {
 				global_log->error() << "Unknown parallelisation type: " << parallelisationtype << endl;
 				Simulation::exit(1);

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -326,7 +326,8 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 						global_log->warning() << "Using the GeneralDomainDecomposition without AutoPas is not widely "
 												 "tested and considered BETA."
 											  << endl;
-						// Force grid!
+						// Force grid! This is needed, as the linked cells container assumes a grid and the calculation
+						// of global values will be faulty without one!
 						global_log->warning() << "Forcing a grid for the GeneralDomainDecomposition!" << endl;
 						forceGrid = true;
 					}

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -313,7 +313,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 				_domainDecomposition = new KDDecomposition(getcutoffRadius(), _ensemble->getComponents()->size());
 			} else if (parallelisationtype == "GeneralDomainDecomposition") {
 				double skin = 0.;
-				bool forceLatchingToRegularGrid = false;
+				bool forceLatchingToLinkedCellsGrid = false;
 				// we need the skin here, so we extract it from the AutoPas container's xml,
 				// because the ParticleContainer needs to be instantiated later. :/
 				xmlconfig.changecurrentnode("..");
@@ -331,7 +331,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 						global_log->info() << "Forcing a grid for the GeneralDomainDecomposition! This is required "
 												 "to get correct global values!"
 											  << endl;
-						forceLatchingToRegularGrid = true;
+						forceLatchingToLinkedCellsGrid = true;
 					}
 					global_log->info() << "Using skin = " << skin << " for the GeneralDomainDecomposition." << std::endl;
 				} else {
@@ -343,7 +343,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 					Simulation::exit(1);
 				}
 				delete _domainDecomposition;
-				_domainDecomposition = new GeneralDomainDecomposition(getcutoffRadius() + skin, _domain, forceLatchingToRegularGrid);
+				_domainDecomposition = new GeneralDomainDecomposition(getcutoffRadius() + skin, _domain, forceLatchingToLinkedCellsGrid);
 			} else {
 				global_log->error() << "Unknown parallelisation type: " << parallelisationtype << endl;
 				Simulation::exit(1);

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -365,7 +365,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			}
         #endif
 
-			string loadTimerStr("SIMULATION_COMPUTATION");
+			string loadTimerStr("SIMULATION_FORCE_CALCULATION");
 			xmlconfig.getNodeValue("timerForLoad", loadTimerStr);
 			global_log->info() << "Using timer " << loadTimerStr << " for the load calculation." << std::endl;
 			_timerForLoad = timers()->getTimer(loadTimerStr);

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -313,6 +313,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 				_domainDecomposition = new KDDecomposition(getcutoffRadius(), _ensemble->getComponents()->size());
 			} else if (parallelisationtype == "GeneralDomainDecomposition") {
 				double skin = 0.;
+				bool forceGrid = false;
 				// we need the skin here, so we extract it from the AutoPas container's xml,
 				// because the ParticleContainer needs to be instantiated later. :/
 				xmlconfig.changecurrentnode("..");
@@ -321,13 +322,15 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 					xmlconfig.getNodeValue("@type", datastructuretype);
 					if (datastructuretype == "AutoPas" or datastructuretype == "AutoPasContainer") {
 						xmlconfig.getNodeValue("skin", skin);
-						global_log->info() << "Using skin = " << skin << " for the GeneralDomainDecomposition." << std::endl;
 					} else {
-						global_log->error() << "Using the GeneralDomainDecomposition is only supported when using "
-											   "AutoPas, but the configuration file does not use it."
-											<< endl;
-						Simulation::exit(2);
+						global_log->warning() << "Using the GeneralDomainDecomposition without AutoPas is not widely "
+												 "tested and considered BETA."
+											  << endl;
+						// Force grid!
+						global_log->warning() << "Forcing a grid for the GeneralDomainDecomposition!" << endl;
+						forceGrid = true;
 					}
+					global_log->info() << "Using skin = " << skin << " for the GeneralDomainDecomposition." << std::endl;
 				} else {
 					global_log->error() << "Datastructure section missing" << endl;
 					Simulation::exit(1);
@@ -337,7 +340,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 					Simulation::exit(1);
 				}
 				delete _domainDecomposition;
-				_domainDecomposition = new GeneralDomainDecomposition(getcutoffRadius() + skin, _domain);
+				_domainDecomposition = new GeneralDomainDecomposition(getcutoffRadius() + skin, _domain, forceGrid);
 			} else {
 				global_log->error() << "Unknown parallelisation type: " << parallelisationtype << endl;
 				Simulation::exit(1);

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -328,7 +328,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 											  << endl;
 						// Force grid! This is needed, as the linked cells container assumes a grid and the calculation
 						// of global values will be faulty without one!
-						global_log->warning() << "Forcing a grid for the GeneralDomainDecomposition!" << endl;
+						global_log->warning() << "Forcing a grid for the GeneralDomainDecomposition! This is required "
+												 "to get correct global values!"
+											  << endl;
 						forceGrid = true;
 					}
 					global_log->info() << "Using skin = " << skin << " for the GeneralDomainDecomposition." << std::endl;

--- a/src/io/LoadBalanceWriter.cpp
+++ b/src/io/LoadBalanceWriter.cpp
@@ -18,6 +18,8 @@ LoadbalanceWriter::LoadbalanceWriter::LoadbalanceWriter() :
 void LoadbalanceWriter::readXML(XMLfileUnits& xmlconfig) {
 	xmlconfig.getNodeValue("writefrequency", _writeFrequency);
 	global_log->info() << "Write frequency: " << _writeFrequency << endl;
+	xmlconfig.getNodeValue("averageLength", _averageLength);
+	global_log->info() << "Average length: " << _averageLength << endl;
 	xmlconfig.getNodeValue("outputfilename", _outputFilename);
 	global_log->info() << "Output filename: " << _outputFilename << endl;
 
@@ -68,6 +70,8 @@ void LoadbalanceWriter::init(ParticleContainer */*particleContainer*/,
 
 	if (domainDecomp->getRank() == 0) {
 		_global_sum_times.reserve(_timerNames.size() * _writeFrequency);
+		_global_max_average_times.reserve(_timerNames.size() * (_writeFrequency+_averageLength));
+		_global_sum_average_times.reserve(_timerNames.size() * (_writeFrequency+_averageLength));
 	}
 
 	_defaultTimer->reset();
@@ -101,7 +105,7 @@ void LoadbalanceWriter::writeOutputFileHeader() {
 	}
 	outputfile << "\n";
 	for(const auto& timername : _timerNames) {
-		outputfile << "\tmin\tmax\tf_LB\timbalance";
+		outputfile << "\tmin\tmax\tf_LB\timbalance\timbalance_average";
 	}
 	outputfile << std::endl;
 	outputfile.close();
@@ -119,6 +123,7 @@ void LoadbalanceWriter::recordTimes(unsigned long simstep) {
 		}
 		_times.push_back(time);  // needed for maximum
 		_times.push_back(-time); // needed for minimum
+		_timesForAverage.emplace_back(time);  // needed for average
 	}
 }
 
@@ -135,6 +140,15 @@ void LoadbalanceWriter::flush(DomainDecompBase* domainDecomp) {
 	}
 	MPI_CHECK(MPI_Reduce(_sum_times.data(), _global_sum_times.data(), _sum_times.size(), MPI_DOUBLE, MPI_SUM, 0,
 						 domainDecomp->getCommunicator()));
+
+	auto averagedTimes = getAveragedTimes();
+
+	_global_max_average_times.resize(averagedTimes.size(), 0);
+	MPI_CHECK(MPI_Reduce(averagedTimes.data(), _global_max_average_times.data(), averagedTimes.size(), MPI_DOUBLE, MPI_MAX, 0,
+						 domainDecomp->getCommunicator()));
+	_global_sum_average_times.resize(averagedTimes.size(), 0);
+	MPI_CHECK(MPI_Reduce(averagedTimes.data(), _global_sum_average_times.data(), averagedTimes.size(), MPI_DOUBLE, MPI_SUM, 0,
+						 domainDecomp->getCommunicator()));
 #else
 	//! @todo in case we do not reuse _times later on, we may use here  _global_times = std::move(_times);
 	_global_times = _times;
@@ -142,6 +156,12 @@ void LoadbalanceWriter::flush(DomainDecompBase* domainDecomp) {
 		_sum_times.push_back(_times[ind]);
 		_global_sum_times.push_back(_times[ind]);
 	}
+
+	auto averagedTimes = getAveragedTimes();
+
+	// sum and max are actually the same if only one process is used.
+	_global_max_average_times = averagedTimes;
+	_global_sum_average_times = averagedTimes;
 #endif
 	if(0 == domainDecomp->getRank()) {
 		std::ofstream outputfile(_outputFilename,  std::ofstream::app);
@@ -153,26 +173,47 @@ void LoadbalanceWriter::flush(DomainDecompBase* domainDecomp) {
 	resetTimes();
 }
 
+std::vector<double> LoadbalanceWriter::getAveragedTimes() {
+	std::vector<double> averagedTimes(_timesForAverage.size(), 0.);
+	const auto numTimers = _timerNames.size();
+	mardyn_assert(_timesForAverage.size() % numTimers == 0);
+	std::vector<double> currentAverageSum(numTimers, 0.);
+	for (size_t ind = 0, averageIndex = 0; ind < _timesForAverage.size(); ind += numTimers, ++averageIndex) {
+		for (size_t timer_id = 0; timer_id < numTimers; ++timer_id) {
+			currentAverageSum[timer_id] += _timesForAverage[ind + timer_id];
+			if (averageIndex >= _averageLength) {
+				currentAverageSum[timer_id] -= _timesForAverage[ind + timer_id - _averageLength];
+				averagedTimes[ind + timer_id] = currentAverageSum[timer_id] / static_cast<double>(_averageLength);
+			} else {
+				averagedTimes[ind + timer_id] = currentAverageSum[timer_id] / static_cast<double>(averageIndex + 1);
+			}
+		}
+	}
+	return averagedTimes;
+}
+
 void LoadbalanceWriter::writeLBEntry(size_t id, std::ofstream &outputfile, int numRanks) {
 	outputfile << _simsteps[id];
 	size_t timestep_entry_offset = 2* _timerNames.size();
 	size_t base_offset = timestep_entry_offset * id;
 	size_t single_offset = _timerNames.size() * id;
+	size_t single_offset_average = _timerNames.size() * id + _lastTimesOldValueCount;
 	for(size_t timer_id = 0; timer_id < _timerNames.size(); ++timer_id) {
-		double min, max, f_LB, imbalance;
 		size_t timer_offset = 2 * timer_id;
 		size_t offset = base_offset + timer_offset;
-		max = _global_times[offset];
-		min = -_global_times[offset + 1];
+		double max = _global_times[offset];
+		double min = -_global_times[offset + 1];
 		// imbalance = 1 - (average of time) / maximal time -- fraction: time spent useless / really needed time
 		double optimaltime = (_global_sum_times[timer_id + single_offset] / numRanks);
-		imbalance = 1 - optimaltime / max;
-		f_LB = max / min;
+		double optimaltime_average = (_global_sum_average_times[timer_id + single_offset_average] / numRanks);
+		double imbalance = 1 - optimaltime / max;
+		double imbalance_average = 1 - optimaltime_average / _global_max_average_times[timer_id + single_offset_average];
+		double f_LB = max / min;
 		std::string timername = _timerNames[timer_id];
 		if(_warninglevels.count(timername) > 0 && _warninglevels[timername] < f_LB) {
 			displayWarning(_simsteps[id], timername, f_LB);
 		}
-		outputfile << "\t" << min << "\t" << max << "\t" << f_LB << "\t" << imbalance;
+		outputfile << "\t" << min << "\t" << max << "\t" << f_LB << "\t" << imbalance << "\t" << imbalance_average;
 	}
 	outputfile << std::endl;
 }
@@ -190,4 +231,14 @@ void LoadbalanceWriter::resetTimes() {
 	_simsteps.clear();
 	_sum_times.clear();
 	_global_sum_times.clear();
+	_global_max_average_times.clear();
+	_global_sum_average_times.clear();
+
+	// Removes first few elements, s.t., only the last _averageLength - 1 elements remain.
+	auto numTimers = _timerNames.size();
+	if (_timesForAverage.size() > (_averageLength - 1) * numTimers) {
+		_timesForAverage.erase(_timesForAverage.begin(), _timesForAverage.end() - numTimers * (_averageLength - 1));
+		mardyn_assert(_timesForAverage.size() == (_averageLength - 1) * numTimers);
+	}
+	_lastTimesOldValueCount = _timesForAverage.size();
 }

--- a/src/io/LoadBalanceWriter.cpp
+++ b/src/io/LoadBalanceWriter.cpp
@@ -103,7 +103,7 @@ void LoadbalanceWriter::writeOutputFileHeader() {
 	for(const auto& timername : _timerNames) {
 		outputfile << "\t#" << timername <<"#\t\t";
 	}
-	outputfile << "\n";
+	outputfile << "\nstep";
 	for(const auto& timername : _timerNames) {
 		outputfile << "\tmin\tmax\tf_LB\timbalance\timbalance_average";
 	}

--- a/src/io/LoadBalanceWriter.h
+++ b/src/io/LoadBalanceWriter.h
@@ -22,7 +22,7 @@
  * In each line the following values are stored for each LB timer:
  * - min, max times over all processes
  * - the factor max/min
- * - the imbalance 1 - average / max. This describes lost performance due to imbalances.
+ * - the imbalance 1 - average / max. This describes lost performance due to imbalances for the current time step.
  * - an averaged imbalance. Compared to the step-wise imbalance, the time-values are averaged for averageLength time
  * steps. In the first few steps, this averaging is not fully possible, thus only the average of the first steps is
  * taken. The averaged imbalance aims to reduce imbalances caused by noise and performance fluctuations and is thus a
@@ -30,8 +30,9 @@
  * addition, when comparing the step-wise imbalance and the averaged imbalance, information about the fluctuations can
  * be retrieved.
  *
- * @note Warning levels (for the factor max / min) for each timer can be set which will output a waring to the logfile.
- * This warning level should be bigger than 1.!
+ * @note Warning thresholds (level) (for the factor max / min) for each timer can be set (see documentation of
+ * readXML()) which will output a warning to the logfile if the factor max_time / min_time is above the threshold. This
+ * warning level should be bigger than 1.!
  *
  * @todo This plugin may be extended to threads
  */
@@ -98,7 +99,7 @@ private:
 	std::vector<double> _times;
 
 	// Holds multiple time values (not flushed after write) to get averaged load values.
-	std::deque<double> _timesForAverage;
+	std::deque<double> _timesForAverageBuffer;
 	unsigned long _lastTimesOldValueCount{0};  // How many old values _lastTimes holds from before a flush.
 	std::vector<double> _global_sum_average_times;
 	std::vector<double> _global_max_average_times;

--- a/src/io/LoadBalanceWriter.h
+++ b/src/io/LoadBalanceWriter.h
@@ -109,8 +109,11 @@ private:
 	std::vector<double> _global_times;
 	std::vector<unsigned long> _simsteps;
 	std::map<std::string, double> _warninglevels;
-	std::map<std::string, bool> _incremental;  // describes whether the timer will continuously increase and the difference between two calls should be used as timer value
-	std::map<std::string, double> _incremental_previous_times;  // previous times of the incremental timers
+
+	/// describes whether the timer will continuously increase and the difference between two calls should be used as timer value
+	std::map<std::string, bool> _incremental;
+	/// previous times of the incremental timers
+	std::map<std::string, double> _incremental_previous_times;
 	std::vector<double> getAveragedTimes();
 };
 

--- a/src/io/LoadBalanceWriter.h
+++ b/src/io/LoadBalanceWriter.h
@@ -22,8 +22,16 @@
  * In each line the following values are stored for each LB timer:
  * - min, max times over all processes
  * - the factor max/min
+ * - the imbalance 1 - average / max. This describes lost performance due to imbalances.
+ * - an averaged imbalance. Compared to the step-wise imbalance, the time-values are averaged for averageLength time
+ * steps. In the first few steps, this averaging is not fully possible, thus only the average of the first steps is
+ * taken. The averaged imbalance aims to reduce imbalances caused by noise and performance fluctuations and is thus a
+ * more accurate measure for the quality of the partitioning. It is (in average) lower than the step-wise imbalance. In
+ * addition, when comparing the step-wise imbalance and the averaged imbalance, information about the fluctuations can
+ * be retrieved.
  *
- * Warning levels for each timer can be set which will output a waring to the logfile.
+ * @note Warning levels (for the factor max / min) for each timer can be set which will output a waring to the logfile.
+ * This warning level should be bigger than 1.!
  *
  * @todo This plugin may be extended to threads
  */

--- a/src/io/LoadBalanceWriter.h
+++ b/src/io/LoadBalanceWriter.h
@@ -30,8 +30,8 @@
  * addition, when comparing the step-wise imbalance and the averaged imbalance, information about the fluctuations can
  * be retrieved.
  *
- * @note Warning thresholds (level) (for the factor max / min) for each timer can be set (see documentation of
- * readXML()) which will output a warning to the logfile if the factor max_time / min_time is above the threshold. This
+ * @note Warning thresholds (level) (for the ratio max / min) for each timer can be set (see documentation of
+ * readXML()) which will output a warning to the logfile if the ratio max_time / min_time is above the threshold. This
  * warning level should be bigger than 1.!
  *
  * @todo This plugin may be extended to threads
@@ -115,4 +115,3 @@ private:
 };
 
 #endif  // SRC_IO_LOADBALANCEWRITER_H_
-

--- a/src/io/LoadBalanceWriter.h
+++ b/src/io/LoadBalanceWriter.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <vector>
+#include <deque>
 
 /** name of the LoadbalanceWriter's default timer */
 #define LB_WRITER_DEFAULT_TIMER_NAME "LoadbalanceWriter_default"
@@ -43,6 +44,7 @@ public:
 	 * \code{.xml}
 	   <outputplugin name="LoadbalanceWriter">
 	     <writefrequency>INTEGER</writefrequency>
+	     <averageLength>INTEGER</averageLength>
 	     <outputfilename>STRING</outputfilename>
 	     <timers> <!-- additional timers -->
 	        <timer> <name>LoadbalanceWriter_default</name> <warninglevel>DOUBLE</warninglevel> </timer>
@@ -81,10 +83,18 @@ private:
 	void displayWarning(unsigned long simstep, const std::string& timername, double f_LB);
 
 	unsigned long _writeFrequency;
+	unsigned long _averageLength{10};
 	std::string _outputFilename;
 	Timer *_defaultTimer;
 	std::vector<std::string> _timerNames;
 	std::vector<double> _times;
+
+	// Holds multiple time values (not flushed after write) to get averaged load values.
+	std::deque<double> _timesForAverage;
+	unsigned long _lastTimesOldValueCount{0};  // How many old values _lastTimes holds from before a flush.
+	std::vector<double> _global_sum_average_times;
+	std::vector<double> _global_max_average_times;
+
 	std::vector<double> _sum_times;
 	std::vector<double> _global_sum_times;
 	std::vector<double> _global_times;
@@ -92,6 +102,7 @@ private:
 	std::map<std::string, double> _warninglevels;
 	std::map<std::string, bool> _incremental;  // describes whether the timer will continuously increase and the difference between two calls should be used as timer value
 	std::map<std::string, double> _incremental_previous_times;  // previous times of the incremental timers
+	std::vector<double> getAveragedTimes();
 };
 
 #endif  // SRC_IO_LOADBALANCEWRITER_H_

--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -67,6 +67,12 @@ void DomainDecompMPIBase::readXML(XMLfileUnits& xmlconfig) {
 #else
 	std::string neighbourCommunicationScheme = "direct-pp";
 #endif
+	if(_forceDirectPP){
+		global_log->info()
+			<< "Forcing direct-pp communication scheme, as _forceDirectPP is set (probably by a child class)."
+			<< std::endl;
+		neighbourCommunicationScheme = "direct-pp";
+	}
 
 	std::string zonalMethod = "fs";
 	std::string traversal = "c08"; // currently useless, as traversal is set elsewhere
@@ -98,7 +104,7 @@ void DomainDecompMPIBase::readXML(XMLfileUnits& xmlconfig) {
 	// Specifies if the sequential fallback shall be used.
 	bool useSequentialFallback = true;
 	xmlconfig.getNodeValue("useSequentialFallback", useSequentialFallback);
-	if(zonalMethod=="nt"){
+	if (zonalMethod == "nt") {
 		global_log->info() << "Forcefully disabling sequential fallback, because Neutral Territory is used!" << std::endl;
 		useSequentialFallback = false;
 		global_log->info() << "Enforcing direct-pp neighborcommunicationscheme, because NT is used!" << std::endl;
@@ -125,7 +131,7 @@ int DomainDecompMPIBase::getNonBlockingStageCount() {
 	return _neighbourCommunicationScheme->getCommDims();
 }
 
-void DomainDecompMPIBase::setCommunicationScheme(std::string scheme, std::string zonalMethod) {
+void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, const std::string& zonalMethod) {
 	// delete if it exists already
 	delete _neighbourCommunicationScheme;
 	_neighbourCommunicationScheme = nullptr;
@@ -144,7 +150,7 @@ void DomainDecompMPIBase::setCommunicationScheme(std::string scheme, std::string
 	} else if(zonalMethod=="nt") {
 		zonalMethodP = new NeutralTerritory();
 	} else {
-		global_log->error() << "DomainDecompMPIBase: invalid zonal method specified. Valid values are 'fs', 'hs', 'mp' and 'nt'"
+		global_log->error() << "DomainDecompMPIBase: invalid zonal method specified. Valid values are 'fs', 'es', 'hs', 'mp' and 'nt'"
 				<< std::endl;
 		Simulation::exit(1);
 	}

--- a/src/parallel/DomainDecompMPIBase.h
+++ b/src/parallel/DomainDecompMPIBase.h
@@ -255,7 +255,8 @@ protected:
 
 	/**
 	 * Indicates whether the direct-pp communication scheme should be forced.
-	 * This will only be effective prior to this classes' `readXML()` call, and can be set by a child class.
+	 * Flag to indicate necessity to use the direct-pp neighbour communication scheme. Can be overwritten by any child class.
+	 * @note Intended to be used in `readXML()`.
 	 */
 	bool _forceDirectPP{false};
 private:

--- a/src/parallel/DomainDecompMPIBase.h
+++ b/src/parallel/DomainDecompMPIBase.h
@@ -203,10 +203,13 @@ public:
 	 */
 	virtual void readXML(XMLfileUnits& xmlconfig);
 
-	//! Sets the communicationScheme.
-	//! If this function is called dynamically, make sure to reinitialise the CommunicationPartners before exchanging molecules!
-	//! @param scheme
-	virtual void setCommunicationScheme(std::string scheme,std::string comScheme);
+	/**
+	 * Sets the communicationScheme.
+	 * @note If this function is called dynamically, make sure to reinitialise the CommunicationPartners before exchanging molecules!
+	 * @param scheme
+	 * @param comScheme
+	 */
+	virtual void setCommunicationScheme(const std::string& scheme, const std::string& comScheme);
 
 	// documentation in base class
 	virtual int getNonBlockingStageCount() override;
@@ -249,6 +252,12 @@ protected:
 	MPI_Comm _comm;
 
 	NeighbourCommunicationScheme* _neighbourCommunicationScheme;
+
+	/**
+	 * Indicates whether the direct-pp communication scheme should be forced.
+	 * This will only be effective prior to this classes' `readXML()` call, and can be set by a child class.
+	 */
+	bool _forceDirectPP{false};
 private:
 	std::unique_ptr<CollectiveCommunicationInterface> _collCommunication;
 };

--- a/src/parallel/DomainDecompMPIBase.h
+++ b/src/parallel/DomainDecompMPIBase.h
@@ -194,9 +194,12 @@ public:
 	 * The following xml object structure is handled by this method:
 	 * \code{.xml}
 	   <parallelisation type="DomainDecomposition" OR "KDDecomposition">
-	   	 <CommunicationScheme>indirect OR direct</CommunicationScheme><!--default: indirect, unless in autopas mode-->
-	   	 <overlappingCollectives>yes OR no</overlappingCollectives><!--default: no-->
-	   	 <useSequentialFallback>yes OR no</useSequentialFallback><!--default: yes-->
+	   <!--default: indirect, unless in autopas mode-->
+	   	 <CommunicationScheme>indirect OR direct OR direct-pp</CommunicationScheme>
+	   	 <!--default: no-->
+	   	 <overlappingCollectives>yes OR no</overlappingCollectives>
+	   	 <!--default: yes-->
+	   	 <useSequentialFallback>yes OR no</useSequentialFallback>
 	     <!-- structure handled by DomainDecomposition or KDDecomposition -->
 	   </parallelisation>
 	   \endcode

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -12,11 +12,12 @@
 #include "NeighborAcquirer.h"
 #include "NeighbourCommunicationScheme.h"
 
-GeneralDomainDecomposition::GeneralDomainDecomposition(double interactionLength, Domain* domain)
+GeneralDomainDecomposition::GeneralDomainDecomposition(double interactionLength, Domain* domain, bool forceGrid)
 	: _boxMin{0.},
 	  _boxMax{0.},
 	  _domainLength{domain->getGlobalLength(0), domain->getGlobalLength(1), domain->getGlobalLength(2)},
-	  _interactionLength{interactionLength} {}
+	  _interactionLength{interactionLength},
+	  _forceGrid{forceGrid} {}
 
 void GeneralDomainDecomposition::initializeALL() {
 	global_log->info() << "initializing ALL load balancer..." << std::endl;
@@ -25,6 +26,14 @@ void GeneralDomainDecomposition::initializeALL() {
 	global_log->info() << "gridSize:" << gridSize[0] << ", " << gridSize[1] << ", " << gridSize[2] << std::endl;
 	global_log->info() << "gridCoords:" << gridCoords[0] << ", " << gridCoords[1] << ", " << gridCoords[2] << std::endl;
 	std::tie(_boxMin, _boxMax) = initializeRegularGrid(_domainLength, gridSize, gridCoords);
+	if (_forceGrid and not _gridSize.has_value()) {
+		std::array<double, 3> forcedGridSize{};
+		for(size_t dim = 0; dim<3; ++dim){
+			size_t numCells = _domainLength[dim] / _interactionLength;
+			forcedGridSize[dim] = _domainLength[dim] / numCells;
+		}
+		_gridSize = forcedGridSize;
+	}
 	if (_gridSize.has_value()) {
 		std::tie(_boxMin, _boxMax) = latchToGridSize(_boxMin, _boxMax);
 	}
@@ -92,6 +101,11 @@ void GeneralDomainDecomposition::balanceAndExchange(double lastTraversalTime, bo
 			// migrate the particles, this will rebuild the moleculeContainer!
 			global_log->info() << "migrating particles" << std::endl;
 			migrateParticles(domain, moleculeContainer, newBoxMin, newBoxMax);
+
+#ifndef MARDYN_AUTOPAS
+			// The linked cells container needs this (I think just to set the cells to valid...)
+			moleculeContainer->update();
+#endif
 
 			// set new boxMin and boxMax
 			_boxMin = newBoxMin;

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -245,11 +245,15 @@ void GeneralDomainDecomposition::initCommPartners(ParticleContainer* moleculeCon
 }
 
 void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
+	// Ensures that the readXML() call to DomainDecompMPIBase forces the direct-pp communication scheme.
+	_forceDirectPP = true;
+
 	DomainDecompMPIBase::readXML(xmlconfig);
-	global_log->info()
-		<< "The GeneralDomainDecomposition is enforcing the direct-pp neighbor scheme using fs, so setting it."
-		<< std::endl;
+
+#ifdef MARDYN_AUTOPAS
+	global_log->info() << "AutoPas only support FS, so setting it." << std::endl;
 	setCommunicationScheme("direct-pp", "fs");
+#endif
 
 	xmlconfig.getNodeValue("updateFrequency", _rebuildFrequency);
 	global_log->info() << "GeneralDomainDecomposition update frequency: " << _rebuildFrequency << endl;

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -17,7 +17,7 @@ GeneralDomainDecomposition::GeneralDomainDecomposition(double interactionLength,
 	  _boxMax{0.},
 	  _domainLength{domain->getGlobalLength(0), domain->getGlobalLength(1), domain->getGlobalLength(2)},
 	  _interactionLength{interactionLength},
-	  _forceGrid{forceGrid} {}
+	  _forceLatchingToLinkedCellsGrid{forceGrid} {}
 
 void GeneralDomainDecomposition::initializeALL() {
 	global_log->info() << "initializing ALL load balancer..." << std::endl;
@@ -26,7 +26,7 @@ void GeneralDomainDecomposition::initializeALL() {
 	global_log->info() << "gridSize:" << gridSize[0] << ", " << gridSize[1] << ", " << gridSize[2] << std::endl;
 	global_log->info() << "gridCoords:" << gridCoords[0] << ", " << gridCoords[1] << ", " << gridCoords[2] << std::endl;
 	std::tie(_boxMin, _boxMax) = initializeRegularGrid(_domainLength, gridSize, gridCoords);
-	if (_forceGrid and not _gridSize.has_value()) {
+	if (_forceLatchingToLinkedCellsGrid and not _gridSize.has_value()) {
 		std::array<double, 3> forcedGridSize{};
 		for(size_t dim = 0; dim<3; ++dim){
 			size_t numCells = _domainLength[dim] / _interactionLength;

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -28,7 +28,7 @@ void GeneralDomainDecomposition::initializeALL() {
 	std::tie(_boxMin, _boxMax) = initializeRegularGrid(_domainLength, gridSize, gridCoords);
 	if (_forceLatchingToLinkedCellsGrid and not _gridSize.has_value()) {
 		std::array<double, 3> forcedGridSize{};
-		for(size_t dim = 0; dim<3; ++dim){
+		for(size_t dim = 0; dim < 3; ++dim){
 			size_t numCells = _domainLength[dim] / _interactionLength;
 			forcedGridSize[dim] = _domainLength[dim] / numCells;
 		}

--- a/src/parallel/GeneralDomainDecomposition.h
+++ b/src/parallel/GeneralDomainDecomposition.h
@@ -18,8 +18,9 @@ public:
 	 * Constructor for the GeneralDomainDecomposition.
 	 * @param interactionLength
 	 * @param domain
+	 * @param forceGrid
 	 */
-	GeneralDomainDecomposition(double interactionLength, Domain* domain);
+	GeneralDomainDecomposition(double interactionLength, Domain* domain, bool forceGrid);
 
 	// documentation see father class (DomainDecompBase.h)
 	~GeneralDomainDecomposition() override;
@@ -199,6 +200,11 @@ private:
 	 * If no value is given, it is not used.
 	 */
 	std::optional<std::array<double, 3>> _gridSize{};
+
+	/**
+	 * Bool that indicates whether a grid should be forced even if no gridSize is set.
+	 */
+	bool _forceGrid{false};
 
 	std::unique_ptr<LoadBalancer> _loadBalancer{nullptr};
 

--- a/src/parallel/GeneralDomainDecomposition.h
+++ b/src/parallel/GeneralDomainDecomposition.h
@@ -204,7 +204,7 @@ private:
 	/**
 	 * Bool that indicates whether a grid should be forced even if no gridSize is set.
 	 */
-	bool _forceGrid{false};
+	bool _forceLatchingToLinkedCellsGrid{false};
 
 	std::unique_ptr<LoadBalancer> _loadBalancer{nullptr};
 

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -199,6 +199,10 @@ void KDDecomposition::readXML(XMLfileUnits& xmlconfig) {
 	global_log->info() << "measureLoad: Always use interpolation? "
 					   << (_measureLoadAlwaysUseInterpolation ? "yes" : "no") << endl;
 
+	xmlconfig.getNodeValue("measureLoadIncreasingTimeValues", _measureLoadIncreasingTimeValues);
+	global_log->info() << "measureLoad: Ensure that cells with more particles take longer ? "
+					   << (_measureLoadIncreasingTimeValues ? "yes" : "no") << endl;
+
 	DomainDecompMPIBase::readXML(xmlconfig);
 
 	string oldPath(xmlconfig.getcurrentnodepath());
@@ -274,7 +278,7 @@ void KDDecomposition::balanceAndExchange(double lastTraversalTime, bool forceReb
 
 	size_t measureLoadInitTimers = 2;
 	if (_steps == measureLoadInitTimers and _doMeasureLoadCalc) {
-		_measureLoadCalc = new MeasureLoad(_measureLoadAlwaysUseInterpolation);
+		_measureLoadCalc = new MeasureLoad(_measureLoadAlwaysUseInterpolation, _measureLoadIncreasingTimeValues);
 	}
 	size_t measureLoadStart = 50;
 	if (_steps == measureLoadStart and _doMeasureLoadCalc) {

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -30,31 +30,17 @@
 using namespace std;
 using Log::global_log;
 
-
-KDDecomposition::KDDecomposition() :
-		_globalNumCells(1), _decompTree(nullptr), _ownArea(nullptr), _numParticlesPerCell(), _steps(0), _frequency(1.),
-		_cutoffRadius(1.), _fullSearchThreshold(8), _totalMeanProcessorSpeed(1.), _totalProcessorSpeed(1.),
-		_processorSpeedUpdateCount(0), _heterogeneousSystems(false), _clusteredHeterogeneouseSystems {false}, _splitBiggest(true), _forceRatio(false),
-		_splitThreshold(std::numeric_limits<int>::max()), _numParticleTypes {}, _maxPars{std::numeric_limits<int>::min()},
-		_maxPars2{std::numeric_limits<int>::min()}, _partitionRank {calculatePartitionRank()}, _vecTunParticleNums {}, _generateNewFiles {},
-		_useExistingFiles {}, _rebalanceLimit(0) {
-	_loadCalc = new TradLoad();
-	_measureLoadCalc = nullptr;
-}
-
-KDDecomposition::KDDecomposition(double cutoffRadius, int numParticleTypes, int updateFrequency, int fullSearchThreshold, bool hetero,
-		bool cutsmaller, bool forceRatio, int splitThresh) :
-		_steps(0), _frequency(updateFrequency), _fullSearchThreshold(fullSearchThreshold), _totalMeanProcessorSpeed(1.),
-		_totalProcessorSpeed(1.), _processorSpeedUpdateCount(0), _heterogeneousSystems(hetero), _clusteredHeterogeneouseSystems {false}, _splitBiggest(!cutsmaller),
-		_forceRatio(forceRatio), _splitThreshold{splitThresh},
-		_numParticleTypes {numParticleTypes}, _maxPars{std::numeric_limits<int>::min()}, _maxPars2{std::numeric_limits<int>::min()},
-		_partitionRank {calculatePartitionRank()}, _vecTunParticleNums (_numParticleTypes, 50), _generateNewFiles {true},
-		_useExistingFiles {true}, _rebalanceLimit(0) {
+KDDecomposition::KDDecomposition(double cutoffRadius, int numParticleTypes, int updateFrequency,
+								 int fullSearchThreshold)
+	: _frequency(updateFrequency),
+	  _fullSearchThreshold(fullSearchThreshold),
+	  _numParticleTypes{numParticleTypes},
+	  _partitionRank{calculatePartitionRank()},
+	  _vecTunParticleNums(_numParticleTypes, 50) {
 	_loadCalc = new TradLoad();
 	_measureLoadCalc = nullptr;
 
 	_cutoffRadius = cutoffRadius;
-
 }
 
 void KDDecomposition::init(Domain* domain){

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -176,7 +176,6 @@ void KDDecomposition::readXML(XMLfileUnits& xmlconfig) {
 	}
 	xmlconfig.getNodeValue("splitThreshold", _splitThreshold);
 	if(!_splitBiggest){
-		xmlconfig.getNodeValue("splitThreshold", _splitThreshold);
 		global_log->info() << "KDDecomposition threshold for splitting not only the biggest Domain: " << _splitThreshold << endl;
 	}
 

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -191,6 +191,8 @@ void KDDecomposition::readXML(XMLfileUnits& xmlconfig) {
 	global_log->info() << "Generate new vectorization tuner files: " << (_generateNewFiles?"yes":"no") << endl;
 	xmlconfig.getNodeValue("useExistingFiles", _useExistingFiles);
 	global_log->info() << "Use existing vectorization tuner files (if available)?: " << (_useExistingFiles?"yes":"no") << endl;
+	xmlconfig.getNodeValue("vecTunerAllowMPIReduce", _vecTunerAllowMPIReduce);
+	global_log->info() << "Allow an MPI Reduce for the vectorization tuner?: " << (_vecTunerAllowMPIReduce?"yes":"no") << endl;
 
 	xmlconfig.getNodeValue("doMeasureLoadCalc", _doMeasureLoadCalc);
 	global_log->info() << "Use measureLoadCalc? (requires compilation with armadillo): " << (_doMeasureLoadCalc?"yes":"no") << endl;
@@ -578,7 +580,7 @@ void KDDecomposition::fillTimeVecs(CellProcessor **cellProc){
 		VectorizationTuner tuner;
 		tuner.init(global_simulation->getMoleculeContainer(), &global_simulation->domainDecomposition(), global_simulation->getDomain());
 		mardyn_assert(cellProc && (*cellProc));
-		tuner.tune(*(_simulation.getEnsemble()->getComponents()), *_tunerLoadCalc, _vecTunParticleNums, _generateNewFiles, _useExistingFiles);
+		tuner.tune(*(_simulation.getEnsemble()->getComponents()), *_tunerLoadCalc, _vecTunParticleNums, _generateNewFiles, _useExistingFiles, _vecTunerAllowMPIReduce);
 	}
 
 

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -194,6 +194,11 @@ void KDDecomposition::readXML(XMLfileUnits& xmlconfig) {
 
 	xmlconfig.getNodeValue("doMeasureLoadCalc", _doMeasureLoadCalc);
 	global_log->info() << "Use measureLoadCalc? (requires compilation with armadillo): " << (_doMeasureLoadCalc?"yes":"no") << endl;
+
+	xmlconfig.getNodeValue("measureLoadAlwaysUseInterpolation", _measureLoadAlwaysUseInterpolation);
+	global_log->info() << "measureLoad: Always use interpolation? "
+					   << (_measureLoadAlwaysUseInterpolation ? "yes" : "no") << endl;
+
 	DomainDecompMPIBase::readXML(xmlconfig);
 
 	string oldPath(xmlconfig.getcurrentnodepath());
@@ -268,8 +273,8 @@ void KDDecomposition::balanceAndExchange(double lastTraversalTime, bool forceReb
 	const bool removeRecvDuplicates = true;
 
 	size_t measureLoadInitTimers = 2;
-	if(_steps == measureLoadInitTimers and _doMeasureLoadCalc){
-		_measureLoadCalc = new MeasureLoad();
+	if (_steps == measureLoadInitTimers and _doMeasureLoadCalc) {
+		_measureLoadCalc = new MeasureLoad(_measureLoadAlwaysUseInterpolation);
 	}
 	size_t measureLoadStart = 50;
 	if (_steps == measureLoadStart and _doMeasureLoadCalc) {

--- a/src/parallel/KDDecomposition.h
+++ b/src/parallel/KDDecomposition.h
@@ -334,6 +334,7 @@ private:
 
 	bool _doMeasureLoadCalc {false};  // specifies if measureLoad should be used.
 	bool _measureLoadAlwaysUseInterpolation {true};  // specifies if measureLoad should always use interpolation.
+	bool _measureLoadIncreasingTimeValues{true};  // specifies if the time values should be increasing if the number of particles increases.
 
 	/**
 	 * The decomposition only searches in all directions if _splitBiggest is false and the number of processors in a node is less than the _splitThreshold.

--- a/src/parallel/KDDecomposition.h
+++ b/src/parallel/KDDecomposition.h
@@ -377,6 +377,7 @@ private:
 	std::vector<int> _vecTunParticleNums;
 	bool _generateNewFiles;
 	bool _useExistingFiles;
+	bool _vecTunerAllowMPIReduce{true};
 
 
 	double _rebalanceLimit; ///< limit for the fraction max/min time used in traversal before automatic rebalacing

--- a/src/parallel/KDDecomposition.h
+++ b/src/parallel/KDDecomposition.h
@@ -82,6 +82,7 @@ class KDDecomposition: public DomainDecompMPIBase {
 		 <generateNewFiles>BOOL</generateNewFiles>
 		 <useExistingFiles>BOOL</useExistingFiles>
 		 <doMeasureLoadCalc>BOOL</doMeasureLoadCalc>
+		 <measureLoadAlwaysUseInterpolation>BOOL</measureLoadAlwaysUseInterpolation> <!-- default: true -->
 		 <deviationReductionOperation>max OR sum</deviationReductionOperation>
 		 <minNumCellsPerDimension>UINT</minNumCellsPerDimension> <!--Has to be bigger than 0-->
 	   </parallelisation>

--- a/src/parallel/KDDecomposition.h
+++ b/src/parallel/KDDecomposition.h
@@ -79,10 +79,13 @@ class KDDecomposition: public DomainDecompMPIBase {
 	     <forceRatio>BOOL</forceRatio>
 	     <rebalanceLimit>DOUBLE</rebalanceLimit>
 	     <splitThreshold>INTEGER</splitThreshold>
-		 <generateNewFiles>BOOL</generateNewFiles>
-		 <useExistingFiles>BOOL</useExistingFiles>
+		 <generateNewFiles>BOOL</generateNewFiles> <!--for vectorization tuner-->
+		 <useExistingFiles>BOOL</useExistingFiles> <!--for vectorization tuner-->
+		 <vecTunerAllowMPIReduce>BOOL</vecTunerAllowMPIReduce> <!--for vectorization tuner-->
+
 		 <doMeasureLoadCalc>BOOL</doMeasureLoadCalc>
 		 <measureLoadAlwaysUseInterpolation>BOOL</measureLoadAlwaysUseInterpolation> <!-- default: true -->
+		 <measureLoadIncreasingTimeValues>BOOL</measureLoadIncreasingTimeValues> <!-- default: true -->
 		 <deviationReductionOperation>max OR sum</deviationReductionOperation>
 		 <minNumCellsPerDimension>UINT</minNumCellsPerDimension> <!--Has to be bigger than 0-->
 	   </parallelisation>

--- a/src/parallel/KDDecomposition.h
+++ b/src/parallel/KDDecomposition.h
@@ -332,6 +332,7 @@ private:
 	bool _forceRatio;  // if you want to enable forcing the above ratio, enable this.
 
 	bool _doMeasureLoadCalc {false};  // specifies if measureLoad should be used.
+	bool _measureLoadAlwaysUseInterpolation {true};  // specifies if measureLoad should always use interpolation.
 
 	/**
 	 * The decomposition only searches in all directions if _splitBiggest is false and the number of processors in a node is less than the _splitThreshold.

--- a/src/parallel/KDDecomposition.h
+++ b/src/parallel/KDDecomposition.h
@@ -83,22 +83,28 @@ class KDDecomposition: public DomainDecompMPIBase {
 		      for the force calculation. -->
 		 <heterogeneousSystems>BOOL</heterogeneousSystems>
 		 <!-- Indicates whether the vectorization tuner should be used. If it is used, the load for cells is measured
-		      depending on the number of particles. Repeated measurements are performed using one or two cells. -->
+		      depending on the number of particles. Repeated measurements are performed using one or two cells.
+		      If deactivated a simple fall back using a quadratic model is used for the cost model (i.e., Cost =
+		      particle number * particle number). This quadratic model tends to underestimate the cost needed for low
+		      density regions.-->
 		 <useVectorizationTuner>BOOL</useVectorizationTuner>
 		 <!-- For vectorization tuner: Generates a file with the measured performance characteristics if enabled. -->
 		 <generateNewFiles>BOOL</generateNewFiles>
-		 <!-- For vectorization tuner: Tries to load the file generated via generateNewFiles if enabled. -->
+		 <!-- For vectorization tuner: Load the file generated via generateNewFiles in a previous run. If no file
+		 exists, the vectorization tuner is run. -->
 		 <useExistingFiles>BOOL</useExistingFiles>
 		 <!-- For vectorization tuner: Allows an allreduce for the measured performances. This should be disabled if the
-		      compute resources don't all have the same performance. -->
+		      compute resources don't all have the same performance. If disabled the performances are measured for each
+		      process separately, which is (mostly) not what you want.-->
 		 <vecTunerAllowMPIReduce>BOOL</vecTunerAllowMPIReduce>
-		 <!-- A cluster version of load balancing. This option is useful if multiple clusters, where within each cluster
-		      identical devices are used, but the clusters itself use different compute resources. Currently only two
-		      clusters are supported. The clusters are identified based on the node names which are read via
-		      MPI_Get_processor_name(). -->
+		 <!-- A cluster version of load balancing. This option is useful if multiple clusters/islands are used that use
+		      different hardware, e.g., one cluster/island using AMD and one cluster/island using Intel processors.
+		      Currently only two clusters are supported. The clusters are identified based on the node names which are
+		      read via MPI_Get_processor_name(). -->
 		 <clusterHetSys>BOOL</clusterHetSys>
 		 <!-- Option to indicate to always split the domain along the biggest dimension. Splitting along the biggest
-		      dimension creates more cubic subdomains, but might lead to worse overall load balancing. -->
+		      dimension creates more cubic subdomains, but might lead to worse overall load balancing. If this is false,
+		      all dimensions are tested and in the end, the one producing the lowest imbalance is chosen.-->
 		 <splitBiggestDimension>BOOL</splitBiggestDimension>
 		 <!-- Alternative threshold for splitBiggestDimension. If more than splitThreshold processes are assigned to a
 		      node it is split in only the biggest dimension. splitBiggestDimension overrides this threshold.-->

--- a/src/parallel/LoadCalc.cpp
+++ b/src/parallel/LoadCalc.cpp
@@ -189,12 +189,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 // MEASURELOAD
 std::string MeasureLoad::TIMER_NAME = "SIMULATION_FORCE_CALCULATION";
 
-MeasureLoad::MeasureLoad() :
-		_times() {
-	_previousTime = global_simulation->timers()->getTime(TIMER_NAME);
-	_interpolationConstants = {0., 0., 0.};
-	_preparedLoad = false;
-}
+MeasureLoad::MeasureLoad() { _previousTime = global_simulation->timers()->getTime(TIMER_NAME); }
 
 #ifdef MARDYN_ARMADILLO
 // this non-negative least-squares (nnls) algorithm is taken from:

--- a/src/parallel/LoadCalc.cpp
+++ b/src/parallel/LoadCalc.cpp
@@ -189,7 +189,9 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 // MEASURELOAD
 std::string MeasureLoad::TIMER_NAME = "SIMULATION_FORCE_CALCULATION";
 
-MeasureLoad::MeasureLoad() { _previousTime = global_simulation->timers()->getTime(TIMER_NAME); }
+MeasureLoad::MeasureLoad(bool alwaysUseInterpolation) : _alwaysUseInterpolation{alwaysUseInterpolation} {
+	_previousTime = global_simulation->timers()->getTime(TIMER_NAME);
+}
 
 #ifdef MARDYN_ARMADILLO
 // this non-negative least-squares (nnls) algorithm is taken from:

--- a/src/parallel/LoadCalc.cpp
+++ b/src/parallel/LoadCalc.cpp
@@ -251,10 +251,20 @@ int MeasureLoad::prepareLoads(DomainDecompBase* decomp, MPI_Comm& comm) {
 	int global_maxParticlesP1 = 0;  // maxParticle Count + 1 = degrees of freedom
 	MPI_Allreduce(&maxParticlesP1, &global_maxParticlesP1, 1, MPI_INT, MPI_MAX, comm);
 
-	if (numRanks < _interpolationConstants.size()) {
-		Log::global_log->warning() << "MeasureLoad: Not enough processes to sample from (needed _extrapolationConst.size(): "
+	if (_alwaysUseInterpolation) {
+		if (numRanks < _interpolationConstants.size()) {
+			Log::global_log->warning()
+				<< "MeasureLoad: Not enough processes to sample from (needed _interpolationConstants.size(): "
 				<< _interpolationConstants.size() << ", numRanks: " << numRanks << ")." << std::endl;
-		return 1;
+			return 1;
+		}
+	} else {
+		// Here, we require as many ranks as particles!
+		if (numRanks < global_maxParticlesP1) {
+			Log::global_log->warning() << "MeasureLoad: Not enough processes to sample from (needed=maxParticlesP1: "
+									   << global_maxParticlesP1 << ", numRanks: " << numRanks << ")." << std::endl;
+			return 1;
+		}
 	}
 
 	statistics.resize(global_maxParticlesP1);
@@ -292,38 +302,131 @@ int MeasureLoad::prepareLoads(DomainDecompBase* decomp, MPI_Comm& comm) {
 						+ column];
 			}
 		}
-		arma::mat quadratic_equation_fit_matrix(global_maxParticlesP1, 3);
-		for (int row = 0; row < global_maxParticlesP1; row++) {
-			quadratic_equation_fit_matrix.at(row, 0) = row * row;
-			quadratic_equation_fit_matrix.at(row, 1) = row;
-			quadratic_equation_fit_matrix.at(row, 2) = 1;
+		if(_alwaysUseInterpolation) {
+			arma::mat quadratic_equation_fit_matrix(global_maxParticlesP1, 3);
+			for (int row = 0; row < global_maxParticlesP1; row++) {
+				quadratic_equation_fit_matrix.at(row, 0) = row * row;
+				quadratic_equation_fit_matrix.at(row, 1) = row;
+				quadratic_equation_fit_matrix.at(row, 2) = 1;
+			}
+			arma_system_matrix = quadratic_equation_fit_matrix.t() * arma_system_matrix * quadratic_equation_fit_matrix;
+			arma::vec arma_rhs(right_hand_side);
+			arma_rhs = quadratic_equation_fit_matrix.t() * arma_rhs;
+			arma::vec coefficient_vec = nnls(arma_system_matrix, arma_rhs);
+			mardyn_assert(coefficient_vec.size() == 3);
+			global_log->info() << "coefficient_vec: " << std::endl << coefficient_vec << std::endl;
+			for (int i = 0; i < 3; i++) {
+				_interpolationConstants[i] = coefficient_vec[i];
+			}
+			MPI_Bcast(_interpolationConstants.data(), 3, MPI_DOUBLE, 0, comm);
+		} else {
+			// old version
+			arma::vec arma_rhs(right_hand_side);
+			arma::vec cell_time_vec = arma::solve(arma_system_matrix, arma_rhs);
+
+			global_log->info() << "cell_time_vec: " << cell_time_vec << std::endl;
+			_times = arma::conv_to<std::vector<double> >::from(cell_time_vec);
+			mardyn_assert(_times.size() == global_maxParticlesP1);
+			MPI_Bcast(_times.data(), global_maxParticlesP1, MPI_DOUBLE, 0, comm);
 		}
-		arma_system_matrix = quadratic_equation_fit_matrix.t() * arma_system_matrix * quadratic_equation_fit_matrix;
-		arma::vec arma_rhs(right_hand_side);
-		arma_rhs = quadratic_equation_fit_matrix.t() * arma_rhs;
-		arma::vec coefficient_vec = nnls(arma_system_matrix, arma_rhs);
-		mardyn_assert(coefficient_vec.size() == 3);
-		global_log->info() << "coefficient_vec: " << std::endl << coefficient_vec << std::endl;
-		for (int i = 0; i < 3; i++) {
-			_interpolationConstants[i] = coefficient_vec[i];
-		}
-		MPI_Bcast(_interpolationConstants.data(), 3, MPI_DOUBLE, 0, comm);
 	} else {
 		MPI_Gather(statistics.data(), statistics.size(), MPI_UINT64_T, nullptr, 0 /*here insignificant*/, MPI_UINT64_T,
 				0, comm);
-		MPI_Bcast(_interpolationConstants.data(), 3, MPI_DOUBLE, 0, comm);
+		if (_alwaysUseInterpolation) {
+			MPI_Bcast(_interpolationConstants.data(), 3, MPI_DOUBLE, 0, comm);
+		} else {
+			// old version
+			_times.resize(global_maxParticlesP1);
+			MPI_Bcast(_times.data(), global_maxParticlesP1, MPI_DOUBLE, 0, comm);
+		}
 	}
 
+	// interpolation constants:
+	if(not _alwaysUseInterpolation) {
+		calcConstants();
+	}
 	_preparedLoad = true;
 	return 0;
-#endif  // MARDYN_ARMADILLO
+#endif
 }
 #endif  // ENABLE_MPI
+void MeasureLoad::calcConstants() {
+	// we do a least squares fit of: y = a x^2 + b x + c
+
+	// we need at least three entries for that!
+	mardyn_assert(_times.size() >= 3);
+
+	// we do a least square fit of the last 50% of the data:
+	size_t start, numElements;
+	{
+		size_t one = _times.size() - 3;
+		size_t two = _times.size() * 0.5;
+		start = std::min(one, two);
+		numElements = _times.size() - start;
+	}
+
+	std::array<double, 5> momentsX{};  // stores the moments of x: sum{t^i}
+	std::array<double, 3> momentsYX{};  // stores the following: sum{d* t^i}
+
+	momentsX[0] = numElements;
+
+	for (size_t i = start; i < _times.size(); i++) {
+		double x = i;
+		double x2 = x * x;
+		double x3 = x2 * x;
+		double x4 = x2 * x2;
+		double y = _times[i];
+		double yx = y * x;
+		double yx2 = y * x2;
+
+		momentsX[1] += x;
+		momentsX[2] += x2;
+		momentsX[3] += x3;
+		momentsX[4] += x4;
+		momentsYX[0] += y;
+		momentsYX[1] += yx;
+		momentsYX[2] += yx2;
+	}
+#ifdef MARDYN_ARMADILLO
+	// 3x3 matrix:
+	arma::mat system_matrix(3, 3);
+
+	// 3x1 vector from moments:
+	arma::vec rhs(3);
+
+	for (size_t row = 0; row < 3ul; ++row) {
+		rhs[row] = momentsYX[row];
+		for (size_t col = 0; col < 3ul; ++col) {
+			system_matrix.at(row, col) = momentsX[row + col];
+		}
+	}
+
+	arma::vec solution = arma::solve(system_matrix, rhs);
+
+	for (size_t row = 0; row < 3ul; row++) {
+		_interpolationConstants[row] = solution[2 - row];
+	}
+	global_log->info() << "extrapolationconst: " << solution << std::endl;
+#endif
+
+}
 
 double MeasureLoad::getValue(int numParticles) const {
 	mardyn_assert(numParticles >= 0);
 	mardyn_assert(_preparedLoad);
 
-	return _interpolationConstants[0] * numParticles * numParticles + _interpolationConstants[1] * numParticles +
-		   _interpolationConstants[2];
+	if(_alwaysUseInterpolation) {
+		return _interpolationConstants[0] * numParticles * numParticles + _interpolationConstants[1] * numParticles +
+			   _interpolationConstants[2];
+	} else {
+		size_t numPart = numParticles;
+		if (numPart < _times.size()) {
+			// if we are within the known (i.e. measured) particle count, just use the known values
+			return _times[numPart];
+		} else {
+			// otherwise we interpolate
+			return _interpolationConstants[0] * numPart * numPart + _interpolationConstants[1] * numPart +
+				_interpolationConstants[2];
+		}
+	}
 }

--- a/src/parallel/LoadCalc.cpp
+++ b/src/parallel/LoadCalc.cpp
@@ -300,8 +300,6 @@ int MeasureLoad::prepareLoads(DomainDecompBase* decomp, MPI_Comm& comm) {
 			// We multiply the system matrix with quadratic_equation_fit_matrix to be able to get the coefficients of a
 			// quadratic least squares fit (non-negative)
 			arma_system_matrix = arma_system_matrix * quadratic_equation_fit_matrix;
-			std::cout << "system_matrix: " << std::endl << arma_system_matrix << std::endl;
-			std::cout << "arma_rhs: " << std::endl << arma_rhs << std::endl;
 
 			arma::vec coefficient_vec = nnls(arma_system_matrix, arma_rhs);
 			mardyn_assert(coefficient_vec.size() == 3);
@@ -324,11 +322,7 @@ int MeasureLoad::prepareLoads(DomainDecompBase* decomp, MPI_Comm& comm) {
 					increasing_time_values_matrix(row, column) = 0.;
 				}
 			}
-			std::cout << "original system_matrix: " << std::endl << arma_system_matrix << std::endl;
-			std::cout << "increasing_time_values_matrix: " << std::endl << increasing_time_values_matrix << std::endl;
 			arma_system_matrix = arma_system_matrix * increasing_time_values_matrix;
-			std::cout << "system_matrix: " << std::endl << arma_system_matrix << std::endl;
-			std::cout << "arma_rhs: " << std::endl << arma_rhs << std::endl;
 			arma::vec increasing_cell_time_vec = nnls(arma_system_matrix, arma_rhs);
 			// multiply increasing_time_values_matrix to increasing_cell_time_vec to obtain the original cell time
 			// values.
@@ -339,8 +333,6 @@ int MeasureLoad::prepareLoads(DomainDecompBase* decomp, MPI_Comm& comm) {
 			mardyn_assert(_times.size() == global_maxParticlesP1);
 			MPI_Bcast(_times.data(), global_maxParticlesP1, MPI_DOUBLE, 0, comm);
 		} else {
-			std::cout << "system_matrix: " << std::endl << arma_system_matrix << std::endl;
-			std::cout << "arma_rhs: " << std::endl << arma_rhs << std::endl;
 			arma::vec cell_time_vec = nnls(arma_system_matrix, arma_rhs);
 
 			global_log->info() << "cell_time_vec:\n" << cell_time_vec << std::endl;

--- a/src/parallel/LoadCalc.h
+++ b/src/parallel/LoadCalc.h
@@ -45,11 +45,15 @@ class TunerLoad: public LoadCalc {
 public:
 
 	/**
-	 * The whole idea of this class is to take the ownership of the measured values of the tuner, so they are given by rvalue reference
+	 * The whole idea of this class is to take the ownership of the measured values of the tuner, so they are given by rvalue reference.
+	 * This constructor is used when tuning values are read from a file.
 	 */
 	TunerLoad(int count1, int count2, std::vector<double>&& ownTime, std::vector<double>&& faceTime,
 			std::vector<double>&& edgeTime, std::vector<double>&& cornerTime);
 
+	/**
+	 * This constructor is normally used when creating new files.
+	 */
 	TunerLoad() :
 			_count1 { 0 }, _count2 { 0 } {
 	}
@@ -187,10 +191,10 @@ private:
 	 * The first value is the constant for interactions between particles of type 1, the second between particles of type 2
 	 * and the the third for an interaction between particles of type 1 and 2
 	 */
-	std::array<double, 3> _ownConst;
-	std::array<double, 3> _faceConst;
-	std::array<double, 3> _edgeConst;
-	std::array<double, 3> _cornerConst;
+	std::array<double, 3> _ownConst{};
+	std::array<double, 3> _faceConst{};
+	std::array<double, 3> _edgeConst{};
+	std::array<double, 3> _cornerConst{};
 };
 
 /**

--- a/src/parallel/LoadCalc.h
+++ b/src/parallel/LoadCalc.h
@@ -228,7 +228,7 @@ class MeasureLoad: public LoadCalc {
 	static std::string TIMER_NAME;
 
 public:
-	MeasureLoad(bool alwaysUseInterpolation);
+	MeasureLoad(bool alwaysUseInterpolation, bool timeValuesShouldBeIncreasing);
 
 	double getOwn(int index1, int index2) const override {
 		return getValue(index1);
@@ -265,4 +265,5 @@ private:
 	bool _preparedLoad{false};
 	double _previousTime{0.};
 	bool _alwaysUseInterpolation{true};
+	bool _timeValuesShouldBeIncreasing{true};
 };

--- a/src/parallel/LoadCalc.h
+++ b/src/parallel/LoadCalc.h
@@ -224,7 +224,7 @@ class MeasureLoad: public LoadCalc {
 	static std::string TIMER_NAME;
 
 public:
-	MeasureLoad();
+	MeasureLoad(bool alwaysUseInterpolation);
 
 	double getOwn(int index1, int index2) const override {
 		return getValue(index1);
@@ -241,6 +241,7 @@ public:
 	double getCorner(int index1, int index2) const override {
 		return getValue(index1);
 	}
+
 #ifdef ENABLE_MPI
 	int prepareLoads(DomainDecompBase* decomp, MPI_Comm& comm);
 #endif

--- a/src/parallel/LoadCalc.h
+++ b/src/parallel/LoadCalc.h
@@ -246,6 +246,7 @@ public:
 #endif
 private:
 	double getValue(int numParticles) const;
+	void calcConstants();
 
 	/// stores the times needed for the cells
 	std::vector<double> _times;
@@ -254,8 +255,9 @@ private:
 	 * Stores values of the extrapolation of the form y = a x^2 + b x + c.
 	 * Hereby, x is the number of particles and y the expected runtime of the simulation.
 	 */
-	std::array<double, 3> _interpolationConstants;
+	std::array<double, 3> _interpolationConstants{};
 
-	bool _preparedLoad;
-	double _previousTime;
+	bool _preparedLoad{false};
+	double _previousTime{0.};
+	bool _alwaysUseInterpolation{true};
 };

--- a/src/particleContainer/LinkedCells.cpp
+++ b/src/particleContainer/LinkedCells.cpp
@@ -1146,12 +1146,16 @@ bool LinkedCells::requiresForceExchange() const {return _traversalTuner->getCurr
 std::vector<unsigned long> LinkedCells::getParticleCellStatistics() {
 	int maxParticles = 0;
 	for (auto& cell : _cells) {
-		maxParticles = std::max(maxParticles, cell.getMoleculeCount());
+		if(not cell.isHaloCell()) {
+			maxParticles = std::max(maxParticles, cell.getMoleculeCount());
+		}
 	}
 
 	std::vector<unsigned long> statistics(maxParticles + 1, 0ul);
 	for (auto& cell : _cells) {
-		statistics[cell.getMoleculeCount()]++;
+		if(not cell.isHaloCell()) {
+			statistics[cell.getMoleculeCount()]++;
+		}
 	}
 	return statistics;
 }

--- a/src/particleContainer/LinkedCells.h
+++ b/src/particleContainer/LinkedCells.h
@@ -105,6 +105,28 @@ public:
 	   <datastructure type="LinkedCells">
 	     <cellsInCutoffRadius>INTEGER</cellsInCutoffRadius>
 	   </datastructure>
+	   <!-- from TraversalTuner: -->
+	   <!-- select traversal algorithm
+          possible values are:
+            - original
+            - c04
+            - c08        (default for >1 threads)
+            - c08es      (eight-shell)
+            - quicksched
+            - sliced     (default for <2 threads)
+            - hs         (half shell method)
+            - mp         (mid point method)
+            - nt         (neutral territory method)
+            -->
+          <traversalSelector>c08</traversalSelector>
+          <!-- override default block size (2x2x2) for quicksched tasks -->
+          <traversalData type="quicksched">
+            <taskBlockSize>
+              <lx>2</lx>
+              <ly>2</ly>
+              <lz>2</lz>
+            </taskBlockSize>
+          </traversalData>
 	   \endcode
 	 */
 	void readXML(XMLfileUnits& xmlconfig) override;

--- a/src/particleContainer/LinkedCells.h
+++ b/src/particleContainer/LinkedCells.h
@@ -102,31 +102,31 @@ public:
 	 *
 	 * The following xml object structure is handled by this method:
 	 * \code{.xml}
-	   <datastructure type="LinkedCells">
-	     <cellsInCutoffRadius>INTEGER</cellsInCutoffRadius>
-	   </datastructure>
-	   <!-- from TraversalTuner: -->
-	   <!-- select traversal algorithm
-          possible values are:
-            - original
-            - c04
-            - c08        (default for >1 threads)
-            - c08es      (eight-shell)
-            - quicksched
-            - sliced     (default for <2 threads)
-            - hs         (half shell method)
-            - mp         (mid point method)
-            - nt         (neutral territory method)
-            -->
-          <traversalSelector>c08</traversalSelector>
-          <!-- override default block size (2x2x2) for quicksched tasks -->
-          <traversalData type="quicksched">
-            <taskBlockSize>
-              <lx>2</lx>
-              <ly>2</ly>
-              <lz>2</lz>
-            </taskBlockSize>
-          </traversalData>
+		<datastructure type="LinkedCells">
+			<cellsInCutoffRadius>INTEGER</cellsInCutoffRadius>
+			<!-- from TraversalTuner: -->
+			<!-- select traversal algorithm
+				possible values are:
+				- original
+				- c04
+				- c08        (default for >1 threads)
+				- c08es      (eight-shell)
+				- quicksched
+				- sliced     (default for <2 threads)
+				- hs         (half shell method)
+				- mp         (mid point method)
+				- nt         (neutral territory method)
+			-->
+			<traversalSelector>c08</traversalSelector>
+			<!-- override default block size (2x2x2) for quicksched tasks -->
+			<traversalData type="quicksched">
+				<taskBlockSize>
+					<lx>2</lx>
+					<ly>2</ly>
+					<lz>2</lz>
+				</taskBlockSize>
+			</traversalData>
+		</datastructure>
 	   \endcode
 	 */
 	void readXML(XMLfileUnits& xmlconfig) override;

--- a/src/plugins/VectorizationTuner.cpp
+++ b/src/plugins/VectorizationTuner.cpp
@@ -252,7 +252,7 @@ void VectorizationTuner::initCells(ParticleCell& main, ParticleCell& face, Parti
 		corner.setBoxMax(BoxMaxCorner);
 }
 
-void VectorizationTuner::tune(std::vector<Component>& componentList, TunerLoad& times, std::vector<int> particleNums, bool generateNewFiles, bool useExistingFiles){
+void VectorizationTuner::tune(std::vector<Component>& componentList, TunerLoad& times, std::vector<int> particleNums, bool generateNewFiles, bool useExistingFiles, bool allowMPIReduce){
 
 		/*
 		 * MPI parallelization strategy:
@@ -261,7 +261,7 @@ void VectorizationTuner::tune(std::vector<Component>& componentList, TunerLoad& 
 		 *
 		 * This does not work when there are different processor types present, which is why this option is currently deactivated
 		 */
-		bool allowMpi = false;
+		bool allowMpi = allowMPIReduce;
 
 		if(useExistingFiles && readFile(times)){
 			global_log->info() << "Read tuner values from file" << std::endl;

--- a/src/plugins/VectorizationTuner.h
+++ b/src/plugins/VectorizationTuner.h
@@ -91,7 +91,7 @@ public:
 	 * generateNewFiles denotes whether the tuner should write his measured values to files, which also overwrites old files.
 	 * If both are true and tuner files are available then the values that were read are written again,
 	 */
-	void tune(std::vector<Component>& ComponentList, TunerLoad& times, std::vector<int> particleNums, bool generateNewFiles, bool useExistingFiles);
+	void tune(std::vector<Component>& ComponentList, TunerLoad& times, std::vector<int> particleNums, bool generateNewFiles, bool useExistingFiles, bool allowMPIReduce);
 
 private:
 	/// The output prefix, that should be prefixed before the output files.


### PR DESCRIPTION
# Description

Changes:
1. Allows enabling ALL even if AutoPas is disabled. In that case, the subdomains generated by ALL are forced to a grid (using changes implemented in #168).
2. Adds an average load balance output to the LoadBalanceWriter. Compared to the step-wise imbalance, the time-values are averaged for `averageLength` time steps. In the first few steps, this averaging is not fully possible, thus only the average of the first steps is taken. the averaged imbalance aims to reduce imbalances caused by noise and performance variations and is thus a more accurate measure of the quality of the partitioning. It is (in average) lower than the step-wise imbalance.
3. Complete rewrite of MeasureLoad:
    - Properly uses NNLS (non-negative least squares).
    - Adds back independent values for every cell (no quadratic model forced)
    - Adds option for independent values to force cells with more particles to take longer than cells with fewer particles (this actually makes sense xD)
4. Allows selecting TunerCalcs allowMPI via xml.

## Related Pull Requests

- Uses GDD latching feature from #168 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

For 1.
- [x] Ran on cluster

For 2.
- [x] Ran locally (with Asan) and looked at output files.

For 3.
- [x] Ran locally and on cluster.

For 4.
- [x] Tested locally.