### PR TITLE
Fixes SpatialProfile if no fixregion is present.

### DIFF
--- a/src/plugins/SpatialProfile.cpp
+++ b/src/plugins/SpatialProfile.cpp
@@ -152,7 +152,11 @@ void SpatialProfile::init(ParticleContainer* particleContainer, DomainDecompBase
 	// Get global number of molecules
 	samplInfo.globalNumMolecules = domain->getglobalNumMolecules();
 	// Get number of molecules in FixRegion
-	samplInfo.numMolFixRegion = getNumFixRegion();
+	if (getNumFixRegion) {
+		samplInfo.numMolFixRegion = (*getNumFixRegion)();
+	} else {
+		samplInfo.numMolFixRegion = 0;
+	}
 	global_log->info() << "getDomain was called with Molecules in Fix Region: " << samplInfo.numMolFixRegion << endl;
 
 	// Calculate sampling units

--- a/src/plugins/SpatialProfile.h
+++ b/src/plugins/SpatialProfile.h
@@ -92,7 +92,10 @@ public:
 
 	void accessAllCallbacks(const std::map<std::string, FunctionWrapper>& callbackMap) override {
 		// Accesses a callback registered by FixRegion. It returns the number of molecules in the fixregion.
-		getNumFixRegion = callbackMap.at("FixRegion::getMoleculesInRegion").get<unsigned long>();
+		std::string name{"FixRegion::getMoleculesInRegion"};
+		if(callbackMap.find(name) != callbackMap.end()) {
+			getNumFixRegion = callbackMap.at(name).get<unsigned long>();
+		}
 	}
 
 private:
@@ -133,7 +136,7 @@ private:
 
 	void addProfile(ProfileBase* profile);
 
-	std::function<unsigned long(void)> getNumFixRegion;
+	std::optional<std::function<unsigned long(void)>> getNumFixRegion;
 
 };
 


### PR DESCRIPTION
# Description

Fixes SpatialProfile if no FixRegion plugin is enabled.

## Related Pull Requests

- regression introduced in #179 

## Resolved Issues

- [x] fixes #184 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Locally