### PR TITLE
Fix missing header

### DIFF
--- a/src/io/PerCellGenerator.h
+++ b/src/io/PerCellGenerator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include "InputBase.h"
 #include "utils/xmlfileUnits.h"
 


### PR DESCRIPTION
# Description

Fix missing header for use of `std::numeric_limits `