### PR TITLE
Adds possibility to use no LRC at all

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -520,7 +520,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			else if("none" == type)
 			{
 				delete _longRangeCorrection;
-				_longRangeCorrection = new nolrc(_cutoffRadius, _LJCutoffRadius, _domain, global_simulation);
+				_longRangeCorrection = new NoLRC(_cutoffRadius, _LJCutoffRadius, _domain, global_simulation);
 			}
 			else
 			{

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -71,6 +71,7 @@
 #include "longRange/LongRangeCorrection.h"
 #include "longRange/Homogeneous.h"
 #include "longRange/Planar.h"
+#include "longRange/NoLRC.h"
 
 #include "bhfmm/FastMultipoleMethod.h"
 #include "bhfmm/cellProcessors/VectorizedLJP2PCellProcessor.h"
@@ -516,9 +517,14 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 				global_log->info() << "Initializing homogeneous LRC." << endl;
 				_longRangeCorrection = new Homogeneous(_cutoffRadius, _LJCutoffRadius, _domain, global_simulation);
 			}
+			else if("none" == type)
+			{
+				delete _longRangeCorrection;
+				_longRangeCorrection = new nolrc(_cutoffRadius, _LJCutoffRadius, _domain, global_simulation);
+			}
 			else
 			{
-				global_log->error() << "LongRangeCorrection: Wrong type. Expected type == homogeneous|planar. Program exit ..." << endl;
+				global_log->error() << "LongRangeCorrection: Wrong type. Expected type == homogeneous|planar|none. Program exit ..." << endl;
                 Simulation::exit(-1);
 			}
 			xmlconfig.changecurrentnode("..");

--- a/src/longRange/Homogeneous.cpp
+++ b/src/longRange/Homogeneous.cpp
@@ -133,7 +133,7 @@ void Homogeneous::calculateLongRange() {
 	double UpotCorr = UpotCorrLJ + MySelbstTerm;
 	double VirialCorr = VirialCorrLJ + 3. * MySelbstTerm;
 
-	global_log->debug() << "Far field terms: U_pot_correction  = " << UpotCorr << " virial_correction = " << VirialCorr
+	global_log->debug() << "Far field terms: U_pot_correction = " << UpotCorr << " virial_correction = " << VirialCorr
 					   << endl;
 	_domain->setUpotCorr(UpotCorr);
 	_domain->setVirialCorr(VirialCorr);

--- a/src/longRange/NoLRC.h
+++ b/src/longRange/NoLRC.h
@@ -1,0 +1,35 @@
+#ifndef NOLRC_H__
+#define NOLRC_H__
+
+#include "Domain.h"
+#include "LongRangeCorrection.h"
+
+#include "utils/Logger.h"
+using Log::global_log;
+
+class Simulation;
+class Domain;
+class LongRangeCorrection;
+
+class NoLRC: public LongRangeCorrection{
+
+public:
+	NoLRC(double cutoffRadius, double cutoffRadiusLJ,  Domain* domain, Simulation* simulation) {
+        global_log->info() << "No long range correction is used: UpotCorr = VirialCorr = 0" << std::endl;
+        _domain = domain;
+    };
+	virtual ~NoLRC() {}
+
+	virtual void init() {}
+	virtual void readXML(XMLfileUnits& xmlconfig) {}
+	virtual void calculateLongRange() {
+        _domain->setUpotCorr(0.);
+        _domain->setVirialCorr(0.);
+      };
+	virtual void writeProfiles(DomainDecompBase* domainDecomp, Domain* domain, unsigned long simstep) {}
+
+private:
+    Domain* _domain;
+};
+
+#endif /* __NOLRC_H__ */

--- a/src/longRange/NoLRC.h
+++ b/src/longRange/NoLRC.h
@@ -15,12 +15,11 @@ class NoLRC: public LongRangeCorrection{
 
 public:
 	NoLRC(double cutoffRadius, double cutoffRadiusLJ,  Domain* domain, Simulation* simulation) {
-        global_log->info() << "No long range correction is used: UpotCorr = VirialCorr = 0" << std::endl;
         _domain = domain;
     };
 	virtual ~NoLRC() {}
 
-	virtual void init() {}
+	virtual void init() { global_log->info() << "No long range correction is used: UpotCorr = VirialCorr = 0" << std::endl; }
 	virtual void readXML(XMLfileUnits& xmlconfig) {}
 	virtual void calculateLongRange() {
         _domain->setUpotCorr(0.);

--- a/src/longRange/NoLRC.h
+++ b/src/longRange/NoLRC.h
@@ -11,6 +11,9 @@ class Simulation;
 class Domain;
 class LongRangeCorrection;
 
+/**
+ * Dummy long-range correction class which provides no correction.
+ */
 class NoLRC: public LongRangeCorrection{
 
 public:


### PR DESCRIPTION
### Description

Until now, it is not possible to use no long range correction (LRC) at all. When not specifying a LRC, the homogeneous one is used. This PR introduces an new type of LRC which does simply nothing.

### Resolved Issues

Introduces a feature which is used in LRC tests.

### How Has This Been Tested?

The argon example was run with and without LRC. The difference in U_pot was exactly the correction term calculated by the homogeneous LRC.
