### PR TITLE
Fix incorrect MPI datatype usage

### DIFF
--- a/src/parallel/ParticleDataRMM.cpp
+++ b/src/parallel/ParticleDataRMM.cpp
@@ -26,7 +26,7 @@ void ParticleDataRMM::getMPIType(MPI_Datatype &sendPartType) {
 	if (sizeof(pdata_dummy.r[0]) == 8) {  // 8 bytes for double
 		types[1] = MPI_DOUBLE;
 	} else if (sizeof(pdata_dummy.r[0]) == 4) {  // 4 bytes for single
-		types[1] = MPI_REAL;
+		types[1] = MPI_FLOAT;
 	} else {
 		global_log->error() << "invalid size of vcp_real_calc";
 		Simulation::exit(4852);


### PR DESCRIPTION
The MPI_REAL type is the corresponding Fortran floating point type and not
for c!

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>