### PR TITLE
Minor fix for Injection example: Init velocity of the tube has to be …

### DIFF
--- a/examples/Injection/nemd/sim01/run02/config.xml
+++ b/examples/Injection/nemd/sim01/run02/config.xml
@@ -278,7 +278,7 @@
 				<writefreq>10000</writefreq>
 				<numvals>10</numvals>
 				<feed>
-					<init>0.003</init>
+					<init>0.000</init>
 					<direction>1</direction>
 					<method>4</method>
 					<targetID>1</targetID>

--- a/examples/Injection/nemd/sim02/run02/config.xml
+++ b/examples/Injection/nemd/sim02/run02/config.xml
@@ -277,7 +277,7 @@
 				<writefreq>10000</writefreq>
 				<numvals>10</numvals>
 				<feed>
-					<init>0.003</init>
+					<init>0.000</init>
 					<direction>1</direction>
 					<method>4</method>
 					<targetID>1</targetID>


### PR DESCRIPTION
Minor fix for Injection example

# Description

Init velocity of the tube was set to 0.003, but has to be 0.000, so that the tube does not move (stay fixed).

## Related Pull Requests

- #PR

## Resolved Issues

- [ ] #Issue

# How Has This Been Tested?

Viewed visualization with MegaMol after the fix => looks fine.
