### PR TITLE
Singularity

### DIFF
--- a/tools/singularity/base-system.def
+++ b/tools/singularity/base-system.def
@@ -1,0 +1,10 @@
+bootstrap: library
+from: centos:8
+
+%post
+    dnf makecache
+    dnf -y install filesystem
+    dnf -y install gcc-toolset-10-gcc gcc-toolset-10-gcc-c++ gcc-toolset-10-gdb
+    # can't get this to work...
+    #echo \#\!/bin/bash > /etc/profile.d/gcc10.sh
+    #echo source scl_source enable gcc-toolset-10 >> /etc/profile.d/gcc10.sh

--- a/tools/singularity/ls1-megamol.def
+++ b/tools/singularity/ls1-megamol.def
@@ -1,0 +1,17 @@
+bootstrap: localimage
+from: base.sif
+
+%post
+    dnf -y install mpich mpich-devel
+    dnf -y install cmake git
+    mkdir -p /tmp
+    cd /tmp
+    git clone https://github.com/ls1mardyn/ls1-mardyn.git --depth 1
+    source scl_source enable gcc-toolset-10
+    export CFLAGS=-I/usr/include/mpich-x86_64
+    export CXXFLAGS=-I/usr/include/mpich-x86_64
+    cd ls1-mardyn
+    cmake -B build -D ENABLE_MPI=ON -D CMAKE_INSTALL_PREFIX=/opt/ls1 -D CMAKE_C_COMPILER=/usr/lib64/mpich/bin/mpicc -D CMAKE_CXX_COMPILER=/usr/lib64/mpich/bin/mpic++
+    cmake --build build -- -j
+    # this would work but does nothing currently
+    cmake --install build

--- a/tools/singularity/ls1-megamol.def
+++ b/tools/singularity/ls1-megamol.def
@@ -1,16 +1,18 @@
 bootstrap: localimage
 from: base.sif
 
+%files
+    ../../../ls1-mardyn/cmake /tmp/ls1-mardyn/cmake
+    ../../../ls1-mardyn/src /tmp/ls1-mardyn/src
+    ../../../ls1-mardyn/CMakeLists.txt /tmp/ls1-mardyn/CMakeLists.txt
+
 %post
     dnf -y install mpich mpich-devel
     dnf -y install cmake git
-    mkdir -p /tmp
-    cd /tmp
-    git clone https://github.com/ls1mardyn/ls1-mardyn.git --depth 1
     source scl_source enable gcc-toolset-10
     export CFLAGS=-I/usr/include/mpich-x86_64
     export CXXFLAGS=-I/usr/include/mpich-x86_64
-    cd ls1-mardyn
+    cd /tmp/ls1-mardyn
     cmake -B build -D ENABLE_MPI=ON -D CMAKE_INSTALL_PREFIX=/opt/ls1 -D CMAKE_C_COMPILER=/usr/lib64/mpich/bin/mpicc -D CMAKE_CXX_COMPILER=/usr/lib64/mpich/bin/mpic++
     cmake --build build -- -j
     # this would work but does nothing currently


### PR DESCRIPTION
relates to the chat we had this morning, @FG-TUM 

# Description

Added some scripts that allow building ls1 into a singularity container. Singularity should allow use of low-level MPI regardless of the containerization. The idea is to improve testing and deployment both for ls1. This needs to be extended to optionally build MegaMol alongside ls1 for the same reasons.

# Usage:
- Install Singularity as per manual https://sylabs.io/guides/3.9/user-guide/quick_start.html
- in tools/singularity:
  - Build a base system: `sudo singularity build base.sif base-system.def` Currently sudo seems to be required since the fakeroot produced some cpio issue when installing the filesystem package inside the image
  - Build ls1 on top of that system: `singularity build --fakeroot ls1-megamol.sif ls1-megamol.def` note: this works in user space
- this gives you a working `/tmp/ls1-mardyn/build/src/MarDyn` inside the image `tools/singularity/ls1-megamol.sif`

using the mpirun from the outside host, I was, for example, able to compute the standard example in the "outside sources" using the executable inside the image:
` mpirun -np 2 singularity exec ~/ls1-mardyn/tools/singularity/ls1-megamol.sif /tmp/ls1-mardyn/build/src/MarDyn config.xml  --steps 10`

TODOs:
- the scripts need to be improved to allow mirroring the outside MPI configuration so that pass-through hardware access works properly, if I understood it correctly: https://sylabs.io/guides/3.5/user-guide/mpi.html It is unclear to me how closely they have to match though, I had MPICH 3.3.2-2build1 on WSL2/Ubuntu 20.04.3 LTS and MPICH 3.4.1-1.el inside the image (CentOS 85.2111).
- maybe a multi-stage build is better than two separate definitions?
- can we solve the CPIO issue?

## Related Pull Requests

- N/A

## Resolved Issues

- N/A

# How Has This Been Tested?

So far, only the basic EOX example has been run, and that looked okay in MegaMol.