### PR TITLE
Fix in CI

### DIFF
--- a/.github/workflows/ls1_test.yml
+++ b/.github/workflows/ls1_test.yml
@@ -114,9 +114,35 @@ jobs:
           rm -f output_new output_master
           rootPath=$PWD
           echo "New commit build running examples..."
-          for i in $(cat ./examples/example-list.txt); do echo $i | tee -a output_new; cd ./examples/$(dirname $i); mpirun -np 2 $rootPath/build_${JOBNAME}/src/MarDyn $(basename $i) --steps=50 --final-checkpoint=0 | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' >> $rootPath/output_new ; cd - > /dev/null; done
+          for i in $(cat ./examples/example-list.txt)
+          do
+            echo $i | \
+              tee -a output_new
+            cd ./examples/$(dirname $i)
+            mpirun -np 2 $rootPath/build_${JOBNAME}/src/MarDyn \
+              $(basename $i) \
+              --steps=50 \
+              --final-checkpoint=0 \
+              | \
+                awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' \
+                >> $rootPath/output_new
+            cd - > /dev/null
+          done
           echo "Master build running examples..."
-          for i in $(cat ./examples/example-list.txt); do echo $i | tee -a output_master; cd ./examples/$(dirname $i); mpirun -np 2 $rootPath/build_${JOBNAME}_master/src/MarDyn $(basename $i) --steps=50 --final-checkpoint=0 | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' >> $rootPath/output_master ; cd - > /dev/null; done
+          for i in $(cat ./examples/example-list.txt)
+          do
+            echo $i | \
+              tee -a output_master
+            cd ./examples/$(dirname $i)
+            mpirun -np 2 $rootPath/build_${JOBNAME}_master/src/MarDyn \
+              $(basename $i) \
+              --steps=50 \
+              --final-checkpoint=0 \
+              | \
+                awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' \
+                >> $rootPath/output_master
+            cd - > /dev/null
+          done
           diff output_new output_master
           echo "---"
           [ "$(diff output_new output_master)" == "" ]

--- a/.github/workflows/ls1_test.yml
+++ b/.github/workflows/ls1_test.yml
@@ -113,8 +113,10 @@ jobs:
           # python3 ./validation/validationRun/validationRun.py -m 2 -n ./build_${JOBNAME}/src/MarDyn -o ./build_${JOBNAME}_master/src/MarDyn -c ./validation/validationInput/simple-lj-direct/config.xml
           rm -f output_new output_master
           rootPath=$PWD
-          for i in $(cat ./examples/example-list.txt); do echo $i | tee -a output_new; cd ./examples/$(dirname $i); mpirun -np 2 $rootPath/build_${JOBNAME}/src/MarDyn $(basename $i) --steps=50 --final-checkpoint=0 | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' >> $rootPath/output_new ; cd - ; done
-          for i in $(cat ./examples/example-list.txt); do echo $i | tee -a output_master; cd ./examples/$(dirname $i); mpirun -np 2 $rootPath/build_${JOBNAME}_master/src/MarDyn $(basename $i) --steps=50 --final-checkpoint=0 | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' >> $rootPath/output_master ; cd - ; done
+          echo "New commit build running examples..."
+          for i in $(cat ./examples/example-list.txt); do echo $i | tee -a output_new; cd ./examples/$(dirname $i); mpirun -np 2 $rootPath/build_${JOBNAME}/src/MarDyn $(basename $i) --steps=50 --final-checkpoint=0 | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' >> $rootPath/output_new ; cd - > /dev/null; done
+          echo "Master build running examples..."
+          for i in $(cat ./examples/example-list.txt); do echo $i | tee -a output_master; cd ./examples/$(dirname $i); mpirun -np 2 $rootPath/build_${JOBNAME}_master/src/MarDyn $(basename $i) --steps=50 --final-checkpoint=0 | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' >> $rootPath/output_master ; cd - > /dev/null; done
           diff output_new output_master
           echo "---"
           [ "$(diff output_new output_master)" == "" ]

--- a/.github/workflows/ls1_test.yml
+++ b/.github/workflows/ls1_test.yml
@@ -112,8 +112,9 @@ jobs:
           cd ..
           # python3 ./validation/validationRun/validationRun.py -m 2 -n ./build_${JOBNAME}/src/MarDyn -o ./build_${JOBNAME}_master/src/MarDyn -c ./validation/validationInput/simple-lj-direct/config.xml
           rm -f output_new output_master
-          for i in $(head -n15 ./examples/example-list.txt); do echo $i | tee output_new ; mpirun -np 2 ./build_${JOBNAME}/src/MarDyn ./examples/$i --steps=50 --final-checkpoint=0 | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' >> output_new ; done
-          for i in $(head -n15 ./examples/example-list.txt); do echo $i | tee output_master; mpirun -np 2 ./build_${JOBNAME}_master/src/MarDyn ./examples/$i --steps=50 --final-checkpoint=0 | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' >> output_master ; done
+          rootPath=$PWD
+          for i in $(cat ./examples/example-list.txt); do echo $i | tee -a output_new; cd ./examples/$(dirname $i); mpirun -np 2 $rootPath/build_${JOBNAME}/src/MarDyn $(basename $i) --steps=50 --final-checkpoint=0 | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' >> $rootPath/output_new ; cd - ; done
+          for i in $(cat ./examples/example-list.txt); do echo $i | tee -a output_master; cd ./examples/$(dirname $i); mpirun -np 2 $rootPath/build_${JOBNAME}_master/src/MarDyn $(basename $i) --steps=50 --final-checkpoint=0 | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' >> $rootPath/output_master ; cd - ; done
           diff output_new output_master
           echo "---"
           [ "$(diff output_new output_master)" == "" ]


### PR DESCRIPTION
## Description

CI was not done thoroughly as the result of the examples was not compared to the master. This failed because of a missing option (`-a` in `tee`). In addition, now all examples in the `examples-list.txt` are now used for checks.


## Resolved Issues

- [x] Fix in CI to properly include example list

## How Has This Been Tested?

Tested by automatic CI and manual check of output of examples.

## Open issues -> #214 

~- [ ] The validation check with mpi and Autopas kind of fails (writing the final checkpoint results in error). This needs to be fixed.~
~- [ ] Furthermore, the CI did not recognize that the validation check run with enabled Autopas produced errors.~
