### PR TITLE
Doxygen Workflow + Deployment

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,27 @@
+name: Doxygen Generate & Deploy
+
+on: 
+  push:
+    branches: [ master ]
+
+jobs:
+  doxygen:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v2
+      
+      - name: Get doxygen
+        run: sudo apt-get install doxygen -y
+        
+      - name: Build doxyfile
+        uses: mattnotmitt/doxygen-action@v1.9.2
+        with:
+          working-directory: '.'
+          doxyfile-path: './Doxyfile'
+
+      - name: Deploy documentation to GitHub pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: './doxygen_doc/html'
+

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,5 +1,6 @@
-name: Doxygen Generate & Deploy
+name: Doxygen Build & Deploy
 
+# execute this action on each push to remote master
 on: 
   push:
     branches: [ master ]
@@ -8,17 +9,21 @@ jobs:
   doxygen:
       runs-on: ubuntu-latest
       steps:
+      # get current state from git
       - uses: actions/checkout@v2
       
       - name: Get doxygen
         run: sudo apt-get install doxygen -y
         
-      - name: Build doxyfile
+      # build Doxygen documentation from Doxyfile in project root folder
+      # output is found as specified in Doxyfile in: doxygen_doc/html
+      - name: Build documentation
         uses: mattnotmitt/doxygen-action@v1.9.2
         with:
           working-directory: '.'
           doxyfile-path: './Doxyfile'
 
+      # host Doxygen output on ls1's github pages site (ls1mardyn.github.io/ls1-mardyn)
       - name: Deploy documentation to GitHub pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
# Description

Moves the Doxygen generation action to a separate workflow file.
Implements deployment to GitHub pages via `peaceiris/actions-gh-pages`.

# Todo: Enable GitHub pages for this repository

In order to be able to access the documentation automatically generated and pushed to the `gh-pages` branch, someone with sufficient access rights has to:

1. Go to _Settings ->Pages_.
2. Enable Pages for the repository.
3. Set branch to `gh-pages` and folder to `/`.

Note that for the `gh-pages` branch to exist, the workflow has to be executed at least once before.

# How Has This Been Tested?

In my fork of the repository, I enabled GitHub pages and started hosting the Doxygen documentation.
You can find it [here](https://maurerf.github.io/ls1-mardyn).
