### PR TITLE
[OUTDATED] Fix in thermostat

### DIFF
--- a/.github/workflows/ls1_test.yml
+++ b/.github/workflows/ls1_test.yml
@@ -1,162 +1,204 @@
-name: C/C++ CI
+name: C/C++ CI for ls1
 
-on: [push]
+on:
+  push:
+    # pushes to master
+    # branches: [ master ] 
+  pull_request:
+    # PRs to master
+    branches: [ master ]
+
+# abort old runs if a new one is started
+concurrency:
+  group: ${{ github.head_ref }}-tests
+  cancel-in-progress: true
 
 jobs:
-  check_AutoPas_seq:
+  ci-matrix:
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: prepare_seq
-      run: |
-        sudo apt-get install libcppunit-dev openmpi-bin -y
-    - name: build with autopas sequential
-      run: |
-        mkdir build && cd build
-        cmake -DENABLE_AUTOPAS=ON -DOPENMP=ON -DENABLE_UNIT_TESTS=1 ..
-        make -j2
-    - name: test sequential
-      run: |
-        ls
-        ls build
-        ls build/src
-        ./build/src/MarDyn -t -d ./test_input/
-    - name: validation - run with autopas aos
-      run: |
-        ./build/src/MarDyn ./examples/Argon/200K_18mol_l/config_autopas_aos.xml --steps=20 | tee autopas_run_log.txt
-        grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-        grep "T = 0.000633975" simstep20.txt
-        grep "U_pot = -2.14161" simstep20.txt
-        grep "p = 5.34057e-07" simstep20.txt
-    - name: validation - run with autopas soa
-      run: |
-        ./build/src/MarDyn ./examples/Argon/200K_18mol_l/config_autopas_soa.xml --steps=20 | tee autopas_run_log.txt
-        grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-        grep "T = 0.000633975" simstep20.txt
-        grep "U_pot = -2.14161" simstep20.txt
-        grep "p = 5.34057e-07" simstep20.txt
-  check_AutoPas_mpi:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: prepare_mpi
-      run: |
-        sudo apt-get install libcppunit-dev openmpi-bin -y
-    - name: build with autopas MPI
-      run: |
-        mkdir build-mpi && cd build-mpi
-        CC=mpicc CXX=mpicxx cmake -DENABLE_ALLLBL=ON -DENABLE_MPI=ON -DENABLE_AUTOPAS=ON -DOPENMP=ON -DENABLE_UNIT_TESTS=1 ..
-        make -j2
-    - name: test mpi
-      run: |
-        mpirun -np 1 --oversubscribe ./build-mpi/src/MarDyn -t -d ./test_input/
-        mpirun -np 2 --oversubscribe ./build-mpi/src/MarDyn -t -d ./test_input/
-    - name: validation - run with autopas DD
-      run: |
-        mpirun -np 2 --oversubscribe ./build-mpi/src/MarDyn ./examples/Argon/200K_18mol_l/config_autopas_aos.xml --steps=20 | tee autopas_run_log.txt
-        grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-        grep "T = 0.000633975" simstep20.txt
-        grep "U_pot = -2.14161" simstep20.txt
-        grep "p = 5.34057e-07" simstep20.txt
-    - name: validation - run with autopas ALLLB
-      run: |
-        mpirun -np 2 --oversubscribe ./build-mpi/src/MarDyn ./examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml --steps=20 | tee autopas_run_log.txt
-        grep "Simstep = 20" autopas_run_log.txt > simstep20.txt
-        grep "T = 0.000633975" simstep20.txt
-        grep "U_pot = -2.14161" simstep20.txt
-        grep "p = 5.34057e-07" simstep20.txt
-  run_ci-matrix:
-    runs-on: ubuntu-latest
-    # continue-on-error: true
     strategy:
+      # do not cancel all other workflow runs if one fails
+      fail-fast: false
       matrix: 
-        vector: ['SSE', 'AVX2']
+        vector: ['SSE', 'NONE', 'AVX', 'AVX2']
         target: ['Debug', 'Release']
-        parall: ['0', '1']
+        parall: ['SEQ', 'PAR']
+        cc: ['gcc', 'clang']
+        cxx: ['g++', 'clang++']
+        autopas: ['ON', 'OFF']
+        procs: ['1', '4', '8'] #TODO: >= 27 ranks case, to have non-border rank
+        openmp: ['ON', 'OFF']
+        exclude:
+            # exclude incompatible compiler pairs
+          - cc: 'gcc'
+            cxx: 'clang++'
+          - cc: 'clang'
+            cxx: 'g++'
+            # exclude legacy configurations
+          - vector: 'SSE'
+          - vector: 'AVX'
+          - openmp: 'OFF'
+            # exclude SEQ & np > 1, exclude PAR & np = 1
+          - parall: 'PAR'
+            procs: '1'
+          - parall: 'SEQ'
+            procs: '4'
+          - parall: 'SEQ'
+            procs: '8'
+
     env:
-      JOBNAME: ${{ matrix.vector }}-${{ matrix.target }}-${{ matrix.parall }}
+      JOBNAME: ${{ join(matrix.*, '-') }}
+    name: ${{ matrix.vector }}-${{ matrix.target }}-${{ matrix.parall }}-${{ matrix.cc }}-AutoPas=${{ matrix.autopas }}-Ranks=${{ matrix.procs }}-OMP=${{ matrix.openmp }}
     steps:
+      # setup github actions runner node
     - uses: actions/checkout@v2
-    - name: prepare_matrix
+    - name: Setup
       run: |
-        sudo apt-get install libcppunit-dev openmpi-bin -y
+        sudo apt-get update
+        sudo apt-get install -y \
+          libcppunit-dev        \
+          libmpich-dev
         echo "Running ${JOBNAME}"
         git status
         mkdir build_${JOBNAME}
-    - if: matrix.parall == '0'
-      name: Build seq. Matrix - vector ${{ matrix.vector }}, target ${{ matrix.target }}, parall ${{ matrix.parall }}
+      # build testing & unit testing
+    - name: Build and Unit Test
       run: |
           cd build_${JOBNAME}
-          CC=gcc CXX=g++ cmake -DVECTOR_INSTRUCTIONS=${{ matrix.vector }} -DCMAKE_BUILD_TYPE=${{ matrix.target }} -DENABLE_MPI=OFF -DENABLE_UNIT_TESTS=1 ..
+
+          #translate matrix to ON/OFF for certain entries
+          if [[ ${{ matrix.parall }} == 'PAR' ]]
+          then
+            mpi_enabled='ON'
+          else
+            mpi_enabled='OFF'
+          fi
+          if [[ ${{ matrix.parall }} == 'PAR' ]] && [[ ${{ matrix.autopas }} == 'ON' ]]
+          then
+            alllbl_enabled='ON'
+          else
+            alllbl_enabled='OFF'
+          fi
+
+          cmake -DVECTOR_INSTRUCTIONS=${{ matrix.vector }} \
+                -DCMAKE_BUILD_TYPE=${{ matrix.target }} \
+                -DENABLE_AUTOPAS=${{ matrix.autopas }} \
+                -DENABLE_ALLLBL=$alllbl_enabled \
+                -DOPENMP=${{ matrix.openmp }} \
+                -DENABLE_MPI=$mpi_enabled \
+                -DENABLE_UNIT_TESTS=ON \
+              ..
+
           make -j2
+
           cd ..
-          ./build_${JOBNAME}/src/MarDyn -t -d ./test_input/
-    - if: matrix.parall == '1'
-      name: Build par. Matrix - vector ${{ matrix.vector }}, target ${{ matrix.target }}, parall ${{ matrix.parall }}
+
+          if [[ ${{ matrix.parall }} == 'PAR' ]]
+          then
+            mpirun -np ${{ matrix.procs }} ./build_${JOBNAME}/src/MarDyn -t -d ./test_input/
+          else
+            ./build_${JOBNAME}/src/MarDyn -t -d ./test_input/
+          fi
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+        OMP_NUM_THREADS: 2
+
+      # validation testing
+    - if: ${{ matrix.parall == 'PAR' }}
+      name: Validation
       run: |
-          cd build_${JOBNAME}
-          CC=mpicc CXX=mpicxx cmake -DVECTOR_INSTRUCTIONS=${{ matrix.vector }} -DCMAKE_BUILD_TYPE=${{ matrix.target }} -DENABLE_MPI=ON -DENABLE_UNIT_TESTS=1 ..
-          make -j2
-          cd ..
-          mpirun -np 2 --oversubscribe ./build_${JOBNAME}/src/MarDyn -t -d ./test_input/
-    - if: matrix.parall == '1'
-      name: Validation par. examples Matrix - vector ${{ matrix.vector }}, target ${{ matrix.target }}, parall ${{ matrix.parall }}
-      run: |
+          #save absolute path to root of ls1 directory
+          repoPath=$PWD
+          # choose and save examples (so that this commit and master execute the same list)
+          if [[ ${{ matrix.autopas }} == 'ON' ]]
+          then
+            cp ./examples/example-list_autopas.txt branchExamples.txt
+          else
+            cp ./examples/example-list.txt branchExamples.txt
+          fi
+
+          #translate matrix to ON/OFF for certain entries
+          if [[ ${{ matrix.parall }} == 'PAR' ]]
+          then
+            mpi_enabled='ON'
+          else
+            mpi_enabled='OFF'
+          fi
+          if [[ ${{ matrix.parall }} == 'PAR' ]] && [[ ${{ matrix.autopas }} == 'ON' ]]
+          then
+            alllbl_enabled='ON'
+          else
+            alllbl_enabled='OFF'
+          fi
+
+          #build master branch equivalent to compare new build to
           mkdir build_${JOBNAME}_master
-          git remote add upstream https://github.com/ls1mardyn/ls1-mardyn.git
-          git fetch upstream
-          git checkout upstream/master
+          git fetch
+          git checkout master
           git status
           cd build_${JOBNAME}_master
-          CC=mpicc CXX=mpicxx cmake -DVECTOR_INSTRUCTIONS=${{ matrix.vector }} -DCMAKE_BUILD_TYPE=${{ matrix.target }} -DENABLE_MPI=ON -DENABLE_UNIT_TESTS=1 ..
-          make -j2
-          cd ..
-          # python3 ./validation/validationRun/validationRun.py -m 2 -n ./build_${JOBNAME}/src/MarDyn -o ./build_${JOBNAME}_master/src/MarDyn -c ./validation/validationInput/simple-lj-direct/config.xml
-          rm -f output_new output_master
-          rootPath=$PWD
-          echo "New commit build running examples..."
-          for i in $(cat ./examples/example-list.txt)
-          do
-            echo $i | \
-              tee -a output_new
-            cd ./examples/$(dirname $i)
-            mpirun -np 2 --oversubscribe $rootPath/build_${JOBNAME}/src/MarDyn \
-              $(basename $i) \
-              --steps=50 \
-              --final-checkpoint=0 \
-              | \
-                awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' \
-                >> $rootPath/output_new
-            cd - > /dev/null
-          done
-          echo "Master build running examples..."
-          for i in $(cat ./examples/example-list.txt)
-          do
-            echo $i | \
-              tee -a output_master
-            cd ./examples/$(dirname $i)
-            mpirun -np 2 --oversubscribe $rootPath/build_${JOBNAME}_master/src/MarDyn \
-              $(basename $i) \
-              --steps=50 \
-              --final-checkpoint=0 \
-              | \
-                awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' \
-                >> $rootPath/output_master
-            cd - > /dev/null
-          done
-          diff output_new output_master
-          echo "---"
-          [ "$(diff output_new output_master)" == "" ]
-          
-  post-build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: documentation
-      run: |
-        sudo apt-get install doxygen -y
-    - name: build doc
-      run: |
-        mkdir doxygen_doc || echo 'doxygen_doc Folder exists already'
-        doxygen
+          #note: ALLLBL is enabled if AutoPas is enabled.
+          cmake -DVECTOR_INSTRUCTIONS=${{ matrix.vector }} \
+                -DCMAKE_BUILD_TYPE=${{ matrix.target }} \
+                -DENABLE_AUTOPAS=${{ matrix.autopas }} \
+                -DENABLE_ALLLBL=$alllbl_enabled \
+                -DOPENMP=${{ matrix.openmp }} \
+                -DENABLE_MPI=$mpi_enabled \
+              ..
 
+          make -j2
+
+          cd "${repoPath}"
+
+          #set strict pipefail option
+          set -eo pipefail
+        
+          # execute all examples. These calls create artifacts which we will then compare
+          while read i
+          do
+            # skip if comment or empty line
+            if [[ $i == \#* || -z "$i" ]]
+            then
+              continue
+            fi
+            echo $i
+            cd $repoPath/examples/$(dirname $i)
+        
+            # patch input files according to current conf
+            cp $(basename $i) input_patched.xml
+            # if AutoPas is enabled, replace all occurrences of LinkedCell in the examples' config files with AutoPas
+            if [[ ${{ matrix.autopas }} == 'ON' ]]
+            then
+              sed --in-place 's/LinkedCells/AutoPas/g' input_patched.xml
+            fi
+        
+            # if AutoPas is enabled and no vectorization is used, the AVX functor of Autopas has to be disabled
+            if [[ ${{ matrix.vector }} == 'NONE' ]]
+            then
+              sed --in-place 's|AutoPas">|AutoPas">\n\t<useAVXFunctor>false</useAVXFunctor>|g' input_patched.xml
+            fi
+        
+            # run the example with the old and new exe
+            for VERSION in "master" "new"
+            do
+              if [[ "${VERSION}" == "master" ]]
+              then
+                EXE=$repoPath/build_${JOBNAME}_master/src/MarDyn
+              else
+                EXE=$repoPath/build_${JOBNAME}/src/MarDyn
+              fi
+          
+              mpirun -np ${{ matrix.procs }} ${EXE} input_patched.xml --steps=20                            \
+                | tee "output_${{ join(matrix.*, '-') }}"                                                   \
+                | awk '/Simstep = /{ print $7 " " $10 " " $13 " " $16 }' > ${repoPath}/output_${VERSION}    \
+                || cat "output_${{ join(matrix.*, '-') }}"
+            done
+            # compare the two runs
+            diff ${repoPath}/output_new ${repoPath}/output_master
+          done <${repoPath}/branchExamples.txt
+
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+        OMP_NUM_THREADS: 2

--- a/examples/example-list.txt
+++ b/examples/example-list.txt
@@ -1,11 +1,11 @@
+# Configs in this file will be tested by the CI for vanilla ls1 mardyn
+
 ./Argon/200K_18mol_l/config.xml
 ./CO2/370K_15mol_l/config.xml
 ./EOX/305K_liq/config.xml
 ./EOX/600K_15mol_l/config.xml
 ./Generators/mkTcTS/config.xml
 ./Generators/mkesfera/config.xml
-./Generators/cubic_grid_generator/config.xml
-./FMM/config.xml
 ./surface-tension_LRC/CO2_Merker/vle/220K/run01/config.xml
 ./surface-tension_LRC/CO2_Merker/vle/250K/run01/config.xml
 ./surface-tension_LRC/CO2_Merker/vle/280K/run01/config.xml
@@ -18,3 +18,6 @@
 ./adios/write/config_mix.xml
 ./adios/read/config.xml
 ./adios/read/config_parallel.xml
+
+## deactivated because FMM:
+#./FMM/config.xml

--- a/examples/example-list_autopas.txt
+++ b/examples/example-list_autopas.txt
@@ -1,0 +1,27 @@
+# Configs in this file will be tested by the CI with AutoPas.
+# If they specify LinkedCells as their datastructures the CI will replace this.
+# Currently AutoPas-mode does not yet support multi-center molecules.
+
+./Argon/200K_18mol_l/config.xml
+./Generators/mkTcTS/config.xml
+./Generators/mkesfera/config.xml
+
+## deactivated because FMM:
+#./FMM/config.xml
+
+## deactivated because multi centered:
+#./CO2/370K_15mol_l/config.xml
+#./EOX/305K_liq/config.xml
+#./EOX/600K_15mol_l/config.xml
+#./surface-tension_LRC/CO2_Merker/vle/220K/run01/config.xml
+#./surface-tension_LRC/CO2_Merker/vle/250K/run01/config.xml
+#./surface-tension_LRC/CO2_Merker/vle/280K/run01/config.xml
+#./surface-tension_LRC/C6H12/vle/330K/run01/config.xml
+#./surface-tension_LRC/C6H12/vle/415K/run01/config.xml
+#./surface-tension_LRC/C6H12/vle/500K/run01/config.xml
+#./Injection/liq/sim01/run03/config.xml
+#./Injection/liq/sim01/run04/config.xml
+#./adios/write/config.xml
+#./adios/write/config_mix.xml
+#./adios/read/config.xml
+#./adios/read/config_parallel.xml

--- a/makefile/Makefile
+++ b/makefile/Makefile
@@ -172,9 +172,22 @@ INCLUDES = -I$(SRCDIR) -isystem $(SRCDIR)/../libs/rapidxml -isystem $(SRCDIR)/..
 BINARY_BASENAME = MarDyn
 ifneq ("$(wildcard $(SRCDIR)/../.git)","")
   $(info Building from a git version.)
-  GIT_VERSION = $(shell git rev-parse --short HEAD | sed -e "s/:/-/")
-  ifneq ($(GIT_VERSION),)
-    BINARY = $(BINARY_BASENAME)_$(GIT_VERSION).$(PARTYPE)_$(TARGET)_$(VECTORIZE_CODE)
+  # Using git, the current version and state of the code are written to MarDyn_version.h
+  # this enables for the display of the information during execution of MarDyn
+  # see version.cmake for accordance in cmake
+  GIT_VERSION_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+  GIT_VERSION_HASH = $(shell git rev-parse --short HEAD)
+  GIT_VERSION_IS_DIRTY = $(shell git diff --quiet || echo "_dirty")
+  GIT_VERSION_HASH_CURRENT = $(shell grep "MARDYN_VERSION_HASH =" MarDyn_version.h 2> /dev/null | awk -F '"' '{print $$2}' | tr -d '_')
+  # Check if git commit has changed since last execution of make command
+  ifneq ($(GIT_VERSION_HASH),$(GIT_VERSION_HASH_CURRENT))
+    $(shell rm -f MarDyn.o) # Force new build of MarDyn including updated version info
+    $(shell sed "s=@MarDyn_VERSION_BRANCH@=$(GIT_VERSION_BRANCH)=g" MarDyn_version.h.in > MarDyn_version.h)
+    $(shell sed -i "s=@MarDyn_VERSION_HASH@=$(GIT_VERSION_HASH)=g" MarDyn_version.h)
+    $(shell sed -i "s=@MarDyn_VERSION_IS_DIRTY@=$(GIT_VERSION_IS_DIRTY)=g" MarDyn_version.h)
+  endif
+  ifneq ($(GIT_VERSION_HASH),)
+    BINARY = $(BINARY_BASENAME)_$(GIT_VERSION_HASH).$(PARTYPE)_$(TARGET)_$(VECTORIZE_CODE)
   else
     BINARY = $(BINARY_BASENAME).$(PARTYPE)_$(TARGET)_$(VECTORIZE_CODE)
   endif

--- a/src/io/CubicGridGeneratorInternal.h
+++ b/src/io/CubicGridGeneratorInternal.h
@@ -36,7 +36,11 @@ public:
 	 * The following xml object structure is handled by this method:
 	 * \code{.xml}
 	 <generator name="CubicGridGenerator">
-	 TODO: more
+		<numMolecules>INT</numMolecules>
+	 	<!-- OR -->
+	 	<density>DOUBLE</density>
+
+	 	<binaryMixture>BOOL<binaryMixture>
 	 </generator>
 	 \endcode
 	 */

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -131,6 +131,12 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 
 	// use avx functor?
 	xmlconfig.getNodeValue("useAVXFunctor", _useAVXFunctor);
+#ifndef __AVX__
+	if(_useAVXFunctor) {
+		global_log->warning() << "Selected AVX Functor but AVX is not supported! Switching to non-AVX functor." << std::endl;
+		_useAVXFunctor = false;
+	}
+#endif
 
 	// AutoPas log level
 	auto logLevelStr = xmlconfig.getNodeValue_string("logLevel", "");

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -13,6 +13,76 @@
 #include "autopas/utils/logging/Logger.h"
 #include "parallel/DomainDecompBase.h"
 
+// Declare the main AutoPas class and the iteratePairwise() methods with all used functors as extern template
+// instantiation. They are instantiated in the respective cpp file inside the templateInstantiations folder.
+//! @cond Doxygen_Suppress
+extern template class autopas::AutoPas<Molecule>;
+extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+		autopas::LJFunctor<
+				Molecule,
+				/*applyShift*/ true,
+				/*mixing*/ true,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true
+		> *);
+extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+		autopas::LJFunctor<
+				Molecule,
+				/*applyShift*/ true,
+				/*mixing*/ false,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true
+		> *);
+extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+		autopas::LJFunctor<
+				Molecule,
+				/*applyShift*/ false,
+				/*mixing*/ true,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true
+		> *);
+extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+		autopas::LJFunctor<
+				Molecule,
+				/*applyShift*/ false,
+				/*mixing*/ false,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true
+		> *);
+extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+		autopas::LJFunctorAVX<
+				Molecule,
+				/*applyShift*/ true,
+				/*mixing*/ true,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true
+		> *);
+extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+		autopas::LJFunctorAVX<
+				Molecule,
+				/*applyShift*/ true,
+				/*mixing*/ false,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true
+		> *);
+extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+		autopas::LJFunctorAVX<
+				Molecule,
+				/*applyShift*/ false,
+				/*mixing*/ true,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true
+		> *);
+extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+		autopas::LJFunctorAVX<
+				Molecule,
+				/*applyShift*/ false,
+				/*mixing*/ false,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true
+		> *);
+//! @endcond
+
 AutoPasContainer::AutoPasContainer(double cutoff) : _cutoff(cutoff), _particlePropertiesLibrary(cutoff) {
 	// use autopas defaults. This block is important when we do not read from an XML like in the unit tests
 	_verletSkin = _autopasContainer.getVerletSkin();
@@ -469,7 +539,56 @@ std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> AutoPasContaine
 
 unsigned long AutoPasContainer::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
 											  std::array<double, 3> simBoxLength, size_t seed_offset) {
-	throw std::runtime_error("AutoPasContainer::initCubicGrid() not yet implemented");
+
+	// Stolen from ParticleCellBase.cpp
+	auto getRandomVelocity = [](auto temperature, Random &RNG) {
+		using T = vcp_real_calc;
+		std::array<T,3> ret{};
+
+		// Velocity
+		for (int dim = 0; dim < 3; dim++) {
+			ret[dim] = RNG.uniformRandInRange(-0.5f, 0.5f);
+		}
+		T dotprod_v = 0;
+		for (unsigned int i = 0; i < ret.size(); i++) {
+			dotprod_v += ret[i] * ret[i];
+		}
+		// Velocity Correction
+		const T three = static_cast<T>(3.0);
+		T vCorr = sqrt(three * temperature / dotprod_v);
+		for (unsigned int i = 0; i < ret.size(); i++) {
+			ret[i] *= vCorr;
+		}
+
+		return ret;
+	};
+
+	Random myRNG{static_cast<int>(seed_offset) + mardyn_get_thread_num()};
+	vcp_real_calc T = global_simulation->getEnsemble()->T();
+
+	const std::array<double, 3> spacing = autopas::utils::ArrayMath::div(simBoxLength,
+																		 autopas::utils::ArrayUtils::static_cast_array<double>(
+																				 numMoleculesPerDimension));
+	size_t numMolecules = 0;
+	for (int grid = 0; grid < 2; ++grid) {
+		// grid starts 1/4 away from the corner. Grids are offset by 1/2 spacing
+		const std::array<double, 3> offset = autopas::utils::ArrayMath::mulScalar(spacing, 0.25 + .5 * grid);
+		for (int z = 0; z < numMoleculesPerDimension[2]; ++z) {
+			const double posZ = offset[2] + spacing[2] * z;
+			for (int y = 0; y < numMoleculesPerDimension[1]; ++y) {
+				const double posY = offset[1] + spacing[1] * y;
+				for (int x = 0; x < numMoleculesPerDimension[0]; ++x) {
+					const double posX = offset[0] + spacing[0] * x;
+					std::array<vcp_real_calc, 3> v = getRandomVelocity(T, myRNG);
+					Molecule m(numMolecules++, &(global_simulation->getEnsemble()->getComponents()->at(0)), posX, posY,
+							   posZ, v[0], v[1],
+							   v[2]);
+					addParticle(m, true, false, false);
+				}
+			}
+		}
+	}
+	return numMolecules;
 }
 
 double *AutoPasContainer::getCellLength() {

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -171,7 +171,13 @@ private:
 	autopas::Logger::LogLevel _logLevel{autopas::Logger::LogLevel::info};
 
 	std::vector<Molecule> _invalidParticles;
-	bool _useAVXFunctor{true};
+	bool _useAVXFunctor{
+#ifdef __AVX__
+		true
+#else
+		false
+#endif
+	};
 
 	ParticlePropertiesLibrary<double, size_t> _particlePropertiesLibrary;
 

--- a/src/particleContainer/AutoPasTemplateInstantiations/AutoPasClass.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/AutoPasClass.cpp
@@ -1,0 +1,11 @@
+/**
+ * @file AutoPasClass.cpp
+ * @author F. Gratl
+ * @date 25.06.22
+ */
+#include "autopas/AutoPasImpl.h"
+#include "molecules/Molecule.h"
+
+//! @cond Doxygen_Suppress
+template class autopas::AutoPas<Molecule>;
+//! @endcond

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXNoShiftMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXNoShiftMix.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file iteratePairwiseAVXLJFunctorNoShiftMix.cpp
+ * @author F. Gratl
+ * @date 25.06.22
+ */
+
+#include "autopas/AutoPasImpl.h"
+#include "molecules/Molecule.h"
+#include "autopas/molecularDynamics/LJFunctorAVX.h"
+
+//! @cond Doxygen_Suppress
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+		autopas::LJFunctorAVX<
+				Molecule,
+				/*applyShift*/ false,
+				/*mixing*/ true,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true>
+		*);
+//! @endcond

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXNoShiftNoMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXNoShiftNoMix.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file iteratePairwiseAVXLJFunctorNoShiftNoMix.cpp
+ * @author F. Gratl
+ * @date 25.06.22
+ */
+
+#include "autopas/AutoPasImpl.h"
+#include "molecules/Molecule.h"
+#include "autopas/molecularDynamics/LJFunctorAVX.h"
+
+//! @cond Doxygen_Suppress
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+		autopas::LJFunctorAVX<
+				Molecule,
+				/*applyShift*/ false,
+				/*mixing*/ false,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true>
+		*);
+//! @endcond

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXShiftMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXShiftMix.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file iteratePairwiseAVXLJFunctorShiftMix.cpp
+ * @author F. Gratl
+ * @date 25.06.22
+ */
+
+#include "autopas/AutoPasImpl.h"
+#include "molecules/Molecule.h"
+#include "autopas/molecularDynamics/LJFunctorAVX.h"
+
+//! @cond Doxygen_Suppress
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+		autopas::LJFunctorAVX<
+				Molecule,
+				/*applyShift*/ true,
+				/*mixing*/ true,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true>
+		*);
+//! @endcond

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXShiftNoMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXShiftNoMix.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file iteratePairwiseAVXLJFunctorShiftNoMix.cpp
+ * @author F. Gratl
+ * @date 25.06.22
+ */
+
+#include "autopas/AutoPasImpl.h"
+#include "molecules/Molecule.h"
+#include "autopas/molecularDynamics/LJFunctorAVX.h"
+
+//! @cond Doxygen_Suppress
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+		autopas::LJFunctorAVX<
+				Molecule,
+				/*applyShift*/ true,
+				/*mixing*/ false,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true>
+		*);
+//! @endcond

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorNoShiftMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorNoShiftMix.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file iteratePairwiseLJFunctorNoShiftMix.cpp
+ * @author F. Gratl
+ * @date 25.06.22
+ */
+
+#include "autopas/AutoPasImpl.h"
+#include "molecules/Molecule.h"
+#include "autopas/molecularDynamics/LJFunctor.h"
+
+//! @cond Doxygen_Suppress
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+		autopas::LJFunctor<
+				Molecule,
+				/*applyShift*/ false,
+				/*mixing*/ true,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true>
+		*);
+//! @endcond

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorNoShiftNoMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorNoShiftNoMix.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file iteratePairwiseLJFunctorNoShiftNoMix.cpp
+ * @author F. Gratl
+ * @date 25.06.22
+ */
+
+#include "autopas/AutoPasImpl.h"
+#include "molecules/Molecule.h"
+#include "autopas/molecularDynamics/LJFunctor.h"
+
+//! @cond Doxygen_Suppress
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+		autopas::LJFunctor<
+				Molecule,
+				/*applyShift*/ false,
+				/*mixing*/ false,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true>
+		*);
+//! @endcond

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorShiftMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorShiftMix.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file iteratePairwiseLJFunctorShiftMix.cpp
+ * @author F. Gratl
+ * @date 25.06.22
+ */
+
+#include "autopas/AutoPasImpl.h"
+#include "molecules/Molecule.h"
+#include "autopas/molecularDynamics/LJFunctor.h"
+
+//! @cond Doxygen_Suppress
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+		autopas::LJFunctor<
+				Molecule,
+				/*applyShift*/ true,
+				/*mixing*/ true,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true>
+		*);
+//! @endcond

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorShiftNoMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorShiftNoMix.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file iteratePairwiseLJFunctorShiftNoMix.cpp
+ * @author F. Gratl
+ * @date 25.06.22
+ */
+
+#include "autopas/AutoPasImpl.h"
+#include "molecules/Molecule.h"
+#include "autopas/molecularDynamics/LJFunctor.h"
+
+//! @cond Doxygen_Suppress
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+		autopas::LJFunctor<
+				Molecule,
+				/*applyShift*/ true,
+				/*mixing*/ false,
+				autopas::FunctorN3Modes::Both,
+				/*calculateGlobals*/ true>
+		*);
+//! @endcond

--- a/src/particleContainer/ParticleCellBase.cpp
+++ b/src/particleContainer/ParticleCellBase.cpp
@@ -31,7 +31,7 @@ bool ParticleCellBase::deleteMoleculeByID(unsigned long molid) {
 
 template <typename T>
 std::array<T, 3> getRandomVelocity(T temperature, Random& RNG) {
-	std::array<T,3> ret;
+	std::array<T,3> ret{};
 
 	// Velocity
 	for (int dim = 0; dim < 3; dim++) {
@@ -70,13 +70,14 @@ bool PositionIsInBox3D(const T l[3], const T u[3], const T r[3]) {
 	return in;
 }
 
-unsigned long ParticleCellBase::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength, Random & RNG) {
+unsigned long ParticleCellBase::initCubicGrid(const array<unsigned long, 3> &numMoleculesPerDimension,
+											  const std::array<double, 3> &simBoxLength, Random &RNG) {
 
-	std::array<double, 3> spacing;
-	std::array<double, 3> origin1; // origin of the first DrawableMolecule
-	std::array<double, 3> origin2; // origin of the first DrawableMolecule
+	std::array<double, 3> spacing{};
+	std::array<double, 3> origin1{}; // origin of the first DrawableMolecule
+	std::array<double, 3> origin2{}; // origin of the first DrawableMolecule
 	for (int d = 0; d < 3; ++d) {
-		spacing[d] = simBoxLength[d] / numMoleculesPerDimension[d];
+		spacing[d] = simBoxLength[d] / static_cast<double>(numMoleculesPerDimension[d]);
 		origin1[d] = spacing[d] * 0.25;
 		origin2[d] = spacing[d] * 0.25 * 3.;
 	}
@@ -86,13 +87,13 @@ unsigned long ParticleCellBase::initCubicGrid(std::array<unsigned long, 3> numMo
 	double boxMin[3] = {getBoxMin(0), getBoxMin(1), getBoxMin(2)};
 	double boxMax[3] = {getBoxMax(0), getBoxMax(1), getBoxMax(2)};
 
-	int start_i = floor((boxMin[0] / simBoxLength[0]) * numMoleculesPerDimension[0]) - 1;
-	int start_j = floor((boxMin[1] / simBoxLength[1]) * numMoleculesPerDimension[1]) - 1;
-	int start_k = floor((boxMin[2] / simBoxLength[2]) * numMoleculesPerDimension[2]) - 1;
+	int start_i = floor((boxMin[0] / simBoxLength[0]) * static_cast<double>(numMoleculesPerDimension[0])) - 1;
+	int start_j = floor((boxMin[1] / simBoxLength[1]) * static_cast<double>(numMoleculesPerDimension[1])) - 1;
+	int start_k = floor((boxMin[2] / simBoxLength[2]) * static_cast<double>(numMoleculesPerDimension[2])) - 1;
 
-	int end_i = ceil((boxMax[0] / simBoxLength[0]) * numMoleculesPerDimension[0]) + 1;
-	int end_j = ceil((boxMax[1] / simBoxLength[1]) * numMoleculesPerDimension[1]) + 1;
-	int end_k = ceil((boxMax[2] / simBoxLength[2]) * numMoleculesPerDimension[2]) + 1;
+	int end_i = ceil((boxMax[0] / simBoxLength[0]) * static_cast<double>(numMoleculesPerDimension[0])) + 1;
+	int end_j = ceil((boxMax[1] / simBoxLength[1]) * static_cast<double>(numMoleculesPerDimension[1])) + 1;
+	int end_k = ceil((boxMax[2] / simBoxLength[2]) * static_cast<double>(numMoleculesPerDimension[2])) + 1;
 
 	std::vector<Molecule> buffer;
 	int numMolsUpperBound = (end_k - start_k) * (end_j - start_j) * (end_i - start_i) * 2;

--- a/src/particleContainer/ParticleCellBase.h
+++ b/src/particleContainer/ParticleCellBase.h
@@ -82,7 +82,8 @@ public:
 
 	virtual void prefetchForForce() const {/*TODO*/}
 
-	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength, Random & RNG);
+	unsigned long initCubicGrid(const std::array<unsigned long, 3> &numMoleculesPerDimension,
+								const std::array<double, 3> &simBoxLength, Random &RNG);
 
 //protected: Do not use! use SingleCellIterator instead!
 	// multipurpose:

--- a/src/particleContainer/ParticleContainer.h
+++ b/src/particleContainer/ParticleContainer.h
@@ -228,7 +228,14 @@ public:
 	// @brief Should the domain decomposition exchange calculated forces at the boundaries,
 	// or does this particle container calculate all forces.
 	virtual bool requiresForceExchange() const {return false;}
-        
+
+    /**
+     * Generates a body-centered cubic grid.
+     * @param numMoleculesPerDimension
+     * @param simBoxLength
+     * @param seed_offset
+     * @return
+     */
 	virtual unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength, size_t seed_offset) = 0;
 
 	virtual double* getCellLength() = 0;

--- a/src/thermostats/TemperatureControl.cpp
+++ b/src/thermostats/TemperatureControl.cpp
@@ -388,10 +388,8 @@ void ControlRegionT::ControlTemperature(Molecule* mol) {
 		// ignore outer (halo) molecules
 		if (nPosIndex > nIndexMax)  // negative values will be ignored to: cast to unsigned int --> high value
 			return;
-
 		GlobalThermostatVariables& globalTV = _globalThermVars[nPosIndex];  // do not forget &
 		if (globalTV._numMolecules < 1) return;
-
 		// scale velocity
 		double vcorr = 2. - 1. / globalTV._betaTrans;
 		double Dcorr = 2. - 1. / globalTV._betaRot;
@@ -637,20 +635,21 @@ void TemperatureControl::AddRegion(ControlRegionT* region) { _vecControlRegions.
 
 void TemperatureControl::MeasureKineticEnergy(Molecule* mol, DomainDecompBase* domainDecomp, unsigned long simstep) {
 	if (simstep % _nControlFreq != 0) return;
+	if (simstep <= this->GetStart() || simstep > this->GetStop()) return;
 
 	for (auto&& reg : _vecControlRegions) reg->MeasureKineticEnergy(mol, domainDecomp);
 }
 
 void TemperatureControl::CalcGlobalValues(DomainDecompBase* domainDecomp, unsigned long simstep) {
 	if (simstep % _nControlFreq != 0) return;
+	if (simstep <= this->GetStart() || simstep > this->GetStop()) return;
 
 	for (auto&& reg : _vecControlRegions) reg->CalcGlobalValues(domainDecomp);
 }
 
 void TemperatureControl::ControlTemperature(Molecule* mol, unsigned long simstep) {
-	if (simstep % _nControlFreq != 0) {
-		return;
-	}
+	if (simstep % _nControlFreq != 0) return;
+	if (simstep <= this->GetStart() || simstep > this->GetStop()) return;
 
 	for (auto&& reg : _vecControlRegions) {
 		reg->ControlTemperature(mol);
@@ -659,6 +658,7 @@ void TemperatureControl::ControlTemperature(Molecule* mol, unsigned long simstep
 
 void TemperatureControl::Init(unsigned long simstep) {
 	if (simstep % _nControlFreq != 0) return;
+	if (simstep <= this->GetStart() || simstep > this->GetStop()) return;
 
 	for (auto&& reg : _vecControlRegions) reg->ResetLocalValues();
 }


### PR DESCRIPTION
# Description

The thermostat does not work properly when using the start/stop control values. Instead it does not stop correcting the velocity of the particles but only stops sampling. This leads to an constantly increasing temperature when the current timestep is greater than the set stop timestep of the thermostat.
Try by running any simulation and setting the control/stop value of the thermostat to a lower value than the total number of steps of the simulation.

This is a quick and dirty fix as the whole thermostat is kind of messy and may need a rewrite.

In addition, this PR fixes the `make` command to build ls1 mardyn. A `mardyn_version.h` file is now automatically generated in accordance to the `cmake` command.

# How Has This Been Tested?

Tested by:
1. setting up a simple simulation with LJ particles
2. set thermostat start and stop step
3. observe temperature progress in standard output

Conduct steps 1-3 with `master` and with the present branch. The temperature in the master simulation increases, while it stays more or less constant (to a certain extent as it is a NVE simulation) in the simulation with the present version.