### PR TITLE
Hotfix in thermostat

### DIFF
--- a/makefile/Makefile
+++ b/makefile/Makefile
@@ -172,9 +172,22 @@ INCLUDES = -I$(SRCDIR) -isystem $(SRCDIR)/../libs/rapidxml -isystem $(SRCDIR)/..
 BINARY_BASENAME = MarDyn
 ifneq ("$(wildcard $(SRCDIR)/../.git)","")
   $(info Building from a git version.)
-  GIT_VERSION = $(shell git rev-parse --short HEAD | sed -e "s/:/-/")
-  ifneq ($(GIT_VERSION),)
-    BINARY = $(BINARY_BASENAME)_$(GIT_VERSION).$(PARTYPE)_$(TARGET)_$(VECTORIZE_CODE)
+  # Using git, the current version and state of the code are written to MarDyn_version.h
+  # this enables for the display of the information during execution of MarDyn
+  # see version.cmake for accordance in cmake
+  GIT_VERSION_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+  GIT_VERSION_HASH = $(shell git rev-parse --short HEAD)
+  GIT_VERSION_IS_DIRTY = $(shell git diff --quiet || echo "_dirty")
+  GIT_VERSION_HASH_CURRENT = $(shell grep "MARDYN_VERSION_HASH =" MarDyn_version.h 2> /dev/null | awk -F '"' '{print $$2}' | tr -d '_')
+  # Check if git commit has changed since last execution of make command
+  ifneq ($(GIT_VERSION_HASH),$(GIT_VERSION_HASH_CURRENT))
+    $(shell rm -f MarDyn.o) # Force new build of MarDyn including updated version info
+    $(shell sed "s=@MarDyn_VERSION_BRANCH@=$(GIT_VERSION_BRANCH)=g" MarDyn_version.h.in > MarDyn_version.h)
+    $(shell sed -i "s=@MarDyn_VERSION_HASH@=$(GIT_VERSION_HASH)=g" MarDyn_version.h)
+    $(shell sed -i "s=@MarDyn_VERSION_IS_DIRTY@=$(GIT_VERSION_IS_DIRTY)=g" MarDyn_version.h)
+  endif
+  ifneq ($(GIT_VERSION_HASH),)
+    BINARY = $(BINARY_BASENAME)_$(GIT_VERSION_HASH).$(PARTYPE)_$(TARGET)_$(VECTORIZE_CODE)
   else
     BINARY = $(BINARY_BASENAME).$(PARTYPE)_$(TARGET)_$(VECTORIZE_CODE)
   endif

--- a/src/thermostats/TemperatureControl.cpp
+++ b/src/thermostats/TemperatureControl.cpp
@@ -388,10 +388,8 @@ void ControlRegionT::ControlTemperature(Molecule* mol) {
 		// ignore outer (halo) molecules
 		if (nPosIndex > nIndexMax)  // negative values will be ignored to: cast to unsigned int --> high value
 			return;
-
 		GlobalThermostatVariables& globalTV = _globalThermVars[nPosIndex];  // do not forget &
 		if (globalTV._numMolecules < 1) return;
-
 		// scale velocity
 		double vcorr = 2. - 1. / globalTV._betaTrans;
 		double Dcorr = 2. - 1. / globalTV._betaRot;
@@ -637,20 +635,21 @@ void TemperatureControl::AddRegion(ControlRegionT* region) { _vecControlRegions.
 
 void TemperatureControl::MeasureKineticEnergy(Molecule* mol, DomainDecompBase* domainDecomp, unsigned long simstep) {
 	if (simstep % _nControlFreq != 0) return;
+	if (simstep <= this->GetStart() || simstep > this->GetStop()) return;
 
 	for (auto&& reg : _vecControlRegions) reg->MeasureKineticEnergy(mol, domainDecomp);
 }
 
 void TemperatureControl::CalcGlobalValues(DomainDecompBase* domainDecomp, unsigned long simstep) {
 	if (simstep % _nControlFreq != 0) return;
+	if (simstep <= this->GetStart() || simstep > this->GetStop()) return;
 
 	for (auto&& reg : _vecControlRegions) reg->CalcGlobalValues(domainDecomp);
 }
 
 void TemperatureControl::ControlTemperature(Molecule* mol, unsigned long simstep) {
-	if (simstep % _nControlFreq != 0) {
-		return;
-	}
+	if (simstep % _nControlFreq != 0) return;
+	if (simstep <= this->GetStart() || simstep > this->GetStop()) return;
 
 	for (auto&& reg : _vecControlRegions) {
 		reg->ControlTemperature(mol);
@@ -659,6 +658,7 @@ void TemperatureControl::ControlTemperature(Molecule* mol, unsigned long simstep
 
 void TemperatureControl::Init(unsigned long simstep) {
 	if (simstep % _nControlFreq != 0) return;
+	if (simstep <= this->GetStart() || simstep > this->GetStop()) return;
 
 	for (auto&& reg : _vecControlRegions) reg->ResetLocalValues();
 }


### PR DESCRIPTION
# Description

The thermostat does not work properly when using the start/stop control values. Instead it does not stop correcting the velocity of the particles but only stops sampling. This leads to an constantly increasing temperature when the current timestep is greater than the set stop timestep of the thermostat.
Try by running any simulation and setting the control/stop value of the thermostat to a lower value than the total number of steps of the simulation.

This is a quick and dirty fix as the whole thermostat is kind of messy and may need a rewrite.

In addition, this PR fixes the `make` command to build ls1 mardyn. A `mardyn_version.h` file is now automatically generated in accordance to the `cmake` command.

# How Has This Been Tested?

Tested by:
1. setting up a simple simulation with LJ particles
2. set thermostat start and stop step
3. observe temperature progress in standard output

Conduct steps 1-3 with `master` and with the present branch. The temperature in the master simulation increases, while it stays more or less constant (to a certain extent as it is a NVE simulation) in the simulation with the present version.