### PR TITLE
Functor selector bugfix

### DIFF
--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -442,6 +442,8 @@ void AutoPasContainer::traverseTemplateHelper() {
 				throw std::runtime_error("SVE Functor not compiled due to lack of compiler support!");
 #endif
 			}
+			break;
+
 			case AVX: {
 #ifdef __AVX__
 				// Generate the functor. Should be regenerated every iteration to wipe internally saved globals.
@@ -454,6 +456,8 @@ void AutoPasContainer::traverseTemplateHelper() {
 				throw std::runtime_error("AVX Functor not compiled due to lack of compiler support!");
 #endif
 			}
+			break;
+
 			case autoVec: {
 				// Generate the functor. Should be regenerated every iteration to wipe internally saved globals.
 				autopas::LJFunctor<Molecule, /*applyShift*/ shifting, /*mixing*/ true, autopas::FunctorN3Modes::Both,
@@ -478,6 +482,8 @@ void AutoPasContainer::traverseTemplateHelper() {
 				throw std::runtime_error("SVE Functor not compiled due to lack of compiler support!");
 #endif
 			}
+			break;
+
 			case AVX: {
 #ifdef __AVX__
 				// Generate the functor. Should be regenerated every iteration to wipe internally saved globals.
@@ -490,6 +496,8 @@ void AutoPasContainer::traverseTemplateHelper() {
 				throw std::runtime_error("AVX Functor not compiled due to lack of compiler support!");
 #endif
 			}
+			break;
+			
 			case autoVec: {
 				// Generate the functor. Should be regenerated every iteration to wipe internally saved globals.
 				autopas::LJFunctor<Molecule, /*applyShift*/ shifting, /*mixing*/ false, autopas::FunctorN3Modes::Both,


### PR DESCRIPTION
# Description

Added breaks to the switch statements in the functor selector.

## Resolved Issues

When selecting SVE, the switch would fall through to AVX and stop execution with a runtime error

# How Has This Been Tested?

Tested with exploding liquid on classic scenarios branch
