### PR TITLE
added random seed funtionality in velocity distributors

### DIFF
--- a/examples/Mamico-couette/ls1configNoCP.xml
+++ b/examples/Mamico-couette/ls1configNoCP.xml
@@ -55,7 +55,7 @@
 							<lower> <x>0</x> <y>0</y> <z>0</z> </lower>
 							<upper> <x>30</x> <y>30</y> <z>30</z> </upper>
 						</object>
-						<velocityAssigner type="EqualVelocityDistribution"></velocityAssigner>
+						<velocityAssigner type="EqualVelocityDistribution" enableRandomSeed="1"></velocityAssigner>
 					</objectgenerator>
 				</generator>
 			</phasespacepoint>

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -1,6 +1,7 @@
 #include "io/ObjectGenerator.h"
 
 #include <limits>
+#include <chrono>
 
 #include "Simulation.h"
 #include "ensemble/EnsembleBase.h"
@@ -61,6 +62,12 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 			_velocityAssigner = std::make_shared<EqualVelocityAssigner>();
 		} else if(velocityAssignerName == "MaxwellVelocityDistribution") {
 			_velocityAssigner = std::make_shared<MaxwellVelocityAssigner>();
+		} else if(velocityAssignerName == "EqualVelocityDistributionRandomSeed") {
+			const int seed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+			_velocityAssigner = std::make_shared<EqualVelocityAssigner>(0, seed);
+		} else if(velocityAssignerName == "MaxwellVelocityDistributionRandomSeed") {
+			const int seed = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+			_velocityAssigner = std::make_shared<MaxwellVelocityAssigner>(0, seed);
 		} else {
 			global_log->error() << "Unknown velocity assigner specified." << endl;
 			Simulation::exit(1);

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -59,7 +59,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		xmlconfig.getNodeValue("@type", velocityAssignerName);
 		global_log->info() << "Velocity assigner: " << velocityAssignerName << endl;
 
-		const int seed = [&]() -> int {
+		const long seed = [&]() -> int {
 			bool enableRandomSeed = false;
 			xmlconfig.getNodeValue("@enableRandomSeed", enableRandomSeed);
 			if(enableRandomSeed) {
@@ -68,8 +68,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 				 *  multiple ranks (for ex. when coupling to MaMiCo), the seeds will be unique if they are created
 				 *  at the same time
 				 */
-				return std::chrono::duration_cast<std::chrono::seconds>
-				(std::chrono::system_clock::now().time_since_epoch()).count() + _simulation.domainDecomposition().getRank();
+				return std::chrono::system_clock::now().time_since_epoch().count() + _simulation.domainDecomposition().getRank();
 			
 			} else {
 				return 0;

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -59,7 +59,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		xmlconfig.getNodeValue("@type", velocityAssignerName);
 		global_log->info() << "Velocity assigner: " << velocityAssignerName << endl;
 
-		const int seed = [&]() {
+		const int seed = [&]() -> int {
 			bool enableRandomSeed = false;
 			xmlconfig.getNodeValue("@enableRandomSeed", enableRandomSeed);
 			if(enableRandomSeed) {

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -59,7 +59,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		xmlconfig.getNodeValue("@type", velocityAssignerName);
 		global_log->info() << "Velocity assigner: " << velocityAssignerName << endl;
 
-		const long seed = [&]() -> int {
+		const long seed = [&]() -> long {
 			bool enableRandomSeed = false;
 			xmlconfig.getNodeValue("@enableRandomSeed", enableRandomSeed);
 			if(enableRandomSeed) {

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -56,22 +56,25 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 
 	if(xmlconfig.changecurrentnode("velocityAssigner")) {
 		std::string velocityAssignerName;
-		bool enableRandomSeed = false;
-		int seed = 0;
 		xmlconfig.getNodeValue("@type", velocityAssignerName);
-		xmlconfig.getNodeValue("@enableRandomSeed", enableRandomSeed);
 		global_log->info() << "Velocity assigner: " << velocityAssignerName << endl;
-		if(enableRandomSeed)
-		{
-			/** A random seed for the velocity generator is created.
-			 *  The current rank is added to make sure that, if multiple simulations are instantiated across
-			 *  multiple ranks (for ex. when coupling to MaMiCo), the seeds will be unique if they are created
-			 *  at the same time
-			*/
-			seed = std::chrono::duration_cast<std::chrono::seconds>
+
+		const int seed = [&]() {
+			bool enableRandomSeed = false;
+			xmlconfig.getNodeValue("@enableRandomSeed", enableRandomSeed);
+			if(enableRandomSeed) {
+				/** A random seed for the velocity generator is created.
+				 *  The current rank is added to make sure that, if multiple simulations are instantiated across
+				 *  multiple ranks (for ex. when coupling to MaMiCo), the seeds will be unique if they are created
+				 *  at the same time
+				 */
+				return std::chrono::duration_cast<std::chrono::seconds>
 				(std::chrono::system_clock::now().time_since_epoch()).count() + _simulation.domainDecomposition().getRank();
 			
-		}
+			} else {
+				return 0;
+			}
+		}();
 		global_log->info() << "Seed for velocity assigner: " << seed << endl;
 		if(velocityAssignerName == "EqualVelocityDistribution") {
 			_velocityAssigner = std::make_shared<EqualVelocityAssigner>(0, seed);

--- a/src/utils/generator/EqualVelocityAssigner.h
+++ b/src/utils/generator/EqualVelocityAssigner.h
@@ -9,7 +9,7 @@
  */
 class EqualVelocityAssigner : public VelocityAssignerBase {
 public:
-	EqualVelocityAssigner(double T = 0, int seed = 0) : VelocityAssignerBase(T), _mt(seed), _uniformDistribution(0, 1) {}
+	EqualVelocityAssigner(double T = 0, long seed = 0) : VelocityAssignerBase(T), _mt(seed), _uniformDistribution(0, 1) {}
 	~EqualVelocityAssigner(){}
 
 	void assignVelocity(Molecule *molecule) {

--- a/src/utils/generator/MaxwellVelocityAssigner.h
+++ b/src/utils/generator/MaxwellVelocityAssigner.h
@@ -10,7 +10,7 @@
  */
 class MaxwellVelocityAssigner : public VelocityAssignerBase {
 public:
-	MaxwellVelocityAssigner(double T = 0, int seed = 0) : VelocityAssignerBase(T), _mt(seed), _normalDistribution(0.0, 1.0) {}
+	MaxwellVelocityAssigner(double T = 0, long seed = 0) : VelocityAssignerBase(T), _mt(seed), _normalDistribution(0.0, 1.0) {}
 	~MaxwellVelocityAssigner() {}
 
 	void assignVelocity(Molecule *molecule) {


### PR DESCRIPTION
# Description
It is now possible to use "EqualVelocityDistributionRandomSeed" and "MaxwellVelocityDistributionRandomSeed" in the velocityAssigner when defining a generator with an xml config. A random seed will be used for the random velocities, instead of only 0.

EDIT: removed new names for distributions, added new xml property "useRandomSeed" instead with commit 5168db8

## Resolved Issues

#252 

## How Has This Been Tested?

Compilation, and ls1ConfigNoCP.xml from the Mamico-couette folder
Coupled run with MaMiCo with 100 ls1 + AutoPas instances running simultaneously with different seeds