### PR TITLE
Fix for shift autocalculation in components

### DIFF
--- a/examples/Adsorption/Generator/adsorption.xml
+++ b/examples/Adsorption/Generator/adsorption.xml
@@ -36,7 +36,7 @@
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>1</shifted>
+            <shifted>true</shifted>
           </site>
         </moleculetype>
       </components>

--- a/examples/Adsorption/Generator/adsorption_autopas_default.xml
+++ b/examples/Adsorption/Generator/adsorption_autopas_default.xml
@@ -36,7 +36,7 @@
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>1</shifted>
+            <shifted>true</shifted>
           </site>
         </moleculetype>
       </components>

--- a/examples/Adsorption/Generator/adsorption_autopas_tuning.xml
+++ b/examples/Adsorption/Generator/adsorption_autopas_tuning.xml
@@ -36,7 +36,7 @@
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>1</shifted>
+            <shifted>true</shifted>
           </site>
         </moleculetype>
       </components>

--- a/examples/Argon/components.xml
+++ b/examples/Argon/components.xml
@@ -7,7 +7,7 @@
 			<mass>0.039948</mass>
 			<sigma>6.4160007</sigma>
 			<epsilon>0.000369852537</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/CO2/components.xml
+++ b/examples/CO2/components.xml
@@ -7,21 +7,21 @@
 			<mass>0.012</mass>
 			<sigma>5.31712452</sigma>
 			<epsilon>3.91811245e-05</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="LJ126" id="2" >
 			<coords> <x>0.0</x> <y>0.0</y> <z>-2.43188952</z> </coords>
 			<mass>0.016</mass>
 			<sigma>5.62288233</sigma>
 			<epsilon>0.00031824324</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="LJ126" id="3" >
 			<coords> <x>0.0</x> <y>0.0</y> <z>2.43188952</z> </coords>
 			<mass>0.016</mass>
 			<sigma>5.62288233</sigma>
 			<epsilon>0.00031824324</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 
 		<site type="Charge" id="4" >

--- a/examples/EOX/components.xml
+++ b/examples/EOX/components.xml
@@ -7,21 +7,21 @@
 			<mass>0.016</mass>
 			<sigma>5.84473626</sigma>
 			<epsilon>0.000196741979</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="LJ126" id="2" >
 			<coords> <x>1.47398696</x> <y>-0.83835156</y> <z>0.0</z> </coords>
 			<mass>0.014</mass>
 			<sigma>6.66431081</sigma>
 			<epsilon>0.000268352891</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="LJ126" id="3" >
 			<coords> <x>-1.47398696</x> <y>-0.83835156</y> <z>0.0</z> </coords>
 			<mass>0.014</mass>
 			<sigma>6.66431081</sigma>
 			<epsilon>0.000268352891</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="Dipole" id="4" >
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>

--- a/examples/Evaporation/stationary/components_3c.xml
+++ b/examples/Evaporation/stationary/components_3c.xml
@@ -7,7 +7,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>1</shifted>
+			<shifted>true</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>
@@ -22,7 +22,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>1</shifted>
+			<shifted>true</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>
@@ -37,7 +37,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>1</shifted>
+			<shifted>true</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>

--- a/examples/Evaporation/stationary/components_3c.xml
+++ b/examples/Evaporation/stationary/components_3c.xml
@@ -7,7 +7,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0.097901347</shifted>
+			<shifted>1</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>
@@ -22,7 +22,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0.097901347</shifted>
+			<shifted>1</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>
@@ -37,7 +37,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0.097901347</shifted>
+			<shifted>1</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>

--- a/examples/ExplodingLiquid/components.xml
+++ b/examples/ExplodingLiquid/components.xml
@@ -7,7 +7,7 @@
 		<mass>1</mass>
 		<sigma>1</sigma>
 		<epsilon>1</epsilon>
-		<shifted>1</shifted>
+		<shifted>true</shifted>
 	</site>
 	<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/components.xml
+++ b/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/components.xml
@@ -8,7 +8,7 @@
 			<mass>1</mass>
 			<sigma>1</sigma>
 			<epsilon>1</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>
@@ -23,7 +23,7 @@
 			<mass>2</mass>
 			<sigma>1</sigma>
 			<epsilon>1</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>

--- a/examples/Generators/PerCellGenerator/components.xml
+++ b/examples/Generators/PerCellGenerator/components.xml
@@ -7,7 +7,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_220K/components_co2_merker.xml
+++ b/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_220K/components_co2_merker.xml
@@ -13,21 +13,21 @@
 			<mass>12.012</mass>
 			<sigma>2.8137</sigma>
 			<epsilon>12.3724</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="LJ126" id="2" >
 			<coords> <x>0.0</x> <y>0.0</y> <z>-1.2869</z> </coords>
 			<mass>15.999</mass>
 			<sigma>2.9755</sigma>
 			<epsilon>100.493</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="LJ126" id="3" >
 			<coords> <x>0.0</x> <y>0.0</y> <z>1.2869</z> </coords>
 			<mass>15.999</mass>
 			<sigma>2.9755</sigma>
 			<epsilon>100.493</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="Quadrupole" id="4" >
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>

--- a/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_242-15K/components_co2_merker.xml
+++ b/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_242-15K/components_co2_merker.xml
@@ -13,21 +13,21 @@
 			<mass>12.012</mass>
 			<sigma>2.8137</sigma>
 			<epsilon>12.3724</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="LJ126" id="2" >
 			<coords> <x>0.0</x> <y>0.0</y> <z>-1.2869</z> </coords>
 			<mass>15.999</mass>
 			<sigma>2.9755</sigma>
 			<epsilon>100.493</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="LJ126" id="3" >
 			<coords> <x>0.0</x> <y>0.0</y> <z>1.2869</z> </coords>
 			<mass>15.999</mass>
 			<sigma>2.9755</sigma>
 			<epsilon>100.493</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<site type="Quadrupole" id="4" >
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>

--- a/examples/Generators/ReplicaGenerator/homogeneous/1CLJ-full_cubic/components.xml
+++ b/examples/Generators/ReplicaGenerator/homogeneous/1CLJ-full_cubic/components.xml
@@ -8,7 +8,7 @@
     <mass>1.0</mass>
     <sigma>1.0</sigma>
     <epsilon>1.0</epsilon>
-    <shifted>0</shifted>
+    <shifted>false</shifted>
   </site>
   <momentsofinertia rotaxes="xyz" >
     <Ixx>0.0</Ixx>

--- a/examples/Generators/cubic_grid_generator/components.xml
+++ b/examples/Generators/cubic_grid_generator/components.xml
@@ -7,7 +7,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/Generators/mkTcTS/components.xml
+++ b/examples/Generators/mkTcTS/components.xml
@@ -7,7 +7,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/Generators/mkesfera/components.xml
+++ b/examples/Generators/mkesfera/components.xml
@@ -7,7 +7,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/Injection/comp/components_4c.xml
+++ b/examples/Injection/comp/components_4c.xml
@@ -8,7 +8,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>1</shifted>
+			<shifted>true</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>
@@ -23,7 +23,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>1</shifted>
+			<shifted>true</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>
@@ -38,7 +38,7 @@
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>1</shifted>
+            <shifted>true</shifted>
         </site>
         <momentsofinertia rotaxes="xyz" >
             <Ixx>0.0</Ixx>
@@ -53,7 +53,7 @@
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>1</shifted>
+            <shifted>true</shifted>
         </site>
         <momentsofinertia rotaxes="xyz" >
             <Ixx>0.0</Ixx>

--- a/examples/KDD-vectorization-tuner/one-component/components.xml
+++ b/examples/KDD-vectorization-tuner/one-component/components.xml
@@ -7,7 +7,7 @@
 			<mass>0.039948</mass>
 			<sigma>6.4160007</sigma>
 			<epsilon>0.000369852537</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/KDD-vectorization-tuner/two-components/components.xml
+++ b/examples/KDD-vectorization-tuner/two-components/components.xml
@@ -7,7 +7,7 @@
 			<mass>0.039948</mass>
 			<sigma>6.4160007</sigma>
 			<epsilon>0.000369852537</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/adios/write/config_mix.xml
+++ b/examples/adios/write/config_mix.xml
@@ -36,7 +36,7 @@
 						<mass>1</mass>
 						<sigma>1</sigma>
 						<epsilon>1</epsilon>
-						<shifted>0</shifted>
+						<shifted>false</shifted>
 					</site>
 					<momentsofinertia rotaxes="xyz" >
 						<Ixx>0.0</Ixx>
@@ -51,7 +51,7 @@
 						<mass>2</mass>
 						<sigma>1</sigma>
 						<epsilon>1</epsilon>
-						<shifted>0</shifted>
+						<shifted>false</shifted>
 					</site>
 					<momentsofinertia rotaxes="xyz" >
 						<Ixx>0.0</Ixx>

--- a/examples/comparison.xml
+++ b/examples/comparison.xml
@@ -29,7 +29,7 @@
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>0</shifted>
+            <shifted>false</shifted>
           </site>
           <momentsofinertia rotaxes="xyz" >
           <Ixx>0.0</Ixx>

--- a/examples/general-plugins/CavityWriter/CavityWriterTest.xml
+++ b/examples/general-plugins/CavityWriter/CavityWriterTest.xml
@@ -46,7 +46,7 @@ It detects the less dense space around the dense drop as a cavity.
 		  	        	<mass>1.0</mass>
 		  	        	<sigma>1.0</sigma>
 		  	        	<epsilon>1.0</epsilon>
-		  	        	<shifted>1</shifted>
+		  	        	<shifted>true</shifted>
 		        	</site>
 		          	<momentsofinertia rotaxes="xyz" >
 			      	    <Ixx>0.0</Ixx>

--- a/examples/general-plugins/RegionSampling/case01/components.xml
+++ b/examples/general-plugins/RegionSampling/case01/components.xml
@@ -8,7 +8,7 @@
 			<mass>39.948</mass>
 			<sigma>3.3916</sigma>
 			<epsilon>137.90</epsilon>
-			<shifted>1</shifted>
+			<shifted>true</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 			<Ixx>0.0</Ixx>

--- a/examples/general-plugins/SpatialProfiles/CartesianSampling/CartesianSampling.xml
+++ b/examples/general-plugins/SpatialProfiles/CartesianSampling/CartesianSampling.xml
@@ -29,7 +29,7 @@
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>1</shifted>
+            <shifted>true</shifted>
           </site>
           <momentsofinertia rotaxes="xyz" >
           <Ixx>0.0</Ixx>

--- a/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
+++ b/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
@@ -36,7 +36,7 @@
 		  	        	<mass>1.0</mass>
 		  	        	<sigma>1.0</sigma>
 		  	        	<epsilon>1.0</epsilon>
-		  	        	<shifted>1</shifted>
+		  	        	<shifted>true</shifted>
 		        	</site>
 		          	<momentsofinertia rotaxes="xyz" >
 			      	    <Ixx>0.0</Ixx>

--- a/examples/general-plugins/components-1clj.xml
+++ b/examples/general-plugins/components-1clj.xml
@@ -7,7 +7,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/in-memory-checkpointing/components.xml
+++ b/examples/in-memory-checkpointing/components.xml
@@ -7,7 +7,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/insitu-test/components.xml
+++ b/examples/insitu-test/components.xml
@@ -7,7 +7,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/resilience-test/components.xml
+++ b/examples/resilience-test/components.xml
@@ -7,7 +7,7 @@
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
 			<epsilon>1.0</epsilon>
-			<shifted>0</shifted>
+			<shifted>false</shifted>
 		</site>
 		<momentsofinertia rotaxes="xyz" >
 		<Ixx>0.0</Ixx>

--- a/examples/surface-tension_LRC/2CLJ/components_2clj.xml
+++ b/examples/surface-tension_LRC/2CLJ/components_2clj.xml
@@ -13,14 +13,14 @@
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>0</shifted>
+            <shifted>false</shifted>
         </site>
         <site type="LJ126" id="2" >
             <coords> <x>0.0</x> <y>0.0</y> <z>0.5</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>0</shifted>
+            <shifted>false</shifted>
         </site>
         <momentsofinertia rotaxes="xyz" >
         <Ixx>0.5</Ixx>

--- a/examples/surface-tension_LRC/CO2_Merker/components_co2_merker.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/components_co2_merker.xml
@@ -13,21 +13,21 @@
             <mass>12.012</mass>
             <sigma>2.8137</sigma>
             <epsilon>12.3724</epsilon>
-            <shifted>0</shifted>
+            <shifted>false</shifted>
         </site>
         <site type="LJ126" id="2" name="O">
             <coords> <x>0.0</x> <y>0.0</y> <z>-1.2869</z> </coords>
             <mass>15.999</mass>
             <sigma>2.9755</sigma>
             <epsilon>100.493</epsilon>
-            <shifted>0</shifted>
+            <shifted>false</shifted>
         </site>
         <site type="LJ126" id="3" name="O">
             <coords> <x>0.0</x> <y>0.0</y> <z>1.2869</z> </coords>
             <mass>15.999</mass>
             <sigma>2.9755</sigma>
             <epsilon>100.493</epsilon>
-            <shifted>0</shifted>
+            <shifted>false</shifted>
         </site>
         <site type="Quadrupole" id="4" >
             <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -265,7 +265,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			if(xmlconfig.getNodeValueReduced("radiusLJ", _LJCutoffRadius)) {
 				global_log->info() << "dimensionless LJ cutoff radius:\t" << _LJCutoffRadius << endl;
 				for(auto &component: *(_ensemble->getComponents())) {
-					component.updateAllLJcenters(_LJCutoffRadius);
+					component.updateAllLJcentersShift(_LJCutoffRadius);
 				}
 			}
 			/** @todo introduce maxCutoffRadius here for datastructures, ...

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -264,6 +264,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			}
 			if(xmlconfig.getNodeValueReduced("radiusLJ", _LJCutoffRadius)) {
 				global_log->info() << "dimensionless LJ cutoff radius:\t" << _LJCutoffRadius << endl;
+				for(auto &component: *(_ensemble->getComponents())) {
+					component.updateAllLJcenters(_LJCutoffRadius);
+				}
 			}
 			/** @todo introduce maxCutoffRadius here for datastructures, ...
 			 *        maybe use map/list to store cutoffs for different potentials? */

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -116,8 +116,8 @@ void Component::addLJcenter(double x, double y, double z,
 }
 
 double Component::calculateLJshift(double eps, double sigma, double rc) const {
-	double sigperrc2 = sigma * sigma / (rc * rc);
-	double sigperrc6 = sigperrc2 * sigperrc2 * sigperrc2;
+	const double sigperrc2 = sigma * sigma / (rc * rc);
+	const double sigperrc6 = sigperrc2 * sigperrc2 * sigperrc2;
 	return 24.0 * eps * (sigperrc6 - sigperrc6 * sigperrc6);
 }
 

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -107,14 +107,18 @@ void Component::addLJcenter(double x, double y, double z,
                             double rc, bool TRUNCATED_SHIFTED) {
 	double shift6 = 0.0;
 	if (TRUNCATED_SHIFTED) {
-		double sigperrc2 = sigma * sigma / (rc * rc);
-		double sigperrc6 = sigperrc2 * sigperrc2 * sigperrc2;
-		shift6 = 24.0 * eps * (sigperrc6 - sigperrc6 * sigperrc6);
+		shift6 = calculateLJshift(eps, sigma, rc);
 	}
 
 	LJcenter ljsite(x, y, z, m, eps, sigma, shift6);
 	_ljcenters.push_back(ljsite);
 	updateMassInertia(ljsite);
+}
+
+double Component::calculateLJshift(double eps, double sigma, double rc) const {
+	double sigperrc2 = sigma * sigma / (rc * rc);
+	double sigperrc6 = sigperrc2 * sigperrc2 * sigperrc2;
+	return 24.0 * eps * (sigperrc6 - sigperrc6 * sigperrc6);
 }
 
 void Component::addLJcenter(LJcenter& ljsite) {

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -128,7 +128,8 @@ void Component::addLJcenter(LJcenter& ljsite) {
 
 void Component::updateAllLJcenters(double rc) {
 	for(LJcenter &ljcenter : _ljcenters) {
-		ljcenter.setULJShift6(calculateLJshift(ljcenter.eps(), ljcenter.sigma(), rc));
+		if(ljcenter.shift6() != 0)
+			ljcenter.setULJShift6(calculateLJshift(ljcenter.eps(), ljcenter.sigma(), rc));
 	}
 }
 

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -126,7 +126,7 @@ void Component::addLJcenter(LJcenter& ljsite) {
 	updateMassInertia(ljsite);
 }
 
-void Component::updateAllLJcenters(double rc) {
+void Component::updateAllLJcentersShift(double rc) {
 	for(LJcenter &ljcenter : _ljcenters) {
 		if(ljcenter.shiftRequested())
 			ljcenter.setULJShift6(calculateLJshift(ljcenter.eps(), ljcenter.sigma(), rc));

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -126,6 +126,11 @@ void Component::addLJcenter(LJcenter& ljsite) {
 	updateMassInertia(ljsite);
 }
 
+void Component::updateAllLJcenters(double rc) {
+	for(LJcenter ljcenter : _ljcenters) {
+		ljcenter.setULJShift6(calculateLJshift(ljcenter.eps(), ljcenter.sigma(), rc));
+	}
+}
 
 void Component::updateMassInertia() {
 	_m = 0;

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -127,7 +127,7 @@ void Component::addLJcenter(LJcenter& ljsite) {
 }
 
 void Component::updateAllLJcenters(double rc) {
-	for(LJcenter ljcenter : _ljcenters) {
+	for(LJcenter &ljcenter : _ljcenters) {
 		ljcenter.setULJShift6(calculateLJshift(ljcenter.eps(), ljcenter.sigma(), rc));
 	}
 }

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -128,7 +128,7 @@ void Component::addLJcenter(LJcenter& ljsite) {
 
 void Component::updateAllLJcenters(double rc) {
 	for(LJcenter &ljcenter : _ljcenters) {
-		if(ljcenter.shift6() != 0)
+		if(ljcenter.shiftRequested())
 			ljcenter.setULJShift6(calculateLJshift(ljcenter.eps(), ljcenter.sigma(), rc));
 	}
 }

--- a/src/molecules/Component.h
+++ b/src/molecules/Component.h
@@ -84,7 +84,6 @@ public:
 			double x, double y, double z, double m, double eps,
 			double sigma, double rc = 0, bool TRUNCATED_SHIFTED = 0
 	);
-	double calculateLJshift(double eps, double sigma, double rc) const;
 	void addCharge(Charge& chargesite);
 	void addCharge(double x, double y, double z, double m, double q);
 	void addDipole(Dipole& dipolesite);
@@ -93,6 +92,9 @@ public:
 	void addQuadrupole(Quadrupole& quadrupolesite);
 	void addQuadrupole(double x, double y, double z,
 	                   double eQx, double eQy, double eQz, double eQabs);
+
+	/** functions to fix the LJTS after rc is read in the simulation*/
+	void updateAllLJcenters(double rc);
 
 	/** delete the last site stored in the vector -- these are used by the external generators*/
 	void deleteLJCenter() { _ljcenters.pop_back() ;}
@@ -137,6 +139,7 @@ public:
 private:
 
 	void updateMassInertia(Site& site);
+	double calculateLJshift(double eps, double sigma, double rc) const;
 
 	unsigned int _id; /**< component ID */
 	// LJcenter,Dipole,Quadrupole have different size -> not suitable to store in a _Site_-array

--- a/src/molecules/Component.h
+++ b/src/molecules/Component.h
@@ -94,7 +94,7 @@ public:
 	                   double eQx, double eQy, double eQz, double eQabs);
 
 	/** functions to fix the LJTS after rc is read in the simulation*/
-	void updateAllLJcenters(double rc);
+	void updateAllLJcentersShift(double rc);
 
 	/** delete the last site stored in the vector -- these are used by the external generators*/
 	void deleteLJCenter() { _ljcenters.pop_back() ;}

--- a/src/molecules/Component.h
+++ b/src/molecules/Component.h
@@ -84,6 +84,7 @@ public:
 			double x, double y, double z, double m, double eps,
 			double sigma, double rc = 0, bool TRUNCATED_SHIFTED = 0
 	);
+	double calculateLJshift(double eps, double sigma, double rc) const;
 	void addCharge(Charge& chargesite);
 	void addCharge(double x, double y, double z, double m, double q);
 	void addDipole(Dipole& dipolesite);

--- a/src/molecules/Site.h
+++ b/src/molecules/Site.h
@@ -97,7 +97,7 @@ protected:
 class LJcenter : public Site {
 public:
 	/** @brief Constructor */
-	LJcenter(): Site(0., 0., 0., 0.), _epsilon(0.), _sigma(0.), _uLJshift6(0.) {}
+	LJcenter(): Site(0., 0., 0., 0.), _epsilon(0.), _sigma(0.), _uLJshift6(0.), _shiftRequested(false) {}
 	/** @brief Constructor
 	 * \param[in] x        relative x coordinate
 	 * \param[in] y        relative y coordinate
@@ -108,7 +108,7 @@ public:
 	 * \param[in] shift    0. for full LJ potential
 	 */
 	LJcenter(double x, double y, double z, double m, double epsilon, double sigma, double shift)
-		: Site(x, y, z, m), _epsilon(epsilon), _sigma(sigma), _uLJshift6(shift) {}
+		: Site(x, y, z, m), _epsilon(epsilon), _sigma(sigma), _uLJshift6(shift), _shiftRequested(false) {}
 
 	/** @brief Read in XML configuration for a LJcenter and all its included objects.
 	 *

--- a/src/molecules/Site.h
+++ b/src/molecules/Site.h
@@ -138,7 +138,7 @@ public:
 	double eps() const { return _epsilon; }  /**< get interaction strength */
 	double sigma() const { return _sigma; }  /**< get interaction diameter */
 	double shift6() const { return _uLJshift6; }  /**< get energy shift of interaction potential */
-	double shiftRequested() const { return _shiftRequested; } /**< get the shift request value */
+	bool shiftRequested() const { return _shiftRequested; } /**< get the shift request value */
 
 	/** set the interaction strength */
 	void setEps(double epsilon) { _epsilon = epsilon; }

--- a/src/molecules/Site.h
+++ b/src/molecules/Site.h
@@ -118,7 +118,7 @@ public:
 	     <!-- all Site class parameters -->
 	     <epsilon>DOUBLE</epsilon>
 	     <sigma>DOUBLE</sigma>
-	     <shifted>DOUBLE</shifted>
+	     <shifted>BOOLEAN</shifted>
 	   </site>
 	   \endcode
 	 */
@@ -126,7 +126,7 @@ public:
 		Site::readXML(xmlconfig);
 		xmlconfig.getNodeValueReduced("epsilon", _epsilon);
 		xmlconfig.getNodeValueReduced("sigma", _sigma);
-		xmlconfig.getNodeValueReduced("shifted", _uLJshift6);
+		xmlconfig.getNodeValue("shifted", _shiftRequested);
 	}
 	
 	/// write to stream
@@ -138,6 +138,7 @@ public:
 	double eps() const { return _epsilon; }  /**< get interaction strength */
 	double sigma() const { return _sigma; }  /**< get interaction diameter */
 	double shift6() const { return _uLJshift6; }  /**< get energy shift of interaction potential */
+	double shiftRequested() const { return _shiftRequested; } /**< get the shift request value */
 
 	/** set the interaction strength */
 	void setEps(double epsilon) { _epsilon = epsilon; }
@@ -151,6 +152,7 @@ private:
 	double _epsilon;  /**< interaction strength */
 	double _sigma;  /**< interaction diameter */
 	double _uLJshift6; /**< energy shift of the interaction potential, used to implement the LJ truncated and shifted (LJTS) potential */
+	bool _shiftRequested; /***< whether the LJTS potential shift needs to be calculated or not */
 };
 
 /** @brief Charge center

--- a/tools/standalone-generators/animake/Domain.cpp
+++ b/tools/standalone-generators/animake/Domain.cpp
@@ -374,7 +374,7 @@ void Domain::write(char* prefix, int format, double mu, double x)
              << FLUIDMASS/REFMASS << "</mass><sigma>"
              << SIG_FLUID/SIG_REF << "</sigma><epsilon>"
              << EPS_FLUID/EPS_REF
-             << "</epsilon><shifted>0</shifted></site>\n";
+             << "</epsilon><shifted>false</shifted></site>\n";
       }
       else if(fluid == FLUID_EOX)
       {
@@ -384,21 +384,21 @@ void Domain::write(char* prefix, int format, double mu, double x)
              << CEOXMASS/REFMASS << "</mass><sigma>"
              << SIG_CEOX/SIG_REF << "</sigma><epsilon>"
              << EPS_CEOX/EPS_REF
-             << "</epsilon><shifted>0</shifted></site>\n"
+             << "</epsilon><shifted>false</shifted></site>\n"
              << "<site type=\"LJ126\" id=\"2\"><coord><x>"
              << R0_C2EOX/SIG_REF << "</x><y>" << R1_C2EOX/SIG_REF
              << "</y><z>" << R2_C2EOX/SIG_REF << "</z></coord><mass>"
              << CEOXMASS/REFMASS << "</mass><sigma>"
              << SIG_CEOX/SIG_REF << "</sigma><epsilon>"
              << EPS_CEOX/EPS_REF
-             << "</epsilon><shifted>0</shifted></site>\n"
+             << "</epsilon><shifted>false</shifted></site>\n"
              << "<site type=\"LJ126\" id=\"3\"><coord><x>"
              << R0_O_EOX/SIG_REF << "</x><y>" << R1_O_EOX/SIG_REF
              << "</y><z>" << R2_O_EOX/SIG_REF << "</z></coord><mass>"
              << OEOXMASS/REFMASS << "</mass><sigma>"
              << SIG_OEOX/SIG_REF << "</sigma><epsilon>"
              << EPS_OEOX/EPS_REF
-             << "</epsilon><shifted>0</shifted></site>\n"
+             << "</epsilon><shifted>false</shifted></site>\n"
              << "<site type=\"Dipol\" id=\"4\"><coord><x>"
              << R0DIPEOX/SIG_REF << "</x><y>" << R1DIPEOX/SIG_REF
              << "</y><z>" << R2DIPEOX/SIG_REF

--- a/validation/validationInput/LRC_planar_2020/components_2clj.xml
+++ b/validation/validationInput/LRC_planar_2020/components_2clj.xml
@@ -13,14 +13,14 @@
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>0</shifted>
+            <shifted>false</shifted>
         </site>
         <site type="LJ126" id="2" >
             <coords> <x>0.0</x> <y>0.0</y> <z>0.5</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>0</shifted>
+            <shifted>false</shifted>
         </site>
         <momentsofinertia rotaxes="xyz" >
         <Ixx>0.5</Ixx>


### PR DESCRIPTION
# Description

The <shifted> tag is now a boolean, and the shift for LJTS is automatically calculated.

## Resolved Issues

- [ ] #204 

## How Has This Been Tested?

Tested with the ls1configNoCP.xml in the Mamico-couette example, with different values and components. The U_pot is different for shifted set to 1 or 0 for the same simulation.