### PR TITLE
Adding includes to cstdint

### DIFF
--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -34,7 +34,7 @@
 using Log::global_log;
 using namespace std;
 
-enum MoleculeFormat : uint32_t {
+enum MoleculeFormat : std::uint32_t {
 	ICRVQD, IRV, ICRV
 };
 
@@ -85,7 +85,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	bool bInputOk = true;
 	double dCurrentTime = 0.;
 	double dBoxLength[3] = {0., 0., 0.};
-	uint64_t numMolecules = 0;
+	std::uint64_t numMolecules = 0;
 	std::string strMoleculeFormat;
 	bInputOk = bInputOk && inp.changecurrentnode("headerinfo");
 	bInputOk = bInputOk && inp.getNodeValue("time", dCurrentTime);
@@ -113,7 +113,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 
 	// Set parameters of Domain and Simulation class
 	_simulation.setSimulationTime(dCurrentTime);
-	for(uint8_t d = 0; d < 3; ++d) {
+	for(std::uint8_t d = 0; d < 3; ++d) {
 		domain->setGlobalLength(d, dBoxLength[d]);
 	}
 	domain->setglobalNumMolecules(numMolecules);
@@ -162,16 +162,16 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 #endif
 
 	double x, y, z, vx, vy, vz, q0, q1, q2, q3, Dx, Dy, Dz;
-	uint64_t id;
-	uint32_t componentid = 0;
+	std::uint64_t id;
+	std::uint32_t componentid = 0;
 
 	x = y = z = vx = vy = vz = q1 = q2 = q3 = Dx = Dy = Dz = 0.;
 	q0 = 1.;
 
 	// Global number of particles must not be updated as this would result in numMolecules = 0
-	uint64_t numMolecules = domain->getglobalNumMolecules(false);
+	std::uint64_t numMolecules = domain->getglobalNumMolecules(false);
 
-	for(uint64_t i = 0; i < numMolecules; i++) {
+	for(std::uint64_t i = 0; i < numMolecules; i++) {
 
 #ifdef ENABLE_MPI
 		if (domainDecomp->getRank() == 0) { // Rank 0 only

--- a/src/io/BinaryReader.h
+++ b/src/io/BinaryReader.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <fstream>
+#include <cstdint>
 
 #include "utils/xmlfile.h"
 #include "io/InputBase.h"

--- a/src/io/BinaryReader.h
+++ b/src/io/BinaryReader.h
@@ -91,7 +91,7 @@ public:
 
 private:
 
-	uint32_t _nMoleculeFormat;
+	std::uint32_t _nMoleculeFormat;
 	std::string _moleculeFormat;
 	std::string _phaseSpaceFile;
 	std::string _phaseSpaceHeaderFile;

--- a/src/io/MmpldWriter.h
+++ b/src/io/MmpldWriter.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <array>
+#include <cstdint>
 
 #include "plugins/PluginBase.h"
 #include "molecules/MoleculeForwardDeclaration.h"

--- a/src/io/MmpldWriter.h
+++ b/src/io/MmpldWriter.h
@@ -13,21 +13,21 @@
 #include "utils/MPI_Info_object.h"
 #endif
 
-enum InitSphereData : uint8_t
+enum InitSphereData : std::uint8_t
 {
 	ISD_USE_DEFAULT = 1,
 	ISD_READ_FROM_FILE = 2,
 	ISD_READ_FROM_XML = 3,
 };
 
-enum MMPLD_Vertex_type : uint8_t {
+enum MMPLD_Vertex_type : std::uint8_t {
 	MMPLD_VERTEX_NONE       = 0,
 	MMPLD_VERTEX_FLOAT_XYZ  = 1,
 	MMPLD_VERTEX_FLOAT_XYZR = 2,
 	MMPLD_VERTEX_SHORT_XYZ  = 3,
 };
 
-enum MMPLD_Color_type : uint8_t {
+enum MMPLD_Color_type : std::uint8_t {
 	MMPLD_COLOR_NONE       = 0,
 	MMPLD_COLOR_UINT8_RGB  = 1,
 	MMPLD_COLOR_UINT8_RGBA = 2,
@@ -53,13 +53,13 @@ protected:
 	//! @param domainDecomp In the parallel version, the file has to be written by more than one process.
 	//!                     Methods to achieve this are available in domainDecomp
 	//! @param writeFrequency Controls the frequency of writing out the data (every timestep, every 10th, 100th, ... timestep)
-	MmpldWriter(uint64_t startTimestep, uint64_t writeFrequency, uint64_t stopTimestep, uint64_t numFramesPerFile,
+	MmpldWriter(std::uint64_t startTimestep, std::uint64_t writeFrequency, std::uint64_t stopTimestep, std::uint64_t numFramesPerFile,
 			std::string outputPrefix);
 	virtual ~MmpldWriter() {}
 
 	virtual void SetNumSphereTypes() {}
-	virtual void CalcNumSpheresPerType(ParticleContainer* particleContainer, uint64_t* numSpheresPerType) {}
-	virtual bool GetSpherePos(float *spherePos, Molecule* mol, uint8_t& nSphereTypeIndex) { return false; }
+	virtual void CalcNumSpheresPerType(ParticleContainer* particleContainer, std::uint64_t* numSpheresPerType) {}
+	virtual bool GetSpherePos(float *spherePos, Molecule* mol, std::uint8_t& nSphereTypeIndex) { return false; }
 
 	void InitSphereData();
 
@@ -81,7 +81,7 @@ public:
 	}
 	static PluginBase* createInstance() { return new MmpldWriter(); }
 
-	void SetInitSphereDataParameters(const uint8_t &bInitSphereData, const std::string &strSphereDataFilename) {
+	void SetInitSphereDataParameters(const std::uint8_t &bInitSphereData, const std::string &strSphereDataFilename) {
 		_bInitSphereData = bInitSphereData; _strSphereDataFilename = strSphereDataFilename;
 	}
 
@@ -92,44 +92,44 @@ protected:
 	void PrepareWriteControl();
 	long get_data_frame_header_size();
 	long get_seekTable_size();
-	void writeSeekTableEntry(int id, uint64_t offset);
+	void writeSeekTableEntry(int id, std::uint64_t offset);
 	long get_data_list_header_size();
 	long get_particle_data_size();
-	long get_data_list_size(uint64_t particle_count);
-	void write_frame_header(uint32_t num_data_lists);
-	void write_particle_list_header(uint64_t particle_count, int sphereId);
+	long get_data_list_size(std::uint64_t particle_count);
+	void write_frame_header(std::uint32_t num_data_lists);
+	void write_particle_list_header(std::uint64_t particle_count, int sphereId);
 	void write_frame(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp);
 
 protected:
 	/** First time step to be recorded */
-	uint64_t _startTimestep;
+	std::uint64_t _startTimestep;
 	/** time steps between two records*/
-	uint64_t _writeFrequency;
+	std::uint64_t _writeFrequency;
 	/** Max time step up to which shall be recorded */
-	uint64_t _stopTimestep;
+	std::uint64_t _stopTimestep;
 	long _writeBufferSize;
 	std::string _outputPrefix;
 	std::string _timestampString;
-	uint32_t _frameCount;
-	uint8_t  _numComponents;
-	uint8_t  _numSitesTotal;
-	uint8_t  _numSphereTypes;
-	std::vector<uint64_t> _seekTable;
-	std::vector<uint8_t> _numSitesPerComp;
-	std::vector<uint8_t> _nCompSitesOffset;
+	std::uint32_t _frameCount;
+	std::uint8_t  _numComponents;
+	std::uint8_t  _numSitesTotal;
+	std::uint8_t  _numSphereTypes;
+	std::vector<std::uint64_t> _seekTable;
+	std::vector<std::uint8_t> _numSitesPerComp;
+	std::vector<std::uint8_t> _nCompSitesOffset;
 	std::string _strSphereDataFilename;
-	uint8_t _bInitSphereData;
+	std::uint8_t _bInitSphereData;
 	bool _bWriteControlPrepared;
 
 	long _fileCount;
-	uint32_t _numFramesPerFile;
+	std::uint32_t _numFramesPerFile;
 
-	uint16_t _mmpldversion;
-	uint32_t _numSeekEntries;
+	std::uint16_t _mmpldversion;
+	std::uint32_t _numSeekEntries;
 	MMPLD_Vertex_type _vertex_type;
 	MMPLD_Color_type _color_type;
 	std::vector<float> _global_radius;
-	std::vector< std::array<uint8_t, 4> > _global_rgba;
+	std::vector< std::array<std::uint8_t, 4> > _global_rgba;
 	std::vector< std::array<float, 2> > _global_intensity_range;
 
 
@@ -143,7 +143,7 @@ class MmpldWriterSimpleSphere : public MmpldWriter
 {
 public:
 	MmpldWriterSimpleSphere() {}
-	MmpldWriterSimpleSphere(uint64_t startTimestep, uint64_t writeFrequency, uint64_t stopTimestep, uint64_t numFramesPerFile,
+	MmpldWriterSimpleSphere(std::uint64_t startTimestep, std::uint64_t writeFrequency, std::uint64_t stopTimestep, std::uint64_t numFramesPerFile,
 			std::string outputPrefix)
 			: MmpldWriter(startTimestep, writeFrequency, stopTimestep, numFramesPerFile, outputPrefix)
 	{
@@ -152,15 +152,15 @@ public:
 	virtual ~MmpldWriterSimpleSphere() {}
 
 	virtual void SetNumSphereTypes() {_numSphereTypes = _numComponents;}
-	virtual void CalcNumSpheresPerType(ParticleContainer* particleContainer, uint64_t* numSpheresPerType);
-	virtual bool GetSpherePos(float *spherePos, Molecule* mol, uint8_t& nSphereTypeIndex);
+	virtual void CalcNumSpheresPerType(ParticleContainer* particleContainer, std::uint64_t* numSpheresPerType);
+	virtual bool GetSpherePos(float *spherePos, Molecule* mol, std::uint8_t& nSphereTypeIndex);
 };
 
 class MmpldWriterMultiSphere : public MmpldWriter
 {
 public:
 	MmpldWriterMultiSphere() {}
-	MmpldWriterMultiSphere(uint64_t startTimestep, uint64_t writeFrequency, uint64_t stopTimestep, uint64_t numFramesPerFile,
+	MmpldWriterMultiSphere(std::uint64_t startTimestep, std::uint64_t writeFrequency, std::uint64_t stopTimestep, std::uint64_t numFramesPerFile,
 			std::string outputPrefix)
 			: MmpldWriter(startTimestep, writeFrequency, stopTimestep, numFramesPerFile, outputPrefix)
 	{
@@ -169,8 +169,8 @@ public:
 	virtual ~MmpldWriterMultiSphere() {}
 
 	virtual void SetNumSphereTypes() {_numSphereTypes = _numSitesTotal;}
-	virtual void CalcNumSpheresPerType(ParticleContainer* particleContainer, uint64_t* numSpheresPerType);
-	virtual bool GetSpherePos(float *spherePos, Molecule* mol, uint8_t& nSphereTypeIndex);
+	virtual void CalcNumSpheresPerType(ParticleContainer* particleContainer, std::uint64_t* numSpheresPerType);
+	virtual bool GetSpherePos(float *spherePos, Molecule* mol, std::uint8_t& nSphereTypeIndex);
 };
 
 #endif /* MMPLDWRITER_H_ */

--- a/src/particleContainer/adapter/vectorization/MaskVecFloat.h
+++ b/src/particleContainer/adapter/vectorization/MaskVecFloat.h
@@ -20,14 +20,14 @@ class MaskVec<float> {
 private:
 	// own typedefs necessary
 	#if   VCP_VEC_WIDTH == VCP_VEC_W__64
-		typedef uint8_t mask_vec;
-		typedef uint8_t mask_single;
+		typedef std::uint8_t mask_vec;
+		typedef std::uint8_t mask_single;
 	#elif VCP_VEC_WIDTH == VCP_VEC_W_128
 		typedef __m128i mask_vec;
-		typedef uint32_t mask_single;
+		typedef std::uint32_t mask_single;
 	#elif VCP_VEC_WIDTH == VCP_VEC_W_256
 		typedef __m256i mask_vec;
-		typedef uint32_t mask_single;
+		typedef std::uint32_t mask_single;
 	#elif VCP_VEC_WIDTH == VCP_VEC_W_512
 
 		// these can't be put in std::conditional, because it would just be too nice. warnings.

--- a/src/particleContainer/adapter/vectorization/MaskVecFloat.h
+++ b/src/particleContainer/adapter/vectorization/MaskVecFloat.h
@@ -9,6 +9,7 @@
 #define SRC_PARTICLECONTAINER_ADAPTER_VECTORIZATION_MASKVECFLOAT_H_
 
 #include "MaskVec.h"
+#include <cstdint>
 
 // keep this file and MaskVecDouble as close as possible, so that they can be examined via diff!
 

--- a/src/utils/FileUtils.h
+++ b/src/utils/FileUtils.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <cstddef>
 #include <limits>
+#include <cstdint>
 
 // write out data in scientific format with max. number of digits
 #define FORMAT_SCI_MAX_DIGITS std::setw(24) << std::scientific << std::setprecision(std::numeric_limits<double>::digits10)

--- a/src/utils/FileUtils.h
+++ b/src/utils/FileUtils.h
@@ -51,7 +51,7 @@ unsigned int getFileSize(const char* fileName);
  */
 struct fill_width
 {
-	fill_width( char f, uint8_t w )
+	fill_width( char f, std::uint8_t w )
 		: fill(f), width(w) {}
 	char fill;
 	int width;

--- a/src/utils/tests/AlignedArrayTest.cpp
+++ b/src/utils/tests/AlignedArrayTest.cpp
@@ -7,7 +7,7 @@
 #include "AlignedArrayTest.h"
 #include "../AlignedArray.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 using namespace std;

--- a/src/utils/tests/AlignedArrayTripletTest.cpp
+++ b/src/utils/tests/AlignedArrayTripletTest.cpp
@@ -8,7 +8,7 @@
 #include "AlignedArrayTripletTest.h"
 #include "../AlignedArrayTriplet.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 using namespace std;

--- a/src/utils/tests/ConcatenatedAlignedArrayRMMTest.cpp
+++ b/src/utils/tests/ConcatenatedAlignedArrayRMMTest.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 using namespace std;
-typedef ConcatenatedAlignedArrayRMM<float, float, uint64_t>::Quantity_t Quantity_t;
+typedef ConcatenatedAlignedArrayRMM<float, float, std::uint64_t>::Quantity_t Quantity_t;
 
 TEST_SUITE_REGISTRATION(ConcatenatedAlignedArrayRMMTest);
 
@@ -31,14 +31,14 @@ void ConcatenatedAlignedArrayRMMTest::testAlignment() {
 
 	for (int i = 0; i < 11; ++i) {
 		const size_t length = i;
-		ConcatenatedAlignedArrayRMM<float, float, uint64_t> a(length);
+		ConcatenatedAlignedArrayRMM<float, float, std::uint64_t> a(length);
 		float * rx = a.begin_calc(Quantity_t::RX);
 		float * ry = a.begin_calc(Quantity_t::RY);
 		float * rz = a.begin_calc(Quantity_t::RZ);
 		float * vx = a.begin_accum(Quantity_t::VX);
 		float * vy = a.begin_accum(Quantity_t::VY);
 		float * vz = a.begin_accum(Quantity_t::VZ);
-		uint64_t * uid = a.begin_uid(Quantity_t::UID);
+		std::uint64_t * uid = a.begin_uid(Quantity_t::UID);
 
 		ASSERT_EQUAL(static_cast<int>(reinterpret_cast<intptr_t>(rx) % CACHE_LINE_SIZE), 0);
 		ASSERT_EQUAL(static_cast<int>(reinterpret_cast<intptr_t>(ry) % VCP_ALIGNMENT), 0);
@@ -51,7 +51,7 @@ void ConcatenatedAlignedArrayRMMTest::testAlignment() {
 }
 
 void ConcatenatedAlignedArrayRMMTest::testGetters() {
-	ConcatenatedAlignedArrayRMM<float, float, uint64_t> a(5);
+	ConcatenatedAlignedArrayRMM<float, float, std::uint64_t> a(5);
 	for (int i = static_cast<int>(Quantity_t::RX); i < static_cast<int>(Quantity_t::VX); ++i) {
 		Quantity_t j = static_cast<Quantity_t>(i);
 		a.get_calc(j,0) = i;
@@ -71,7 +71,7 @@ void ConcatenatedAlignedArrayRMMTest::testGetters() {
 	ASSERT_EQUAL(13ul, a.get_uid(Quantity_t::UID, 0));
 
 	// try out the const methods
-	const ConcatenatedAlignedArrayRMM<float, float, uint64_t> & b = a;
+	const ConcatenatedAlignedArrayRMM<float, float, std::uint64_t> & b = a;
 	ASSERT_DOUBLES_EQUAL(0.0, b.get_calc(Quantity_t::RX, 0), 1e-10);
 	ASSERT_DOUBLES_EQUAL(1.0, b.get_calc(Quantity_t::RY, 0), 1e-10);
 	ASSERT_DOUBLES_EQUAL(2.0, b.get_calc(Quantity_t::RZ, 0), 1e-10);
@@ -82,7 +82,7 @@ void ConcatenatedAlignedArrayRMMTest::testGetters() {
 }
 
 void ConcatenatedAlignedArrayRMMTest::testZero() {
-	ConcatenatedAlignedArrayRMM<float, float, uint64_t> a(8);
+	ConcatenatedAlignedArrayRMM<float, float, std::uint64_t> a(8);
 	const int qbegin = static_cast<int>(Quantity_t::RX);
 	const int qmid = static_cast<int>(Quantity_t::VX);
 	const int qend = static_cast<int>(Quantity_t::UID);
@@ -181,7 +181,7 @@ void ConcatenatedAlignedArrayRMMTest::testAppending() {
 		z.push_back(static_cast<float>(i+2));
 	}
 
-	ConcatenatedAlignedArrayRMM<float, float, uint64_t> A;
+	ConcatenatedAlignedArrayRMM<float, float, std::uint64_t> A;
 	for(int i = 0; i < 17; ++i) {
 		std::array<float,3> val = {
 			static_cast<float>(i),
@@ -202,7 +202,7 @@ void ConcatenatedAlignedArrayRMMTest::testAppending() {
 	float * vx = A.begin_accum(Quantity_t::VX);
 	float * vy = A.begin_accum(Quantity_t::VY);
 	float * vz = A.begin_accum(Quantity_t::VZ);
-	uint64_t * uid = A.begin_uid(Quantity_t::UID);
+	std::uint64_t * uid = A.begin_uid(Quantity_t::UID);
 
 	ASSERT_EQUAL(static_cast<int>(reinterpret_cast<intptr_t>(rx) % CACHE_LINE_SIZE), 0);
 	ASSERT_EQUAL(static_cast<int>(reinterpret_cast<intptr_t>(ry) % VCP_ALIGNMENT), 0);
@@ -224,7 +224,7 @@ void ConcatenatedAlignedArrayRMMTest::testIncreasingStorage() {
 		z.push_back(static_cast<float>(i+2));
 	}
 
-	ConcatenatedAlignedArrayRMM<float, float, uint64_t> A;
+	ConcatenatedAlignedArrayRMM<float, float, std::uint64_t> A;
 	for(int i = 0; i < 11; ++i) {
 		std::array<float, 3> val = {
 			static_cast<float>(i),

--- a/src/utils/tests/ConcatenatedAlignedArrayRMMTest.cpp
+++ b/src/utils/tests/ConcatenatedAlignedArrayRMMTest.cpp
@@ -10,7 +10,7 @@
 
 #include "particleContainer/adapter/vectorization/SIMD_TYPES.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 using namespace std;


### PR DESCRIPTION
# Description

To fix #256, I've added include to the C++ cstdint in some files and changed include to stdint.h to cstdint. 

In some files, there is a `using namespace std` hence the `std::uint*_t` is used but in some files it is not present. So I don't know which one is used but it compiles now. I wanted to solve the issue with as little modifications as possible in the code. But should we add the std namespace everywhere ? 

## How Has This Been Tested?

ls1 compiles fine with gcc 13.1.1 and clang 15.0.7. I've tried to compile with older versions of gcc and clang and it works as well.
