### PR TITLE
Fix data format mismatch between vtu and pvtu

### DIFF
--- a/src/io/vtk/VTKMoleculeWriterImplementation.cpp
+++ b/src/io/vtk/VTKMoleculeWriterImplementation.cpp
@@ -176,9 +176,9 @@ void  VTKMoleculeWriterImplementation::writeVTKFile(const std::string& fileName)
 void VTKMoleculeWriterImplementation::initializeParallelVTKFile(const std::vector<std::string>& fileNames) {
 	// init parallel file
 	PPointData p_pointData;
-	DataArray_t p_moleculeId(type::Float32, "id", 1);
+	DataArray_t p_moleculeId(type::UInt64, "id", 1);
 	p_pointData.PDataArray().push_back(p_moleculeId);
-	DataArray_t p_componentId(type::Float32, "component-id", 1);
+	DataArray_t p_componentId(type::Int32, "component-id", 1);
 	p_pointData.PDataArray().push_back(p_componentId);
 	DataArray_t p_node_rank(type::Int32, "node-rank", 1);
 	p_pointData.PDataArray().push_back(p_node_rank);


### PR DESCRIPTION
# Description

fix data format mismatch between vtu and pvtu

## Related Pull Requests

- #240 changed the type of `id` and `componentid` from `float` to `int` (and rightly so!). However, the types were only changed in the vtu and not the pvtu files.
