### PR TITLE
Plugin timers for all plugin calls

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -1020,7 +1020,9 @@ void Simulation::simulate() {
         global_log -> debug() << "[BEFORE EVENT NEW TIMESTEP] Performing beforeEventNewTimestep plugin call" << endl;
         for (auto plugin : _plugins) {
             global_log -> debug() << "[BEFORE EVENT NEW TIMESTEP] Plugin: " << plugin->getPluginName() << endl;
+			global_simulation->timers()->start(plugin->getPluginName());
             plugin->beforeEventNewTimestep(_moleculeContainer, _domainDecomposition, _simstep);
+			global_simulation->timers()->stop(plugin->getPluginName());
         }
 
         _ensemble->beforeEventNewTimestep(_moleculeContainer, _domainDecomposition, _simstep);
@@ -1031,7 +1033,9 @@ void Simulation::simulate() {
         global_log -> debug() << "[BEFORE FORCES] Performing BeforeForces plugin call" << endl;
         for (auto plugin : _plugins) {
             global_log -> debug() << "[BEFORE FORCES] Plugin: " << plugin->getPluginName() << endl;
+			global_simulation->timers()->start(plugin->getPluginName());
             plugin->beforeForces(_moleculeContainer, _domainDecomposition, _simstep);
+			global_simulation->timers()->stop(plugin->getPluginName());
         }
 
 		computationTimer->stop();
@@ -1075,7 +1079,9 @@ void Simulation::simulate() {
 		global_log -> debug() << "[SITEWISE FORCES] Performing siteWiseForces plugin call" << endl;
 		for (auto plugin : _plugins) {
 			global_log -> debug() << "[SITEWISE FORCES] Plugin: " << plugin->getPluginName() << endl;
+			global_simulation->timers()->start(plugin->getPluginName());
 			plugin->siteWiseForces(_moleculeContainer, _domainDecomposition, _simstep);
+			global_simulation->timers()->stop(plugin->getPluginName());
 		}
 
 		// longRangeCorrection is a site-wise force plugin, so we have to call it before updateForces()
@@ -1109,7 +1115,9 @@ void Simulation::simulate() {
 		global_log -> debug() << "[AFTER FORCES] Performing AfterForces plugin call" << endl;
 		for (auto plugin : _plugins) {
 			global_log -> debug() << "[AFTER FORCES] Plugin: " << plugin->getPluginName() << endl;
+			global_simulation->timers()->start(plugin->getPluginName());
 			plugin->afterForces(_moleculeContainer, _domainDecomposition, _simstep);
+			global_simulation->timers()->stop(plugin->getPluginName());
 		}
 
 		_ensemble->afterForces(_moleculeContainer, _domainDecomposition, _cellProcessor, _simstep);

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -916,7 +916,9 @@ void Simulation::prepare_start() {
 	for (auto plugin : _plugins) {
 		global_log->debug() << "[AFTER FORCES] Plugin: "
 							<< plugin->getPluginName() << endl;
+		global_simulation->timers()->start(plugin->getPluginName());
 		plugin->afterForces(_moleculeContainer, _domainDecomposition, _simstep);
+		global_simulation->timers()->stop(plugin->getPluginName());
 	}
 
 #ifndef MARDYN_AUTOPAS
@@ -1234,7 +1236,9 @@ void Simulation::simulate() {
 
 	global_log->info() << "Finish plugins" << endl;
 	for (auto plugin : _plugins) {
+		global_simulation->timers()->start(plugin->getPluginName());
 		plugin->finish(_moleculeContainer, _domainDecomposition, _domain);
+		global_simulation->timers()->stop(plugin->getPluginName());
 	}
 	global_simulation->timers()->getTimer("SIMULATION_FINAL_IO")->stop();
 


### PR DESCRIPTION
### Description

This PR solves issue #265. The shown consumed time of each plugin at the end of the simulation is not really correct right now as it considers only the time the `endStep()` method took. But as all methods can be used to do the plugin's work, they should all be considered. This also helps in the evaluation of the performance of each plugin, see issue #264.

### Resolved Issues

- [x] #265 

### How Has This Been Tested?

A simulation with e.g. the [MaxCheck plugin](https://github.com/ls1mardyn/ls1-mardyn/blob/master/src/plugins/MaxCheck.h) was run. The displayed time that the plugin took for its computations is now much higher as the work is done by the [`beforeEventNewTimestep()`](https://github.com/ls1mardyn/ls1-mardyn/blob/7d9f712a004ac1110dca370110ca967bff426b41/src/plugins/MaxCheck.cpp#L126C16-L126C38) and [`afterForces()`](https://github.com/ls1mardyn/ls1-mardyn/blob/7d9f712a004ac1110dca370110ca967bff426b41/src/plugins/MaxCheck.cpp#L137) methods.