### PR TITLE
Update to refreshParticleIDs

### DIFF
--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -11,6 +11,12 @@
 
   <!-- simulation options -->
   <simulation type="MD" >
+    <!-- block for misc options -->
+    <options>
+      <!-- immediately after filling the simulation with particles, reset all id's to start at zero and are consecutive -->
+      <option name="refreshIDs">true</option>
+    </options>
+
     <run>
       <currenttime>0</currenttime>
       <production>

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -744,6 +744,13 @@ void Simulation::initConfigXML(const string& inputfilename) {
 			global_log->error() << "Simulation section missing" << endl;
 			Simulation::exit(1);
 		}
+	
+		inp.getNodeValue("simulation/options/option", _prepare_start_opt.refreshIDs);
+		if(_prepare_start_opt.refreshIDs)
+				global_log->info() << "Particle IDs will be refreshed before simulation start." << endl;
+			else
+				global_log->info() << "Particle IDs will NOT be refreshed before simulation start." << endl;
+	
 	} catch (const std::exception& e) {
 		global_log->error() << "Error in XML config. Please check your input file!" << std::endl;
 		global_log->error() << "Exception: " << e.what() << std::endl;
@@ -768,6 +775,10 @@ void Simulation::initConfigXML(const string& inputfilename) {
 
 	_moleculeContainer->update();
 	_moleculeContainer->deleteOuterParticles();
+
+	/** refresh particle IDs */
+	if(_prepare_start_opt.refreshIDs)
+		this->refreshParticleIDs();
 
 	unsigned long globalNumMolecules = _domain->getglobalNumMolecules(true, _moleculeContainer, _domainDecomposition);
 	double rho_global = globalNumMolecules / _ensemble->V();
@@ -1460,6 +1471,6 @@ void Simulation::refreshParticleIDs()
 
 	for (auto pit = _moleculeContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); pit.isValid(); ++pit)
 	{
-		pit->setid(++start_ID);
+		pit->setid(start_ID++);
 	}
 }

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -454,13 +454,20 @@ public:
 
 	CellProcessor *getCellProcessor() const;
 
-	/** @brief Refresh particle IDs to continuous numbering*/
+	/** @brief Refresh particle IDs to continuous numbering starting at zero*/
 	void refreshParticleIDs();
 
 	/** @brief Checks if Simsteps or MaxWallTime are reached */
 	bool keepRunning();
 
 private:
+
+	/**
+	 * Parse everything in the XML path </mardyn/simulation/options/option>
+	 * and store it in _miscOptions.
+	 * @param xmlconfig
+	 */
+	void parseMiscOptions(XMLfileUnits& xmlconfig);
 
 	/// the timer used for the load calculation.
 	Timer* _timerForLoad{nullptr};
@@ -515,15 +522,16 @@ private:
 	unsigned long _nWriteFreqGlobalEnergy;
 	std::string _globalEnergyLogFilename;
 
-	/** Prepare start options, affecting behavior of method prepare_start()
-	 * Options
-	 * -------
-	 * refreshIDs: Refresh particle IDs to continuous numbering by method refreshParticleIDs()
+	/**
+	 * Mechanism to easily add arbitrary options via the XML path <mardyn/simulation/options/option>
+	 * Any option is identified via the label "name"
 	 *
+	 * @note Currently, only bool options are supported.
+	 *
+	 * Example:
+	 *   <option name="refreshIDs">true</option>
 	 */
-	struct PrepareStartOptions {
-		bool refreshIDs;
-	} _prepare_start_opt;
+	std::map<std::string, bool> _miscOptions;
 
 	FixedSizeQueue<double> _lastTraversalTimeHistory;
 };


### PR DESCRIPTION
requesting review by Fabio Gratl 

# Description
1) assigning particleIDs starting from 0 instead of 1 in refreshParticleIDs 
2) parsing the XML-information on refreshParticleIDs earlier in the simulation 
3) calling refreshParticleIDs earlier in the simulation

## Resolved Issues
-- the function refreshParticleIDs would assing IDs from 1 to N (=global number of particles), sometimes causing segmentation faults when using the ID as index 
