### PR TITLE
Fix mixing rules in input files for the DropletCoalescence example

### DIFF
--- a/examples/DropletCoalescence/liq/config_1_generateLiq.xml
+++ b/examples/DropletCoalescence/liq/config_1_generateLiq.xml
@@ -30,7 +30,7 @@
 
 			<components>
 				<include query="/components/moleculetype" >../components.xml</include>
-				<include query="/mixing/rule">../mixing_2c.xml</include>
+				<include query="/mixing">../mixing_2c.xml</include>
 			</components>
 
 			<phasespacepoint>

--- a/examples/DropletCoalescence/liq/config_2_replicateLiq.xml
+++ b/examples/DropletCoalescence/liq/config_2_replicateLiq.xml
@@ -30,7 +30,7 @@
 
 			<components>
 				<include query="/components/moleculetype" >../components.xml</include>
-				<include query="/mixing/rule">../mixing_2c.xml</include>
+				<include query="/mixing">../mixing_2c.xml</include>
 			</components>
 
 			<phasespacepoint>

--- a/examples/DropletCoalescence/vap/config_3_generateVap.xml
+++ b/examples/DropletCoalescence/vap/config_3_generateVap.xml
@@ -30,7 +30,7 @@
 
 			<components>
 				<include query="/components/moleculetype" >../components.xml</include>
-				<include query="/mixing/rule">../mixing_2c.xml</include>
+				<include query="/mixing">../mixing_2c.xml</include>
 			</components>
 
 			<phasespacepoint>

--- a/examples/DropletCoalescence/vap/config_4_replicateVap.xml
+++ b/examples/DropletCoalescence/vap/config_4_replicateVap.xml
@@ -30,7 +30,7 @@
 
 			<components>
 				<include query="/components/moleculetype" >../components.xml</include>
-				<include query="/mixing/rule">../mixing_2c.xml</include>
+				<include query="/mixing">../mixing_2c.xml</include>
 			</components>
 
 			<phasespacepoint>

--- a/examples/DropletCoalescence/vle/config_5_droplet.xml
+++ b/examples/DropletCoalescence/vle/config_5_droplet.xml
@@ -30,7 +30,7 @@
 
 			<components>
 				<include query="/components/moleculetype" >../components.xml</include>
-				<include query="/mixing/rule">../mixing_2c.xml</include>
+				<include query="/mixing">../mixing_2c.xml</include>
 			</components>
 
 			<phasespacepoint>


### PR DESCRIPTION
# Description

Fix mixing rules for the DropletCoalescence example.

The XML path for the mixing rules was incorrect in the configuration files of this example and therefore the mixing rules were not applied correctly.

## Related Pull Requests

- Part picked up as cleanup #255 

## Resolved Issues

(None)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Running DropletCoalescing example and verifying that the initial output shows the correct Mixing rules:
> ...
> Found 1 mixing rules.
> ...
> Mixing rule type: LB
> ...
> Mixing coefficients: (eta, xi) = (1, 1)
