### PR TITLE
Unused interface cleanup for component and molecule class

### DIFF
--- a/src/molecules/AutoPasSimpleMolecule.h
+++ b/src/molecules/AutoPasSimpleMolecule.h
@@ -165,8 +165,6 @@ public:
 
 	unsigned int numSites() const override { return 1; };
 
-	unsigned int numOrientedSites() const override { return 0; }
-
 	unsigned int numLJcenters() const override { return 1; }
 
 	unsigned int numCharges() const override { return 0; }

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -236,15 +236,6 @@ void Component::write(std::ostream& ostrm) const {
 	ostrm << _Ipa[0] << " " << _Ipa[1] << " " << _Ipa[2] << std::endl;
 }
 
-void Component::writeVIM(std::ostream& ostrm) {
-	for (auto pos = _ljcenters.cbegin(); pos != _ljcenters.end(); ++pos) {
-		ostrm << "~ " << this->_id + 1 << " LJ " << std::setw(7) << pos->rx() << ' '
-		      << std::setw(7) << pos->ry() << ' ' << std::setw(7) << pos->rz() << ' '
-		      << std::setw(6) << pos->sigma() << ' ' << std::setw(2) << (1 + (this->_id % 9)) << "\n";
-	}
-	ostrm << std::flush;
-}
-
 std::ostream& operator<<(std::ostream& stream, const Component& component) {
 	component.write(stream);
 	return stream;

--- a/src/molecules/Component.h
+++ b/src/molecules/Component.h
@@ -38,8 +38,7 @@ public:
 		                            + this->numDipoles()
 		                            + this->numQuadrupoles();
 	}
-	/** get number of oriented interaction sites (dipoles and quadrupoles) */
-	unsigned int numOrientedSites() const { return numDipoles() + numQuadrupoles(); }
+
 	/** get number of Lennard Jones interaction sites */
 	unsigned int numLJcenters() const { return _ljcenters.size(); }
 	/** get number of charge interaction sites */

--- a/src/molecules/Component.h
+++ b/src/molecules/Component.h
@@ -110,8 +110,6 @@ public:
 	/** write information to stream */
 	void write(std::ostream& ostrm) const;
 
-	void writeVIM(std::ostream& ostrm);
-
 	void setE_trans(double E) { _E_trans = E; }
 	void setE_rot(double E) { _E_rot = E; }
 	void setT(double T) { _T = T; }

--- a/src/molecules/FullMolecule.h
+++ b/src/molecules/FullMolecule.h
@@ -134,7 +134,6 @@ public:
 	 */
 	/** get number of sites */
 	unsigned int numSites() const override { return _component->numSites(); }
-	unsigned int numOrientedSites() const override { return _component->numOrientedSites();  }
 	unsigned int numLJcenters() const override { return _component->numLJcenters(); }
 	unsigned int numCharges() const override { return _component->numCharges(); }
 	unsigned int numDipoles() const override { return _component->numDipoles(); }

--- a/src/molecules/MoleculeInterface.h
+++ b/src/molecules/MoleculeInterface.h
@@ -114,7 +114,6 @@ public:
 	virtual void setStartIndexSoA_Q(unsigned i) = 0;
 
 	virtual unsigned int numSites() const = 0;
-	virtual unsigned int numOrientedSites() const = 0;
 	virtual unsigned int numLJcenters() const = 0;
 	virtual unsigned int numCharges() const = 0;
 	virtual unsigned int numDipoles() const = 0;

--- a/src/molecules/MoleculeRMM.h
+++ b/src/molecules/MoleculeRMM.h
@@ -161,9 +161,6 @@ public:
 	unsigned int numSites() const override {
 		return 1;
 	}
-	unsigned int numOrientedSites() const override {
-		return 0;
-	}
 	unsigned int numLJcenters() const override {
 		return 1;
 	}


### PR DESCRIPTION
# Description

Some first cleanup for #282

- Remove numOrientedSites() interface of molecules as it is nowhere used
- Remove writeVIM() method of component class as it is nowhere used