### PR TITLE
Fix xmlreader allowed bool values

### DIFF
--- a/examples/Adsorption/Generator/adsorption.xml
+++ b/examples/Adsorption/Generator/adsorption.xml
@@ -150,11 +150,11 @@
       </timesteps>
       <outputprefix>adsorption_2D_comp1</outputprefix>
       <profiles>
-        <density>1</density>
-        <temperature>1</temperature>
-        <velocity>1</velocity>
-        <velocity3d>1</velocity3d>
-        <virial>1</virial>
+        <density>true</density>
+        <temperature>true</temperature>
+        <velocity>true</velocity>
+        <velocity3d>true</velocity3d>
+        <virial>true</virial>
       </profiles>
     </plugin>
     <plugin name="SpatialProfile">
@@ -170,11 +170,11 @@
       </timesteps>
       <outputprefix>adsorption_1D_comp1</outputprefix>
       <profiles>
-        <density>1</density>
-        <temperature>1</temperature>
-        <velocity>1</velocity>
-        <velocity3d>1</velocity3d>
-        <virial>1</virial>
+        <density>true</density>
+        <temperature>true</temperature>
+        <velocity>true</velocity>
+        <velocity3d>true</velocity3d>
+        <virial>true</virial>
       </profiles>
     </plugin>
     <plugin name="Mirror" type="2">

--- a/examples/Adsorption/Generator/adsorption_autopas_default.xml
+++ b/examples/Adsorption/Generator/adsorption_autopas_default.xml
@@ -149,11 +149,11 @@
       </timesteps>
       <outputprefix>adsorption_2D_comp1</outputprefix>
       <profiles>
-        <density>1</density>
-        <temperature>1</temperature>
-        <velocity>1</velocity>
-        <velocity3d>1</velocity3d>
-        <virial>1</virial>
+        <density>true</density>
+        <temperature>true</temperature>
+        <velocity>true</velocity>
+        <velocity3d>true</velocity3d>
+        <virial>true</virial>
       </profiles>
     </plugin>
     <plugin name="SpatialProfile">
@@ -169,11 +169,11 @@
       </timesteps>
       <outputprefix>adsorption_1D_comp1</outputprefix>
       <profiles>
-        <density>1</density>
-        <temperature>1</temperature>
-        <velocity>1</velocity>
-        <velocity3d>1</velocity3d>
-        <virial>1</virial>
+        <density>true</density>
+        <temperature>true</temperature>
+        <velocity>true</velocity>
+        <velocity3d>true</velocity3d>
+        <virial>true</virial>
       </profiles>
     </plugin>
     <plugin name="Mirror" type="2">

--- a/examples/Adsorption/Generator/adsorption_autopas_tuning.xml
+++ b/examples/Adsorption/Generator/adsorption_autopas_tuning.xml
@@ -159,11 +159,11 @@
       </timesteps>
       <outputprefix>adsorption_2D_comp1</outputprefix>
       <profiles>
-        <density>1</density>
-        <temperature>1</temperature>
-        <velocity>1</velocity>
-        <velocity3d>1</velocity3d>
-        <virial>1</virial>
+        <density>true</density>
+        <temperature>true</temperature>
+        <velocity>true</velocity>
+        <velocity3d>true</velocity3d>
+        <virial>true</virial>
       </profiles>
     </plugin>
     <plugin name="SpatialProfile">
@@ -179,11 +179,11 @@
       </timesteps>
       <outputprefix>adsorption_1D_comp1</outputprefix>
       <profiles>
-        <density>1</density>
-        <temperature>1</temperature>
-        <velocity>1</velocity>
-        <velocity3d>1</velocity3d>
-        <virial>1</virial>
+        <density>true</density>
+        <temperature>true</temperature>
+        <velocity>true</velocity>
+        <velocity3d>true</velocity3d>
+        <virial>true</virial>
       </profiles>
     </plugin>
     <plugin name="Mirror" type="2">

--- a/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
@@ -56,7 +56,7 @@
                 <writefrequency>5</writefrequency>
                 <outputprefix>decomp</outputprefix>
                 <incremental>1</incremental>
-                <appendTimestamp>0</appendTimestamp>
+                <appendTimestamp>false</appendTimestamp>
             </outputplugin>
             <!--<outputplugin name="MmpldWriter" type="simple">
               <include query="/spheres">../sphereparams_argon.xml</include>

--- a/examples/Argon/200K_18mol_l/config_noAP_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_noAP_ALL.xml
@@ -52,7 +52,7 @@
 				<writefrequency>5</writefrequency>
 				<outputprefix>decomp</outputprefix>
 				<incremental>1</incremental>
-				<appendTimestamp>0</appendTimestamp>
+				<appendTimestamp>false</appendTimestamp>
 			</outputplugin>
 		</output>
 	</simulation>

--- a/examples/DropletCoalescence/components.xml
+++ b/examples/DropletCoalescence/components.xml
@@ -8,7 +8,7 @@
       <mass>39.948</mass>
       <sigma>3.3916</sigma>
       <epsilon>137.90</epsilon>
-      <shifted>1</shifted>
+      <shifted>true</shifted>
     </site>
     <momentsofinertia rotaxes="xyz" >
       <Ixx>0.0</Ixx>
@@ -23,7 +23,7 @@
       <mass>39.948</mass>
       <sigma>3.3916</sigma>
       <epsilon>137.90</epsilon>
-      <shifted>1</shifted>
+      <shifted>true</shifted>
     </site>
     <momentsofinertia rotaxes="xyz" >
       <Ixx>0.0</Ixx>

--- a/examples/DropletCoalescence/liq/config_1_generateLiq.xml
+++ b/examples/DropletCoalescence/liq/config_1_generateLiq.xml
@@ -69,10 +69,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/DropletCoalescence/liq/config_2_replicateLiq.xml
+++ b/examples/DropletCoalescence/liq/config_2_replicateLiq.xml
@@ -68,10 +68,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/DropletCoalescence/vap/config_3_generateVap.xml
+++ b/examples/DropletCoalescence/vap/config_3_generateVap.xml
@@ -69,10 +69,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/DropletCoalescence/vap/config_4_replicateVap.xml
+++ b/examples/DropletCoalescence/vap/config_4_replicateVap.xml
@@ -68,10 +68,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/DropletCoalescence/vle/config_5_droplet.xml
+++ b/examples/DropletCoalescence/vle/config_5_droplet.xml
@@ -121,10 +121,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>1</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>true</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation> -->
 			<datastructure type="LinkedCells">
 				<cellsInCutoffRadius>1</cellsInCutoffRadius>

--- a/examples/Evaporation/stationary/sim01/run01/config.xml
+++ b/examples/Evaporation/stationary/sim01/run01/config.xml
@@ -72,10 +72,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Evaporation/stationary/sim01/run02/config.xml
+++ b/examples/Evaporation/stationary/sim01/run02/config.xml
@@ -74,10 +74,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Evaporation/stationary/sim02/run01/config.xml
+++ b/examples/Evaporation/stationary/sim02/run01/config.xml
@@ -76,10 +76,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Evaporation/stationary/sim02/run02/config.xml
+++ b/examples/Evaporation/stationary/sim02/run02/config.xml
@@ -54,10 +54,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Evaporation/stationary/sim02/run03/config.xml
+++ b/examples/Evaporation/stationary/sim02/run03/config.xml
@@ -65,10 +65,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Evaporation/stationary/sim03/run01/config.xml
+++ b/examples/Evaporation/stationary/sim03/run01/config.xml
@@ -76,10 +76,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Evaporation/stationary/sim03/run02/config.xml
+++ b/examples/Evaporation/stationary/sim03/run02/config.xml
@@ -54,10 +54,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Evaporation/stationary/sim03/run03/config.xml
+++ b/examples/Evaporation/stationary/sim03/run03/config.xml
@@ -65,10 +65,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/liq1/run01/config.xml
+++ b/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/liq1/run01/config.xml
@@ -81,7 +81,7 @@
 				<updateFrequency>10000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
 				<heterogeneousSystems>1</heterogeneousSystems>
-				<splitBiggestDimension>0</splitBiggestDimension>
+				<splitBiggestDimension>false</splitBiggestDimension>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/liq2/run01/config.xml
+++ b/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/liq2/run01/config.xml
@@ -81,7 +81,7 @@
 				<updateFrequency>10000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
 				<heterogeneousSystems>1</heterogeneousSystems>
-				<splitBiggestDimension>0</splitBiggestDimension>
+				<splitBiggestDimension>false</splitBiggestDimension>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Generators/mkesfera/config.xml
+++ b/examples/Generators/mkesfera/config.xml
@@ -107,7 +107,7 @@
 			<outputplugin name="MPICheckpointWriter">
 				<writefrequency>10</writefrequency>
 				<outputprefix>mkesfera</outputprefix>
-				<appendTimestamp>1</appendTimestamp>
+				<appendTimestamp>true</appendTimestamp>
 				<datarep>native</datarep>
 				<measureTime>1</measureTime>
 				<mpi_info>

--- a/examples/Generators/mkesfera/config.xml
+++ b/examples/Generators/mkesfera/config.xml
@@ -127,9 +127,9 @@
 		</output>
 		<!-- ALPHA: Center of Mass alignment plugin  --> 
 		<plugin name="COMaligner">
-			<x>1</x>
-			<y>0</y>
-			<z>1</z>
+			<x>true</x>
+			<y>false</y>
+			<z>true</z>
 			<interval>1</interval>
 			<correctionFactor>.5</correctionFactor>
 		</plugin>

--- a/examples/Injection/liq/sim01/run01/config.xml
+++ b/examples/Injection/liq/sim01/run01/config.xml
@@ -75,10 +75,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/liq/sim01/run02/config.xml
+++ b/examples/Injection/liq/sim01/run02/config.xml
@@ -53,10 +53,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/liq/sim01/run03/config.xml
+++ b/examples/Injection/liq/sim01/run03/config.xml
@@ -67,10 +67,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/liq/sim01/run04/config.xml
+++ b/examples/Injection/liq/sim01/run04/config.xml
@@ -75,10 +75,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/liq/sim02/run01/config.xml
+++ b/examples/Injection/liq/sim02/run01/config.xml
@@ -75,10 +75,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/liq/sim02/run02/config.xml
+++ b/examples/Injection/liq/sim02/run02/config.xml
@@ -53,10 +53,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/liq/sim02/run03/config.xml
+++ b/examples/Injection/liq/sim02/run03/config.xml
@@ -67,10 +67,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/liq/sim02/run04/config.xml
+++ b/examples/Injection/liq/sim02/run04/config.xml
@@ -75,10 +75,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/nemd/sim01/run01/config.xml
+++ b/examples/Injection/nemd/sim01/run01/config.xml
@@ -98,10 +98,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/nemd/sim01/run02/config.xml
+++ b/examples/Injection/nemd/sim01/run02/config.xml
@@ -57,10 +57,10 @@
 				<CommunicationScheme>indirect</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/nemd/sim02/run01/config.xml
+++ b/examples/Injection/nemd/sim02/run01/config.xml
@@ -98,10 +98,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/Injection/nemd/sim02/run02/config.xml
+++ b/examples/Injection/nemd/sim02/run02/config.xml
@@ -56,10 +56,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/KDD-vectorization-tuner/one-component/config.xml
+++ b/examples/KDD-vectorization-tuner/one-component/config.xml
@@ -79,18 +79,18 @@
         <updateFrequency>1000</updateFrequency>
         <rebalanceLimit>0.</rebalanceLimit>
         <fullSearchThreshold>4</fullSearchThreshold>
-        <heterogeneousSystems>0</heterogeneousSystems>
-        <useVectorizationTuner>1</useVectorizationTuner>
-        <generateNewFiles>1</generateNewFiles>
-        <useExistingFiles>0</useExistingFiles>
-        <vecTunerAllowMPIReduce>1</vecTunerAllowMPIReduce>
-        <clusterHetSys>0</clusterHetSys>
-        <splitBiggestDimension>1</splitBiggestDimension>
+        <heterogeneousSystems>false</heterogeneousSystems>
+        <useVectorizationTuner>true</useVectorizationTuner>
+        <generateNewFiles>true</generateNewFiles>
+        <useExistingFiles>false</useExistingFiles>
+        <vecTunerAllowMPIReduce>true</vecTunerAllowMPIReduce>
+        <clusterHetSys>false</clusterHetSys>
+        <splitBiggestDimension>true</splitBiggestDimension>
         <!--<splitThreshold>INTEGER</splitThreshold>-->
-        <forceRatio>0</forceRatio>
-        <doMeasureLoadCalc>0</doMeasureLoadCalc>
+        <forceRatio>false</forceRatio>
+        <doMeasureLoadCalc>false</doMeasureLoadCalc>
         <measureLoadInterpolationStartsAt>1</measureLoadInterpolationStartsAt>
-        <measureLoadIncreasingTimeValues>1</measureLoadIncreasingTimeValues>
+        <measureLoadIncreasingTimeValues>true</measureLoadIncreasingTimeValues>
         <deviationReductionOperation>max</deviationReductionOperation>
         <minNumCellsPerDimension>2</minNumCellsPerDimension>
         <timerForLoad>SIMULATION_FORCE_CALCULATION</timerForLoad>

--- a/examples/KDD-vectorization-tuner/two-components/config.xml
+++ b/examples/KDD-vectorization-tuner/two-components/config.xml
@@ -79,18 +79,18 @@
         <updateFrequency>1000</updateFrequency>
         <rebalanceLimit>0.</rebalanceLimit>
         <fullSearchThreshold>4</fullSearchThreshold>
-        <heterogeneousSystems>0</heterogeneousSystems>
-        <useVectorizationTuner>1</useVectorizationTuner>
-        <generateNewFiles>1</generateNewFiles>
-        <useExistingFiles>0</useExistingFiles>
-        <vecTunerAllowMPIReduce>1</vecTunerAllowMPIReduce>
-        <clusterHetSys>0</clusterHetSys>
-        <splitBiggestDimension>1</splitBiggestDimension>
+        <heterogeneousSystems>false</heterogeneousSystems>
+        <useVectorizationTuner>true</useVectorizationTuner>
+        <generateNewFiles>true</generateNewFiles>
+        <useExistingFiles>false</useExistingFiles>
+        <vecTunerAllowMPIReduce>true</vecTunerAllowMPIReduce>
+        <clusterHetSys>false</clusterHetSys>
+        <splitBiggestDimension>true</splitBiggestDimension>
         <!--<splitThreshold>INTEGER</splitThreshold>-->
-        <forceRatio>0</forceRatio>
-        <doMeasureLoadCalc>0</doMeasureLoadCalc>
+        <forceRatio>false</forceRatio>
+        <doMeasureLoadCalc>false</doMeasureLoadCalc>
         <measureLoadInterpolationStartsAt>1</measureLoadInterpolationStartsAt>
-        <measureLoadIncreasingTimeValues>1</measureLoadIncreasingTimeValues>
+        <measureLoadIncreasingTimeValues>true</measureLoadIncreasingTimeValues>
         <deviationReductionOperation>max</deviationReductionOperation>
         <minNumCellsPerDimension>2</minNumCellsPerDimension>
         <timerForLoad>SIMULATION_FORCE_CALCULATION</timerForLoad>

--- a/examples/adios/read/config.xml
+++ b/examples/adios/read/config.xml
@@ -59,7 +59,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>

--- a/examples/adios/read/config_parallel.xml
+++ b/examples/adios/read/config_parallel.xml
@@ -59,7 +59,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>

--- a/examples/adios/write/config.xml
+++ b/examples/adios/write/config.xml
@@ -57,7 +57,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -397,7 +397,7 @@
       <outputplugin name="MPICheckpointWriter">
         <writefrequency>10</writefrequency>
         <outputprefix>default</outputprefix>
-        <appendTimestamp>1</appendTimestamp>
+        <appendTimestamp>true</appendTimestamp>
         <datarep>native</datarep>
         <measureTime>1</measureTime>
       </outputplugin>

--- a/examples/example-list.txt
+++ b/examples/example-list.txt
@@ -6,6 +6,8 @@
 ./EOX/600K_15mol_l/config.xml
 ./Generators/mkTcTS/config.xml
 ./Generators/mkesfera/config.xml
+./DropletCoalescence/liq/config_1_generateLiq.xml
+./DropletCoalescence/vap/config_3_generateVap.xml
 ./surface-tension_LRC/CO2_Merker/vle/220K/run01/config.xml
 ./surface-tension_LRC/CO2_Merker/vle/250K/run01/config.xml
 ./surface-tension_LRC/CO2_Merker/vle/280K/run01/config.xml

--- a/examples/general-plugins/CavityWriter/CavityWriterTest.xml
+++ b/examples/general-plugins/CavityWriter/CavityWriterTest.xml
@@ -165,10 +165,10 @@ It detects the less dense space around the dense drop as a cavity.
 	      </timesteps>
 	      <outputprefix>cavity.cyl.</outputprefix>
 	      <profiles>
-	        <density>1</density>
-	        <temperature>0</temperature>
-	        <velocity>0</velocity>
-	        <velocity3d>0</velocity3d>
+	        <density>true</density>
+	        <temperature>false</temperature>
+	        <velocity>false</velocity>
+	        <velocity3d>false</velocity3d>
 	      </profiles>
 	    </plugin>
 

--- a/examples/general-plugins/RegionSampling/case01/run01/config.xml
+++ b/examples/general-plugins/RegionSampling/case01/run01/config.xml
@@ -77,8 +77,8 @@
 			<parallelisation type="KDDecomposition">
 				<updateFrequency>10000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<heterogeneousSystems>1</heterogeneousSystems>
-				<splitBiggestDimension>0</splitBiggestDimension>
+				<heterogeneousSystems>true</heterogeneousSystems>
+				<splitBiggestDimension>false</splitBiggestDimension>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/general-plugins/SpatialProfiles/CartesianSampling/CartesianSampling.xml
+++ b/examples/general-plugins/SpatialProfiles/CartesianSampling/CartesianSampling.xml
@@ -138,11 +138,11 @@
       <outputprefix>cartesian</outputprefix>
       <profiledComponent>all</profiledComponent>
       <profiles>
-        <density>1</density>
-        <temperature>1</temperature>
-        <velocity>1</velocity>
-        <velocity3d>1</velocity3d>
-        <virial>1</virial>
+        <density>true</density>
+        <temperature>true</temperature>
+        <velocity>true</velocity>
+        <velocity3d>true</velocity3d>
+        <virial>true</virial>
       </profiles>
     </plugin>
 
@@ -159,11 +159,11 @@
           <outputprefix>cylinder</outputprefix>
           <profiledComponent>all</profiledComponent>
           <profiles>
-              <density>1</density>
-              <temperature>1</temperature>
-              <velocity>1</velocity>
-              <velocity3d>1</velocity3d>
-              <virial>1</virial>
+              <density>true</density>
+              <temperature>true</temperature>
+              <velocity>true</velocity>
+              <velocity3d>true</velocity3d>
+              <virial>true</virial>
           </profiles>
       </plugin>
    </simulation>

--- a/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
+++ b/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
@@ -180,11 +180,11 @@
           <profiledComponent>all</profiledComponent>
 
             <profiles>
-	        <density>1</density>
-	        <temperature>0</temperature>
-	        <velocity>0</velocity>
-	        <velocity3d>0</velocity3d>
-	        <virial>0</virial>
+	        <density>true</density>
+	        <temperature>false</temperature>
+	        <velocity>false</velocity>
+	        <velocity3d>false</velocity3d>
+	        <virial>false</virial>
 	      </profiles>
 	    </plugin>
 

--- a/examples/surface-tension_LRC/2CLJ/liq/T0-979/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T0-979/run01/config.xml
@@ -74,10 +74,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/liq/T0-979/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T0-979/run02/config.xml
@@ -52,10 +52,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/liq/T0-979/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T0-979/run03/config.xml
@@ -62,10 +62,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-508/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-508/run01/config.xml
@@ -74,10 +74,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-508/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-508/run02/config.xml
@@ -52,10 +52,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-508/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-508/run03/config.xml
@@ -62,10 +62,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-691/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-691/run01/config.xml
@@ -74,10 +74,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-691/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-691/run02/config.xml
@@ -52,10 +52,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-691/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-691/run03/config.xml
@@ -62,10 +62,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/vle/T0-979/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T0-979/run01/config.xml
@@ -86,10 +86,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/vle/T0-979/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T0-979/run02/config.xml
@@ -50,10 +50,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-508/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-508/run01/config.xml
@@ -86,10 +86,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-508/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-508/run02/config.xml
@@ -50,10 +50,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-508/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-508/run03/config.xml
@@ -60,10 +60,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-691/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-691/run01/config.xml
@@ -86,10 +86,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-691/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-691/run02/config.xml
@@ -50,10 +50,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-691/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-691/run03/config.xml
@@ -60,10 +60,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/liq/330K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/330K/run01/config.xml
@@ -74,10 +74,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/liq/330K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/330K/run02/config.xml
@@ -52,10 +52,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/liq/330K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/330K/run03/config.xml
@@ -62,10 +62,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/liq/415K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/415K/run01/config.xml
@@ -74,10 +74,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/liq/415K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/415K/run02/config.xml
@@ -52,10 +52,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/liq/415K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/415K/run03/config.xml
@@ -62,10 +62,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/liq/500K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/500K/run01/config.xml
@@ -74,10 +74,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/liq/500K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/500K/run02/config.xml
@@ -52,10 +52,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/liq/500K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/500K/run03/config.xml
@@ -62,10 +62,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/vle/330K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/330K/run01/config.xml
@@ -86,10 +86,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/vle/330K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/330K/run01/config.xml
@@ -105,7 +105,7 @@
 			
 			<longrange type="planar">
 				<slabs>200</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -201,7 +201,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -236,9 +236,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/C6H12/vle/330K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/330K/run02/config.xml
@@ -50,10 +50,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/vle/330K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/330K/run03/config.xml
@@ -60,10 +60,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/vle/415K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/415K/run01/config.xml
@@ -86,10 +86,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/vle/415K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/415K/run01/config.xml
@@ -105,7 +105,7 @@
 			
 			<longrange type="planar">
 				<slabs>200</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -201,7 +201,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -236,9 +236,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/C6H12/vle/415K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/415K/run02/config.xml
@@ -50,10 +50,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/vle/415K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/415K/run03/config.xml
@@ -60,10 +60,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/vle/500K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/500K/run01/config.xml
@@ -86,10 +86,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/vle/500K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/500K/run01/config.xml
@@ -105,7 +105,7 @@
 			
 			<longrange type="planar">
 				<slabs>200</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -201,7 +201,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -236,9 +236,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/C6H12/vle/500K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/500K/run02/config.xml
@@ -50,10 +50,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/C6H12/vle/500K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/500K/run03/config.xml
@@ -60,10 +60,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/liq/220K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/220K/run01/config.xml
@@ -74,10 +74,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/liq/220K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/220K/run02/config.xml
@@ -52,10 +52,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/liq/220K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/220K/run03/config.xml
@@ -62,10 +62,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/liq/250K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/250K/run01/config.xml
@@ -74,10 +74,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/liq/250K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/250K/run02/config.xml
@@ -52,10 +52,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/liq/250K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/250K/run03/config.xml
@@ -62,10 +62,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/liq/280K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/280K/run01/config.xml
@@ -74,10 +74,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/liq/280K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/280K/run02/config.xml
@@ -52,10 +52,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/liq/280K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/280K/run03/config.xml
@@ -62,10 +62,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/vle/220K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/220K/run01/config.xml
@@ -86,10 +86,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/vle/220K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/220K/run01/config.xml
@@ -105,7 +105,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -201,7 +201,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -236,9 +236,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/CO2_Merker/vle/220K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/220K/run02/config.xml
@@ -50,10 +50,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/vle/220K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/220K/run03/config.xml
@@ -60,10 +60,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/vle/250K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/250K/run01/config.xml
@@ -86,10 +86,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/vle/250K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/250K/run01/config.xml
@@ -105,7 +105,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -201,7 +201,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -236,9 +236,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/CO2_Merker/vle/250K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/250K/run02/config.xml
@@ -50,10 +50,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/vle/250K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/250K/run03/config.xml
@@ -60,10 +60,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/vle/280K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/280K/run01/config.xml
@@ -86,10 +86,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/vle/280K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/280K/run01/config.xml
@@ -105,7 +105,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -201,7 +201,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -236,9 +236,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/CO2_Merker/vle/280K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/280K/run02/config.xml
@@ -50,10 +50,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/examples/surface-tension_LRC/CO2_Merker/vle/280K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/280K/run03/config.xml
@@ -60,10 +60,10 @@
 				<CommunicationScheme>direct</CommunicationScheme>
 				<updateFrequency>100000</updateFrequency>
 				<fullSearchThreshold>3</fullSearchThreshold>
-				<splitBiggestDimension>0</splitBiggestDimension>
-				<useVectorizationTuner>0</useVectorizationTuner>
-				<generateNewFiles>0</generateNewFiles>
-				<useExistingFiles>0</useExistingFiles>
+				<splitBiggestDimension>false</splitBiggestDimension>
+				<useVectorizationTuner>false</useVectorizationTuner>
+				<generateNewFiles>false</generateNewFiles>
+				<useExistingFiles>false</useExistingFiles>
 			</parallelisation>
 -->
 			<datastructure type="LinkedCells">

--- a/src/io/CheckpointWriter.h
+++ b/src/io/CheckpointWriter.h
@@ -22,7 +22,7 @@ public:
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
 	     <incremental>INTEGER</incremental>
-	     <appendTimestamp>INTEGER</appendTimestamp>
+	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode
 	 */

--- a/src/io/CommunicationPartnerWriter.h
+++ b/src/io/CommunicationPartnerWriter.h
@@ -23,7 +23,7 @@ public:
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
 	     <incremental>INTEGER</incremental>
-	     <appendTimestamp>INTEGER</appendTimestamp>
+	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode
 	 */

--- a/src/io/DecompWriter.h
+++ b/src/io/DecompWriter.h
@@ -25,7 +25,7 @@ public:
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
 	     <incremental>INTEGER</incremental>
-	     <appendTimestamp>INTEGER</appendTimestamp>
+	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode
 	 */

--- a/src/io/HaloParticleWriter.h
+++ b/src/io/HaloParticleWriter.h
@@ -25,7 +25,7 @@ public:
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
 	     <incremental>INTEGER</incremental>
-	     <appendTimestamp>INTEGER</appendTimestamp>
+	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode
 	 */

--- a/src/io/KDTreePrinter.h
+++ b/src/io/KDTreePrinter.h
@@ -13,7 +13,7 @@ public:
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
 	     <incremental>INTEGER</incremental>
-	     <appendTimestamp>INTEGER</appendTimestamp>
+	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode
 	 */

--- a/src/io/XyzWriter.h
+++ b/src/io/XyzWriter.h
@@ -24,7 +24,7 @@ public:
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
 	     <incremental>INTEGER</incremental>
-	     <appendTimestamp>INTEGER</appendTimestamp>
+	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode
 	 */

--- a/src/longRange/Planar.h
+++ b/src/longRange/Planar.h
@@ -1,8 +1,3 @@
-
-//Calculation of the surface tension in a system with planar interfaces needs a Long Range Correction.
-//
-//The correction terms are based on Janecek (2006) and Lustig (1988).
-
 #ifndef PLANAR_H_
 #define PLANAR_H_
 
@@ -21,33 +16,42 @@
 class Domain;
 class ParticleContainer;
 
+
+/** @brief This class calculates long range corrections
+ *
+ * Calculation of the surface tension in a system with planar interfaces needs a Long Range Correction.
+ * The correction terms computed by this class are based on Janecek (2006) and Lustig (1988).
+ */
 class Planar : public LongRangeCorrection, public ObserverBase, public ControlInstance {
 public:
 	Planar(double cutoffT,double cutoffLJ,Domain* domain,  DomainDecompBase* domainDecomposition, ParticleContainer* particleContainer, unsigned slabs, Simulation* simulation);
 	virtual ~Planar();
 
 	/** @brief Read in XML configuration for Planar and all its included objects.
+	 */
+
+	void init() override;
+
+	/** @brief Read in XML configuration for planar long range corrections.
 	 *
 	 * The following XML object structure is handled by this method:
 	 * \code{.xml}
 		<longrange type="planar">
 			<region> <!-- y coordinates of left and right boundaries within correction of force is applied to particles; pot. energy and virial correction is always applied since it is necessary for the correct calculation of the state values -->
-				<left refcoordsID="INT">FLOAT</left> <!-- Reference of coordinate can be set (see DistControl); 0: origin (default) | 1:left interface | 2:right interface -->
+				<left refcoordsID="INT">FLOAT</left>  <!-- Reference of coordinate can be set (see DistControl); 0: origin (default) | 1:left interface | 2:right interface -->
 				<right refcoordsID="INT">FLOAT</right>
 			</region>
 			<slabs>INT</slabs> <!-- Domain is divided into INT slabs -->
-			<smooth>0</smooth>
-			<frequency>10</frequency> <!-- Frequency at which LRC is recalculated -->
+			<smooth>BOOL</smooth> <!-- enable or disable smoothed corrections: false (default) | true -->
+			<frequency>INT</frequency> <!-- Frequency at which the LRC is recalculated in number of timesteps between -->
 			<writecontrol> <!-- Parameters to control output in file -->
-				<start>900000</start>
-				<frequency>100000</frequency>
-				<stop>5000000</stop>
+				<start>INT</start>
+				<frequency>INT</frequency>
+				<stop>INT</stop>
 			</writecontrol>
 		</longrange>
 	   \endcode
-	 */
-
-	void init() override;
+		*/
 	void readXML(XMLfileUnits& xmlconfig) override;
 	void calculateLongRange() override;
 	double lrcLJ(Molecule* mol);

--- a/src/plugins/COMaligner.h
+++ b/src/plugins/COMaligner.h
@@ -15,23 +15,13 @@ class COMalignerTest;
 #include "parallel/DomainDecompBase.h"
 
 /** @brief
-* Plugin: can be enabled via config.xml <br>
+* Plugin that moves all particles so the center of mass aligns with the center of the simulation box.
 *
-* Calculates Center of mass and moves all particles to align with center of box<br>
-* Individual dimensions X,Y,Z can be toogled on/off for the alignment<br>
-* Alignment happens once every interval-simsteps<br>
-* The correction factor can be set from 0-1<br>
-* 1 being full alignment -> 0 no alignment at all<br>
+* Individual dimensions X,Y,Z can be toggled on/off for the alignment.<br>
+* Alignment happens once every interval-simsteps.<br>
+* A correction factor can be set from 0-1 to control the alignment with 1 being full alignment and 0 no alignment at all.<br>
 * <b>HALO must not be present</b> for the alignment. Halo would lead to incorrect alignment.<br>
-* This is guarenteed by calling the alignment in the beforeForces step of the simulation
-* \code{.xml}
-* <plugin name="COMaligner">
-*			<x>1</x>
-*			<y>0</y>
-*			<z>1</z>
-*			<interval>1</interval>
-*			<correctionFactor>.5</correctionFactor>
-* </plugin>
+* This is guaranteed by calling the alignment in the beforeForces step of the simulation.
 * \endcode
 */
 class COMaligner : public PluginBase{
@@ -81,6 +71,19 @@ public:
 
     }
 
+	/** @brief Read in XML configuration for COMAligner
+	 *
+	 * The following XML object structure is handled by this method:
+	 * \code{.xml}
+        <plugin name="COMaligner">
+                <x>BOOL</x>  <!-- align along x-axis (default): true | do no align along x-axis: false -->
+                <y>BOOL</y>  <!-- align along y-axis (default): true | do no align along y-axis: false -->
+                <z>BOOL</z>  <!-- align along z-axis (default): true | do no align along z-axis: false -->
+                <interval>INT</interval>  <!-- frequency of algignment in number of time steps between alignments -->
+                <correctionFactor>FLOAT</correctionFactor>  <!-- correction factor [0-1] to apply with 1 meaning full alignment and 0 no alignment at all -->
+        </plugin>
+	   \endcode
+	 */
     void readXML (XMLfileUnits& xmlconfig) override;
 
     void beforeForces(ParticleContainer* particleContainer, DomainDecompBase* domainDecomp, unsigned long simstep) override;

--- a/src/plugins/MaxCheck.h
+++ b/src/plugins/MaxCheck.h
@@ -68,7 +68,7 @@ public:
 				<stop>INT</stop>             <!-- stop time step -->
 			</control>
 			<range>
-				<inclusive>BOOL<inclusive>  <!-- enable checking inside range (default): 1 | outside range: 0 -->
+				<inclusive>BOOL<inclusive>  <!-- enable checking inside range (default): true | outside range: false -->
 				<xmin>FLOAT</xmin> <xmax>FLOAT</xmax>  <!-- range x-axis -->
 				<ymin>FLOAT</ymin> <ymax>FLOAT</ymax>  <!-- range y-axis -->
 				<zmin>FLOAT</zmin> <zmax>FLOAT</zmax>  <!-- range z-axis -->

--- a/src/plugins/NEMD/DensityControl.h
+++ b/src/plugins/NEMD/DensityControl.h
@@ -69,7 +69,7 @@ public:
 				<stop>INT</stop>              <!-- stop time step -->
 			</control>
 			<range>
-				<inclusive>BOOL</inclusive>  <!-- enable checking inside range (default): 1 | outside range: 0 -->
+				<inclusive>BOOL</inclusive>  <!-- enable checking inside range (default): true | outside range: false -->
 				<xmin>FLOAT</xmin> <xmax>FLOAT</xmax>  <!-- range x-axis -->
 				<ymin>FLOAT</ymin> <ymax>FLOAT</ymax>  <!-- range y-axis -->
 				<zmin>FLOAT</zmin> <zmax>FLOAT</zmax>  <!-- range z-axis -->

--- a/src/plugins/NEMD/VelocityExchange.h
+++ b/src/plugins/NEMD/VelocityExchange.h
@@ -36,7 +36,7 @@ class VelocityExchangeTest;
             <zmin>0</zmin> <zmax>box</zmax>      <!-- range z-axis; default: 0 to box size -->
         </coldregion>
         <warmregion>                             <!-- region with higher temperature -->
-            <symmetric>1</symmetric>             <!-- if set to 1 (default), a second warm region is inserted at the opposite side (in y-direction) of the
+            <symmetric>true</symmetric>          <!-- if set to true (default), a second warm region is inserted at the opposite side (in y-direction) of the
                                                       simulation box (from yBoxsize-ymax to yBoxsize-ymin) -->
             <xmin>0</xmin> <xmax>box</xmax>      <!-- range x-axis; default: 0 to box size -->
             <ymin>20</ymin> <ymax>30</ymax>      <!-- range y-axis -->

--- a/src/plugins/SpatialProfile.h
+++ b/src/plugins/SpatialProfile.h
@@ -61,11 +61,11 @@ class Virial2DProfile;
       </timesteps>
       <outputprefix>comparison</outputprefix>
       <profiles>
-        <density>1</density>
-        <temperature>0</temperature>
-        <velocity>1</velocity>
-        <velocity3d>1</velocity>
-        <virial>1</virial>
+        <density>true</density>
+        <temperature>false</temperature>
+        <velocity>true</velocity>
+        <velocity3d>true</velocity>
+        <virial>true</virial>
       </profiles>
     </plugin>
 * \endcode

--- a/src/utils/xmlfile.cpp
+++ b/src/utils/xmlfile.cpp
@@ -575,12 +575,13 @@ template<> bool XMLfile::Node::getValue<bool>(bool& value) const
 		// Convert to upper case letters
 		std::transform(v.begin(), v.end(), v.begin(), ::toupper);
 
-		if (v == "TRUE" || v == "YES" || v == "ON" || v == "1") {
+		if (v == "TRUE" || v == "YES" || v == "ON") {
 			value = true;
-		} else if (v == "FALSE" || v == "NO" || v == "OFF" || v == "0") {
+		} else if (v == "FALSE" || v == "NO" || v == "OFF") {
 			value = false;
 		} else {
-			std::cerr << "ERROR parsing \"" << v << "\" to boolean from tag \"<" << name() << ">\" in xml file" << std::endl;
+			std::cerr << "ERROR parsing \"" << v << "\" to boolean from tag \"<" << name() << ">\" in xml file."
+				<< "Valid values are: true, false, yes, no, on, off. " << std::endl;
 			Simulation::exit(1);
 		}
 	}

--- a/test_input/VelocityExchange.xml
+++ b/test_input/VelocityExchange.xml
@@ -10,7 +10,7 @@
 	<zmin>3.0</zmin> <zmax>111.1</zmax>      <!-- range z-axis; default: 0 to box size -->
 </coldregion>
 <warmregion>                                 <!-- region with higher temperature -->
-	<symmetric>0</symmetric>             <!-- 0: no symmetry; 1: symmetry in y direction (default) -->
+	<symmetric>false</symmetric>             <!-- false: no symmetry; true: symmetry in y direction (default) -->
 	<xmin>7.1</xmin> <xmax>131.3</xmax>      <!-- range x-axis; default: 0 to box size -->
 	<ymin>94.0</ymin> <ymax>120.4</ymax>      <!-- range y-axis -->
 	<zmin>4.0</zmin> <zmax>box</zmax>      <!-- range z-axis; default: 0 to box size -->


### PR DESCRIPTION
# Description
This is part of the work for #255 addressing the checks for the shifted parameter in the input files.
The way this is fixed here is by making the xmlreader generally more strict in parsing boolean input values.

- Fix xmlreader to only accept true/false, yes/no or on/off as boolean values now
- Fix examples to use false and true as boolean values in xml input files where they failed to
- Fix unit tests to use false and true as boolean values in xml input files where they failed to
- Added the new DropletCoalescence example to list of standard inputs to be tested

- [x] Tested running all examples in the "examples/example-list.txt" for 10 time steps
- [x] Tested running internal unit tests