### PR TITLE
Fix type of _adaptive and _periodic parameters in FMM to bool

### DIFF
--- a/examples/FMM/config.xml
+++ b/examples/FMM/config.xml
@@ -63,7 +63,7 @@
 	  <electrostatic type="FastMultipoleMethod">
 			<orderOfExpansions>10</orderOfExpansions>
 			<LJCellSubdivisionFactor>1</LJCellSubdivisionFactor>
-			<adaptiveContainer>0</adaptiveContainer>
+			<adaptiveContainer>false</adaptiveContainer>
 			<systemIsPeriodic>1</systemIsPeriodic>
 	  </electrostatic>
 

--- a/src/bhfmm/FastMultipoleMethod.cpp
+++ b/src/bhfmm/FastMultipoleMethod.cpp
@@ -36,7 +36,7 @@ void FastMultipoleMethod::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "FastMultipoleMethod: LJCellSubdivisionFactor: " << _LJCellSubdivisionFactor << std::endl;
 
 	xmlconfig.getNodeValue("adaptiveContainer", _adaptive);
-	if (_adaptive == 1) {
+	if (_adaptive) {
 		Log::global_log->warning() << "FastMultipoleMethod: adaptiveContainer is not debugged yet and certainly delivers WRONG results!" << std::endl;
 		Log::global_log->warning() << "Unless you are in the process of debugging this container, please stop the simulation and restart with the uniform one" << std::endl;
 	} else {

--- a/src/bhfmm/FastMultipoleMethod.cpp
+++ b/src/bhfmm/FastMultipoleMethod.cpp
@@ -44,10 +44,10 @@ void FastMultipoleMethod::readXML(XMLfileUnits& xmlconfig) {
 	}
 
 	xmlconfig.getNodeValue("systemIsPeriodic", _periodic);
-	if (_periodic == 0) {
-		Log::global_log->warning() << "FastMultipoleMethod: periodicity is turned off!" << std::endl;
-	} else {
+	if (_periodic) {
 		Log::global_log->info() << "FastMultipoleMethod: Periodicity is on." << std::endl;
+	} else {
+		Log::global_log->warning() << "FastMultipoleMethod: periodicity is turned off!" << std::endl;
 	}
 }
 

--- a/src/bhfmm/FastMultipoleMethod.h
+++ b/src/bhfmm/FastMultipoleMethod.h
@@ -94,7 +94,7 @@ private:
 	unsigned _LJCellSubdivisionFactor;
 	int _wellSeparated;
 	bool _adaptive;
-	int _periodic;
+	bool _periodic;
 
 	PseudoParticleContainer * _pseudoParticleContainer;
 

--- a/src/bhfmm/FastMultipoleMethod.h
+++ b/src/bhfmm/FastMultipoleMethod.h
@@ -93,7 +93,7 @@ private:
 	int _order;
 	unsigned _LJCellSubdivisionFactor;
 	int _wellSeparated;
-	int _adaptive;
+	bool _adaptive;
 	int _periodic;
 
 	PseudoParticleContainer * _pseudoParticleContainer;


### PR DESCRIPTION
The adaptive parameter was inconsistently used as integer and bool throughout the code.

This was discovered during work on #286 