### PR TITLE
Remove unused _wellSeparated member from the FastMultipoleMethod class

### DIFF
--- a/src/bhfmm/FastMultipoleMethod.h
+++ b/src/bhfmm/FastMultipoleMethod.h
@@ -46,7 +46,6 @@ class FastMultipoleMethod {
 public:
 	FastMultipoleMethod() : _order(-1),
                             _LJCellSubdivisionFactor(0),
-                            _wellSeparated(0),
                             _adaptive(false)
     {}
 	~FastMultipoleMethod();
@@ -92,7 +91,6 @@ public:
 private:
 	int _order;
 	unsigned _LJCellSubdivisionFactor;
-	int _wellSeparated;
 	bool _adaptive;
 	bool _periodic;
 


### PR DESCRIPTION
The `_wellSeparated` member in the `FastMultipoleMethod` class is nowhere else used in the code, therefore, remove it.

This is work performed in the context of the general code cleanup in #282 