### PR TITLE
Langevin thermostat

### DIFF
--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -15,6 +15,7 @@
 
 // plugins
 #include "plugins/PluginFactory.h"
+#include "thermostats/TemperatureObserver.h"
 
 #if !defined (SIMULATION_SRC) or defined (IN_IDE_PARSER)
 class Simulation;
@@ -226,6 +227,9 @@ public:
 	/** Get pointer to the molecule container */
 	ParticleContainer* getMoleculeContainer() { return _moleculeContainer; }
 
+    /** Get pointer to the temperature observer */
+    TemperatureObserver* getTemperatureObserver() { return _temperatureObserver; }
+
 	/** Set the number of time steps to be performed in the simulation */
 	void setNumTimesteps( unsigned long steps ) { _numberOfTimesteps = steps; }
 	/** Get the number of time steps to be performed in the simulation */
@@ -390,6 +394,9 @@ private:
 
 	/** Temperature Control (Slab Thermostat) */
 	TemperatureControl* _temperatureControl;
+
+    /** No Thermostat - only measures temp in selected regions */
+    TemperatureObserver* _temperatureObserver;
 
 	/** The Fast Multipole Method object */
 	bhfmm::FastMultipoleMethod* _FMM;

--- a/src/integrators/Langevin.cpp
+++ b/src/integrators/Langevin.cpp
@@ -1,0 +1,177 @@
+//
+// Created by alex on 05.03.24.
+//
+
+#include "Langevin.h"
+#include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
+#include "utils/xmlfileUnits.h"
+#include "particleContainer/ParticleContainer.h"
+#include "Simulation.h"
+#include "Domain.h"
+
+#include <random>
+
+void Langevin::readXML(XMLfileUnits &xmlconfig) {
+    _timestepLength = 0;
+    xmlconfig.getNodeValueReduced("timestep", _timestepLength);
+    Log::global_log->info() << "Timestep: " << _timestepLength << std::endl;
+    mardyn_assert(_timestepLength > 0);
+
+    _xi = 0;
+    xmlconfig.getNodeValue("friction", _xi);
+    mardyn_assert(_xi > 0);
+}
+
+void Langevin::init() {
+    std::vector<std::pair<std::array<double, 3>, std::array<double, 3>>> regions;
+    if(_simulation.getTemperatureObserver() == nullptr) return; // we will check again later
+
+    _simulation.getTemperatureObserver()->getRegions(regions);
+    for(auto& [low, high] : regions) {
+        _stochastic_regions.emplace_back(low, high);
+    }
+
+    _dt_half = _timestepLength / 2;
+}
+
+void Langevin::eventForcesCalculated(ParticleContainer *particleContainer, Domain *domain) {
+    for(std::size_t index = 0; index < _stochastic_regions.size(); index++) {
+        auto& region = _stochastic_regions[index];
+        double T = _simulation.getTemperatureObserver()->getTemperature(index);
+        T = _simulation.getEnsemble()->T();
+        #if defined(_OPENMP)
+        #pragma omp parallel
+        #endif
+        for(auto it = particleContainer->regionIterator(std::data(region.low),
+                                                        std::data(region.high),
+                                                        ParticleIterator::ONLY_INNER_AND_BOUNDARY); it.isValid(); ++it) {
+            d3 v_old = it->v_arr();
+            d3 v_rand = sampleRandomForce(it->mass(), T);
+            d3 v_delta {};
+
+            for(int d = 0; d < 3; d++) {
+                v_delta[d] = - _dt_half * _xi * v_old[d] + v_rand[d];
+            }
+
+            it->vadd(v_delta[0], v_delta[1], v_delta[2]);
+        }
+    }
+
+
+    std::map<int, unsigned long> N;
+    std::map<int, unsigned long> rotDOF;
+    std::map<int, double> summv2;
+    std::map<int, double> sumIw2;
+
+    if (domain->severalThermostats()) {
+        #if defined(_OPENMP)
+        #pragma omp parallel
+        #endif
+        {
+            std::map<int, unsigned long> N_l;
+            std::map<int, unsigned long> rotDOF_l;
+            std::map<int, double> summv2_l;
+            std::map<int, double> sumIw2_l;
+
+            for (auto tM = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tM.isValid(); ++tM) {
+                int cid = tM->componentid();
+                int thermostat = domain->getThermostat(cid);
+                tM->upd_postF(_dt_half, summv2_l[thermostat], sumIw2_l[thermostat]);
+                N_l[thermostat]++;
+                rotDOF_l[thermostat] += tM->component()->getRotationalDegreesOfFreedom();
+            }
+
+            #if defined(_OPENMP)
+            #pragma omp critical (thermostat)
+            #endif
+            {
+                for (auto & it : N_l) N[it.first] += it.second;
+                for (auto & it : rotDOF_l) rotDOF[it.first] += it.second;
+                for (auto & it : summv2_l) summv2[it.first] += it.second;
+                for (auto & it : sumIw2_l) sumIw2[it.first] += it.second;
+            }
+        }
+    }
+    else {
+        #if defined(_OPENMP)
+        #pragma omp parallel
+        #endif
+        {
+            unsigned long Ngt_l = 0;
+            unsigned long rotDOFgt_l = 0;
+            double summv2gt_l = 0.0;
+            double sumIw2gt_l = 0.0;
+
+            for (auto i = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); i.isValid(); ++i) {
+                i->upd_postF(_dt_half, summv2gt_l, sumIw2gt_l);
+                mardyn_assert(summv2gt_l >= 0.0);
+                Ngt_l++;
+                rotDOFgt_l += i->component()->getRotationalDegreesOfFreedom();
+            }
+
+            #if defined(_OPENMP)
+            #pragma omp critical (thermostat)
+            #endif
+            {
+                N[0] += Ngt_l;
+                rotDOF[0] += rotDOFgt_l;
+                summv2[0] += summv2gt_l;
+                sumIw2[0] += sumIw2gt_l;
+            }
+        } // end pragma omp parallel
+    }
+    for (auto & thermit : summv2) {
+        domain->setLocalSummv2(thermit.second, thermit.first);
+        domain->setLocalSumIw2(sumIw2[thermit.first], thermit.first);
+        domain->setLocalNrotDOF(thermit.first, N[thermit.first], rotDOF[thermit.first]);
+    }
+}
+
+void Langevin::eventNewTimestep(ParticleContainer *particleContainer, Domain *domain) {
+    for(std::size_t index = 0; index < _stochastic_regions.size(); index++) {
+        auto& region = _stochastic_regions[index];
+        double T = _simulation.getTemperatureObserver()->getTemperature(index);
+        T = _simulation.getEnsemble()->T();
+        #if defined(_OPENMP)
+        #pragma omp parallel
+        #endif
+        for(auto it = particleContainer->regionIterator(std::data(region.low),
+                                                        std::data(region.high),
+                                                        ParticleIterator::ONLY_INNER_AND_BOUNDARY); it.isValid(); ++it) {
+            d3 v_old = it->v_arr();
+            d3 v_rand = sampleRandomForce(it->mass(), T);
+            d3 v_delta {};
+
+            for(int d = 0; d < 3; d++) {
+                v_delta[d] = - _dt_half * _xi * v_old[d] + v_rand[d];
+            }
+
+            it->vadd(v_delta[0], v_delta[1], v_delta[2]);
+        }
+    }
+
+    #if defined(_OPENMP)
+    #pragma omp parallel
+    #endif
+    {
+        for (auto i = particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); i.isValid(); ++i) {
+            i->upd_preF(_timestepLength);
+        }
+    }
+
+
+}
+
+Langevin::d3 Langevin::sampleRandomForce(double m, double T) {
+    static thread_local std::mt19937 generator; // keeping default seed for reproducibility
+    std::normal_distribution normal{0.0, 1.0};
+    d3 r_vec {};
+
+    double scale = std::sqrt(_timestepLength * T * _xi / m);
+    for(int d = 0; d < 3; d++) {
+        r_vec[d] = scale * normal(generator);
+    }
+
+    return r_vec;
+}

--- a/src/integrators/Langevin.h
+++ b/src/integrators/Langevin.h
@@ -1,0 +1,55 @@
+//
+// Created by Alex Hocks on 05.03.24.
+//
+
+#ifndef MARDYN_LANGEVIN_H
+#define MARDYN_LANGEVIN_H
+
+
+#include "Integrator.h"
+
+#include <array>
+#include <vector>
+
+/**
+ * New time integrator that deviates from the standard Verlet integration scheme.
+ * Equations of motion are changed to follow Langevin equations.
+ * This is a stochastic integration scheme, which is incorporated as random "kicks" from the connected heat bath.
+ * */
+class Langevin : public Integrator {
+public:
+    void readXML(XMLfileUnits &xmlconfig) override;
+
+    void init() override;
+
+    void eventNewTimestep(ParticleContainer *moleculeContainer, Domain *domain) override;
+
+    void eventForcesCalculated(ParticleContainer *moleculeContainer, Domain *domain) override;
+private:
+    using d3 = std::array<double, 3>;
+    struct box_t {
+        box_t() = default;
+        box_t(const d3& l, const d3& h) : low(l), high(h) {}
+        d3 low, high;
+    };
+
+    //! @brief friction strength
+    double _xi;
+
+    //! @brief time step length halved
+    double _dt_half;
+
+    //! @brief regions in which friction is not set to 0
+    std::vector<box_t> _stochastic_regions;
+
+    /**
+     * Sample from Gaussian with technically 0 mean and sigma**2 = 2 * m * friction * k_b * T_target / delta_t.
+     * Is already adapted to match the integration scheme.
+     * @param m mass
+     * @param T temp target
+     * */
+    d3 sampleRandomForce(double m, double T);
+};
+
+
+#endif //MARDYN_LANGEVIN_H

--- a/src/integrators/Langevin.h
+++ b/src/integrators/Langevin.h
@@ -15,6 +15,9 @@
  * New time integrator that deviates from the standard Verlet integration scheme.
  * Equations of motion are changed to follow Langevin equations.
  * This is a stochastic integration scheme, which is incorporated as random "kicks" from the connected heat bath.
+ *
+ * This is to be used with the TemperatureObserver, which disables the normal velocity scaling and defines
+ * the regions in which the Langevin Thermostat should be active.
  * */
 class Langevin : public Integrator {
 public:
@@ -41,6 +44,9 @@ private:
 
     //! @brief regions in which friction is not set to 0
     std::vector<box_t> _stochastic_regions;
+
+    //! @brief We need to check at least twice if a TemperatureObserver exists
+    bool _checkFailed;
 
     /**
      * Sample from Gaussian with technically 0 mean and sigma**2 = 2 * m * friction * k_b * T_target / delta_t.

--- a/src/thermostats/TemperatureObserver.cpp
+++ b/src/thermostats/TemperatureObserver.cpp
@@ -1,0 +1,150 @@
+//
+// Created by alex on 06.03.24.
+//
+
+#include "TemperatureObserver.h"
+#include "Simulation.h"
+#include "ensemble/EnsembleBase.h"
+
+void TemperatureObserver::readXML(XMLfileUnits &xmlconfig) {
+    std::size_t num_regions = 0;
+    XMLfile::Query query = xmlconfig.query("ActiveRegions/region");
+    num_regions = query.card();
+    _region_data.resize(num_regions);
+
+    std::string oldpath = xmlconfig.getcurrentnodepath();
+    XMLfile::Query::const_iterator rIt;
+    std::size_t index = 0;
+    for(rIt = query.begin(); rIt; rIt++) {
+        xmlconfig.changecurrentnode(rIt);
+        d3 low {}, high{};
+        xmlconfig.getNodeValue("lowX", low[0]);
+        xmlconfig.getNodeValue("lowY", low[1]);
+        xmlconfig.getNodeValue("lowZ", low[2]);
+
+        xmlconfig.getNodeValue("highX", high[0]);
+        xmlconfig.getNodeValue("highY", high[1]);
+        xmlconfig.getNodeValue("highZ", high[2]);
+
+        _region_data[index].first.low = low;
+        _region_data[index].first.high = high;
+        index++;
+    }
+    xmlconfig.changecurrentnode(oldpath);
+
+    _max_samples = 100;
+    xmlconfig.getNodeValue("samples", _max_samples);
+}
+
+void TemperatureObserver::init() {
+    for(auto& [region, region_cache] : _region_data) {
+        region_cache.history.init(_max_samples);
+        region_cache.current_temp = 0.0;
+    }
+}
+
+void TemperatureObserver::step(ParticleContainer* particleContainer) {
+    for(auto& [region, region_cache] : _region_data) {
+        region_cache.current_temp = measureTemp(region.low, region.high, particleContainer, region_cache.history);
+    }
+}
+
+void TemperatureObserver::getRegions(std::vector<std::pair<std::array<double, 3>, std::array<double, 3>>>& regions) {
+    for(auto& [region, region_cache] : _region_data) {
+        regions.emplace_back(region.low, region.high);
+    }
+}
+
+double TemperatureObserver::getTemperature(std::size_t index) {
+    mardyn_assert(index < _region_data.size() && index >= 0);
+    return _region_data[index].second.current_temp;
+}
+
+double TemperatureObserver::measureTemp(const std::array<double, 3> &low, const std::array<double, 3> &high,
+                                   ParticleContainer *particleContainer, BinData& binData) {
+    std::array<double, 3> v_mean = computeMeanVelocityStep(low, high, particleContainer, binData);
+    double m = _simulation.getEnsemble()->getComponent(0)->m();
+    double v = 0;
+    std::size_t n = 0;
+#if defined(_OPENMP)
+#pragma omp parallel reduction(+:v, n)
+#endif
+    for (auto it = particleContainer->regionIterator(std::data(low), std::data(high),
+                                                     ParticleIterator::ALL_CELLS); it.isValid(); ++it) {
+        for(int d = 0; d < 3; d++) {
+            v += std::pow(it->v(d) - v_mean[d], 2);
+        }
+        n += 1;
+    }
+
+    return v * m / (3 * static_cast<double>(n));
+}
+
+std::array<double, 3> TemperatureObserver::computeMeanVelocityStep(const std::array<double, 3> &low, const std::array<double, 3> &high,
+                                                              ParticleContainer *particleContainer, BinData& binData) {
+    //compute mean velocity per dim using SMC method, see: Karimian et al. 2011
+    std::array<double, 3> v_avg{0};
+    double* v_raw = std::data(v_avg);
+    std::size_t count = 0;
+#if defined(_OPENMP)
+#pragma omp parallel reduction(+:v_raw[:3], count)
+#endif
+    for (auto it = particleContainer->regionIterator(std::data(low), std::data(high),
+                                                     ParticleIterator::ALL_CELLS); it.isValid(); ++it) {
+        for(int d = 0; d < 3; d++) {
+            v_raw[d] += it->v(d);
+        }
+        count += 1;
+    }
+    //TODO check this
+    if(count == 0) count = 1;
+    binData.mol_counts.insert(count);
+    binData.velocities.insert(v_avg);
+
+    //compute CAM average first
+    {
+        std::size_t steps = binData.mol_counts.size();
+        auto d = static_cast<double>(steps<=1?1:steps-1);
+
+        std::array<double, 3> v_cam{ 0 };
+        for(std::size_t i = 0; i < steps; i++) {
+            const auto& vec = binData.velocities.get(i);
+            for(int dim = 0; dim < 3; dim++) {
+                v_cam[dim] += vec[dim];
+            }
+        }
+        for(int dim = 0; dim < 3; dim++) {
+            v_cam[dim] /= d;
+        }
+
+        std::size_t nks = 0;
+        for(std::size_t i = 0; i < steps; i++) {
+            nks += binData.mol_counts.get(i);
+        }
+        double nks_d = static_cast<double>(nks) / d;
+
+        for(int dim = 0; dim < 3; dim++) {
+            v_cam[dim] /= nks_d;
+        }
+        binData.v_cam.insert(v_cam);
+    }
+
+    //compute SAM over CAM
+    {
+        std::size_t steps = binData.v_cam.size();
+        auto d = static_cast<double>(steps<=1?1:steps-1);
+
+        std::array<double, 3> v_scm{ 0 };
+        for(std::size_t i = 0; i < steps; i++) {
+            const auto& vec = binData.v_cam.get(i);
+            for(int dim = 0; dim < 3; dim++) {
+                v_scm[dim] += vec[dim];
+            }
+        }
+        for(int dim = 0; dim < 3; dim++) {
+            v_scm[dim] /= d;
+        }
+
+        return v_scm;
+    }
+}

--- a/src/thermostats/TemperatureObserver.h
+++ b/src/thermostats/TemperatureObserver.h
@@ -1,0 +1,142 @@
+//
+// Created by alex on 06.03.24.
+//
+
+#ifndef MARDYN_TEMPERATUREOBSERVER_H
+#define MARDYN_TEMPERATUREOBSERVER_H
+
+
+#include "utils/xmlfileUnits.h"
+#include "utils/mardyn_assert.h"
+
+#include <array>
+#include <vector>
+
+
+class Domain;
+class ParticleContainer;
+class Ensemble;
+
+/**
+ * Ring buffer that stores up to n entries. Will override oldest entry once n+1 elements are inserted.
+ * */
+template<typename T>
+struct NBuffer {
+    NBuffer() = default;
+    [[maybe_unused]] explicit NBuffer(std::size_t n) : _n(n), _begin(-1), _end(0) {
+        _data.resize(n);
+    }
+    void init(std::size_t n) {
+        _n = n;
+        _begin = -1;
+        _end = 0;
+        _data.resize(n);
+    }
+    void insert(const T& t) {
+        if(_begin == -1) {
+            _data[0] = t;
+            _begin = 0;
+            _end = 1;
+        }
+        else if (_begin == _end) {
+            _data[_end] = t;
+            _begin = (_begin+1) % _n;
+            _end = _begin;
+        }
+        else {
+            _data[_end] = t;
+            _end = (_end+1) % _n;
+        }
+    }
+    const T& get(std::size_t index) {
+        mardyn_assert(index < _n);
+        return _data[(_begin + index) % _n];
+    }
+    std::size_t size() {
+        if(_begin == -1) {
+            return 0;
+        }
+        else if (_begin == _end) {
+            return _n;
+        }
+        else {
+            return _end - _begin;
+        }
+    }
+    std::size_t _n{};
+    long _begin{};
+    long _end{};
+    std::vector<T> _data;
+};
+
+/**
+ * Data struct for computing SAM and CAM averages
+ * */
+struct BinData {
+    NBuffer<std::size_t> mol_counts;
+    NBuffer<std::array<double,3>> velocities;
+    NBuffer<std::array<double,3>> v_cam;
+
+    void init(std::size_t n) {
+        mol_counts.init(n);
+        velocities.init(n);
+        v_cam.init(n);
+    }
+};
+
+/**
+ * Measures the temperature in selected regions. See Karimian et al. 2011 and 2014
+ * */
+class TemperatureObserver {
+public:
+    /**
+     * Init all buffers
+     * */
+    void init();
+    void readXML(XMLfileUnits &xmlconfig);
+    /**
+     * Measure temp in all regions, updates caches and stores current temp
+     * */
+    void step(ParticleContainer* particleContainer);
+
+    /**
+     * @returns all regions, for which the temp is being measured.
+     * */
+    void getRegions(std::vector<std::pair<std::array<double, 3>, std::array<double, 3>>>& regions);
+
+    /**
+     * Gets the temperature for the selected region.
+     * Regions can be queried by accessing getRegions().
+     * @returns T * k_b
+     * */
+    double getTemperature(std::size_t index);
+private:
+    std::size_t _max_samples;
+
+    using d3 = std::array<double, 3>;
+    struct box_t {
+        box_t() = default;
+        box_t(const d3& l, const d3& h) : low(l), high(h) {}
+        d3 low, high;
+    };
+    struct box_data_t {
+        BinData history{ };
+        double current_temp{ };
+    };
+
+    //! @brief each region is defined by a box in 3d space (box_t) and a data cache (box_data_t)
+    std::vector<std::pair<box_t, box_data_t>> _region_data;
+
+    /**
+     * Based on: Details about pressure calculation in molecular dynamic analysis by Karimian et al. 2014
+     * returns T * k_b
+     * */
+    double measureTemp(const std::array<double,3>& low, const std::array<double, 3>& high, ParticleContainer *particleContainer, BinData& binData);
+
+    /**
+     * Computes the SAM over the CAM average of the mean velocity for the specified region. (SCM method)
+     * */
+    std::array<double, 3> computeMeanVelocityStep(const std::array<double,3>& low, const std::array<double, 3>& high, ParticleContainer *particleContainer, BinData& binData);
+};
+
+#endif //MARDYN_TEMPERATUREOBSERVER_H


### PR DESCRIPTION
# Description
- Added a Langevin Thermostat which follows the Langevin equations of motion. 
- This required adding a new integrator as well as a dummy thermostat to disable the default velocity scaling.
- The Integrator handles the actual thermostating of the system.
- The dummy thermostat can measure the temperature in selected regions.

- added xml parsing and init for new integrator in simulation class
- added xml parsing and init for thermostat in simulation class
- added public getter for thermostat in simulation class

## Resolved Issues

- This was needed for further AdResS functionality but could be useful to others

## How Has This Been Tested?

- Base functionality was copied from leapfrog
- Assuming leapfrog works, only checked if new Integrator + Thermo can reach the specified target temperature in one simulation
