### PR TITLE
Fix shifted parameter in SpinodalDecomp

### DIFF
--- a/examples/SpinodalDecomposition/components_1c.xml
+++ b/examples/SpinodalDecomposition/components_1c.xml
@@ -8,7 +8,7 @@
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
-            <shifted>1</shifted>
+            <shifted>true</shifted>
         </site>
         <momentsofinertia rotaxes="xyz" >
             <Ixx>0.0</Ixx>


### PR DESCRIPTION
PR #286 has changed the old numeric boolean values `0`/`1` to `true`/`false`.

However, one [setting](https://github.com/ls1mardyn/ls1-mardyn/blob/5bf6608178a8df38fe4db37c0614d972dbd4e97e/examples/SpinodalDecomposition/components_1c.xml#L11) slipped through the cracks.

This PR fixes it.
