### PR TITLE
Fix quaternion default initialisation

### DIFF
--- a/src/molecules/AutoPasSimpleMolecule.cpp
+++ b/src/molecules/AutoPasSimpleMolecule.cpp
@@ -12,8 +12,8 @@ Component* AutoPasSimpleMolecule::_component = nullptr;
 Quaternion AutoPasSimpleMolecule::_quaternion = Quaternion(1.0, 0.0, 0.0, 0.0);
 
 AutoPasSimpleMolecule::AutoPasSimpleMolecule(unsigned long id, Component* component, double rx, double ry, double rz,
-											 double vx, double vy, double vz, double q0, double q1, double q2,
-											 double q3, double Dx, double Dy, double Dz)
+											 double vx, double vy, double vz, double qw, double qx, double qy,
+											 double qz, double Dx, double Dy, double Dz)
 	: autopas::ParticleFP64({rx, ry, rz}, {vx, vy, vz}, id) {
 	if (_component == nullptr) {
 		_component = component;

--- a/src/molecules/AutoPasSimpleMolecule.h
+++ b/src/molecules/AutoPasSimpleMolecule.h
@@ -18,8 +18,8 @@
 class AutoPasSimpleMolecule final : public MoleculeInterface, public autopas::ParticleFP64 {
 public:
 	explicit AutoPasSimpleMolecule(unsigned long id = 0, Component* component = nullptr, double rx = 0., double ry = 0.,
-								   double rz = 0., double vx = 0., double vy = 0., double vz = 0., double q0 = 1.,
-								   double q1 = 1., double q2 = 0., double q3 = 0., double Dx = 0., double Dy = 0.,
+								   double rz = 0., double vx = 0., double vy = 0., double vz = 0., double qw = 1.,
+								   double qx = 1., double qy = 0., double qz = 0., double Dx = 0., double Dy = 0.,
 								   double Dz = 0.);
 
 	AutoPasSimpleMolecule(const AutoPasSimpleMolecule& m) = default;

--- a/src/molecules/AutoPasSimpleMolecule.h
+++ b/src/molecules/AutoPasSimpleMolecule.h
@@ -19,7 +19,7 @@ class AutoPasSimpleMolecule final : public MoleculeInterface, public autopas::Pa
 public:
 	explicit AutoPasSimpleMolecule(unsigned long id = 0, Component* component = nullptr, double rx = 0., double ry = 0.,
 								   double rz = 0., double vx = 0., double vy = 0., double vz = 0., double qw = 1.,
-								   double qx = 1., double qy = 0., double qz = 0., double Dx = 0., double Dy = 0.,
+								   double qx = 0., double qy = 0., double qz = 0., double Dx = 0., double Dy = 0.,
 								   double Dz = 0.);
 
 	AutoPasSimpleMolecule(const AutoPasSimpleMolecule& m) = default;

--- a/src/molecules/FullMolecule.cpp
+++ b/src/molecules/FullMolecule.cpp
@@ -11,10 +11,10 @@
 FullMolecule::FullMolecule(unsigned long id, Component *component,
 	                 double rx,  double ry,  double rz,
 	                 double vx,  double vy,  double vz,
-	                 double q0,  double q1,  double q2, double q3,
+	                 double qw,  double qx,  double qy, double qz,
 	                 double Dx,  double Dy,  double Dz
 		  )
-		: _q(q0, q1, q2, q3) {
+		: _q(qw, qx, qy, qz) {
 	_id = id;
 	_component = component;
 	_r[0] = rx;

--- a/src/molecules/FullMolecule.h
+++ b/src/molecules/FullMolecule.h
@@ -25,7 +25,7 @@ public:
 	FullMolecule(unsigned long id = 0, Component *component = nullptr,
 	         double rx = 0., double ry = 0., double rz = 0.,
 	         double vx = 0., double vy = 0., double vz = 0.,
-	         double q0 = 1., double q1 = 1., double q2 = 0., double q3 = 0.,
+	         double qw = 1., double qx = 1., double qy = 0., double qz = 0.,
 	         double Dx = 0., double Dy = 0., double Dz = 0.
 	);
 	FullMolecule(const FullMolecule& m);

--- a/src/molecules/FullMolecule.h
+++ b/src/molecules/FullMolecule.h
@@ -25,7 +25,7 @@ public:
 	FullMolecule(unsigned long id = 0, Component *component = nullptr,
 	         double rx = 0., double ry = 0., double rz = 0.,
 	         double vx = 0., double vy = 0., double vz = 0.,
-	         double qw = 1., double qx = 1., double qy = 0., double qz = 0.,
+	         double qw = 1., double qx = 0., double qy = 0., double qz = 0.,
 	         double Dx = 0., double Dy = 0., double Dz = 0.
 	);
 	FullMolecule(const FullMolecule& m);

--- a/src/molecules/MoleculeRMM.h
+++ b/src/molecules/MoleculeRMM.h
@@ -21,8 +21,8 @@ public:
 	MoleculeRMM(unsigned long id = 0, Component *component = nullptr,
         double rx = 0., double ry = 0., double rz = 0.,
         double vx = 0., double vy = 0., double vz = 0.,
-        double = 0., double = 0., double = 0., double = 0., /*q0, q1, q2, q3*/
-        double = 0., double = 0., double = 0. /*Dx, Dy, Dz*/
+        double qw = 0., double qx = 0., double qy = 0., double qz = 0.,
+        double Dx = 0., double Dy = 0., double Dz = 0.
 	) {
 		_state = STORAGE_AOS;
 		_r[0] = rx;

--- a/src/molecules/Quaternion.h
+++ b/src/molecules/Quaternion.h
@@ -9,7 +9,7 @@
  */
 class Quaternion {
 public:
-	Quaternion(double qw = 1., double qx = 1., double qy = 0., double qz = 0.)
+	Quaternion(double qw = 1., double qx = 0., double qy = 0., double qz = 0.)
 			: m_qw(qw), m_qx(qx), m_qy(qy), m_qz(qz) {
 	}
 


### PR DESCRIPTION
This PR reverts changes to the defaults in the constructor made in 20a6b8f13406960dc6c42a9388c9feb9ebe913fd back to 0 + 0i + 0j + 0k (Q(w=0, x=0, y=0, z=0)) to address #291. The issue was first mentioned in #255 


This has been tested using
- [x] internal unit tests
- [x] running examples with run-examples.sh  adding the ./Generators/cubic_grid_generator/config.xml to the list of tests
