### PR TITLE
Energy tuning feature from autopas

### DIFF
--- a/examples/Argon/200K_18mol_l/config_autopas_aos.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_aos.xml
@@ -35,6 +35,7 @@
         <allowedTraversals>lc_c01, lc_c08, lc_c18, lc_sli, ds_sequential</allowedTraversals>
         <allowedContainers>linkedCells, verletLists, directsum</allowedContainers>
         <selectorStrategy>fastestMedian</selectorStrategy>
+        <tuningMetric>energy</tuningMetric>
         <dataLayouts>AoS</dataLayouts>
         <newton3>enabled, disabled</newton3>
         <tuningInterval>1000</tuningInterval>

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -245,6 +245,8 @@
         <!-- set the tuning auto tuning pipeline -->
         <!-- Leave this empty for an exhaustive full search or add any number of strategies that are applied in the stated order -->
         <tuningStrategies>ruleBasedTuning, predictiveTuning</tuningStrategies>
+        <!-- autopas optimizes the simulation based on tuning metric, default option is time -->
+        <tuningMetric>time, energy</tuningMetric>
         <!-- Data layouts to be used: AoS, SoA -->
         <dataLayouts>SoA</dataLayouts>
         <!-- Allowed choices for newton 3 optimization: enabled, disabled -->

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -130,6 +130,7 @@ AutoPasContainer::AutoPasContainer(double cutoff) : _cutoff(cutoff), _particlePr
 	_containerChoices = _autopasContainer.getAllowedContainers();
 	_selectorStrategy = _autopasContainer.getSelectorStrategy();
 	_tuningStrategyOptions = _autopasContainer.getTuningStrategyOptions();
+	_tuningMetricOptions = _autopasContainer.getTuningMetricOptions();
 	_tuningAcquisitionFunction = _autopasContainer.getAcquisitionFunction();
 	_dataLayoutChoices = _autopasContainer.getAllowedDataLayouts();
 	_newton3Choices = _autopasContainer.getAllowedNewton3Options();
@@ -203,6 +204,7 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 			 .begin();
 	_tuningStrategyOptions =
 		parseAutoPasOption<autopas::TuningStrategyOption, std::vector<autopas::TuningStrategyOption>>(xmlconfig, "tuningStrategies", {_tuningStrategyOptions});
+	_tuningMetricOptions = parseAutoPasOption<autopas::TuningMetricOption>(xmlconfig, "tuningMetric", {_tuningMetricOptions});
 	_extrapolationMethod = *parseAutoPasOption<autopas::ExtrapolationMethodOption>(xmlconfig, "extrapolationMethod",
 																				   {_extrapolationMethod})
 								.begin();
@@ -320,6 +322,7 @@ bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {
 	_autopasContainer.setAllowedDataLayouts(_dataLayoutChoices);
 	_autopasContainer.setAllowedNewton3Options(_newton3Choices);
 	_autopasContainer.setTuningStrategyOption(_tuningStrategyOptions);
+	_autopasContainer.setTuningMetricOptions(_tuningMetricOptions);
 	_autopasContainer.setRuleFileName(_ruleFileName);
 	_autopasContainer.setAcquisitionFunction(_tuningAcquisitionFunction);
 	_autopasContainer.setMaxEvidence(_maxEvidence);
@@ -348,6 +351,9 @@ bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {
 					   << "\n"
 					   << std::setw(valueOffset) << std::left << "Newton3"
 					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedNewton3Options())
+					   << "\n"
+					   << std::setw(valueOffset) << std::left << "Tuning Metric Options"
+					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getTuningMetricOptions())
 					   << "\n"
 					   << std::setw(valueOffset) << std::left << "Tuning strategies "
 					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getTuningStrategyOptions())

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -130,7 +130,7 @@ AutoPasContainer::AutoPasContainer(double cutoff) : _cutoff(cutoff), _particlePr
 	_containerChoices = _autopasContainer.getAllowedContainers();
 	_selectorStrategy = _autopasContainer.getSelectorStrategy();
 	_tuningStrategyOptions = _autopasContainer.getTuningStrategyOptions();
-	_tuningMetricOptions = _autopasContainer.getTuningMetricOptions();
+	_tuningMetricOption = _autopasContainer.getTuningMetricOption();
 	_tuningAcquisitionFunction = _autopasContainer.getAcquisitionFunction();
 	_dataLayoutChoices = _autopasContainer.getAllowedDataLayouts();
 	_newton3Choices = _autopasContainer.getAllowedNewton3Options();
@@ -204,7 +204,7 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 			 .begin();
 	_tuningStrategyOptions =
 		parseAutoPasOption<autopas::TuningStrategyOption, std::vector<autopas::TuningStrategyOption>>(xmlconfig, "tuningStrategies", {_tuningStrategyOptions});
-	_tuningMetricOptions = parseAutoPasOption<autopas::TuningMetricOption>(xmlconfig, "tuningMetric", {_tuningMetricOptions});
+	_tuningMetricOption = *parseAutoPasOption<autopas::TuningMetricOption>(xmlconfig, "tuningMetric", {_tuningMetricOption}).begin();
 	_extrapolationMethod = *parseAutoPasOption<autopas::ExtrapolationMethodOption>(xmlconfig, "extrapolationMethod",
 																				   {_extrapolationMethod})
 								.begin();
@@ -322,7 +322,7 @@ bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {
 	_autopasContainer.setAllowedDataLayouts(_dataLayoutChoices);
 	_autopasContainer.setAllowedNewton3Options(_newton3Choices);
 	_autopasContainer.setTuningStrategyOption(_tuningStrategyOptions);
-	_autopasContainer.setTuningMetricOptions(_tuningMetricOptions);
+	_autopasContainer.setTuningMetricOption(_tuningMetricOption);
 	_autopasContainer.setRuleFileName(_ruleFileName);
 	_autopasContainer.setAcquisitionFunction(_tuningAcquisitionFunction);
 	_autopasContainer.setMaxEvidence(_maxEvidence);
@@ -353,8 +353,7 @@ bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {
 					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getAllowedNewton3Options())
 					   << "\n"
 					   << std::setw(valueOffset) << std::left << "Tuning Metric Options"
-					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getTuningMetricOptions())
-					   << "\n"
+					   << ": " << _autopasContainer.getTuningMetricOption() << "\n"
 					   << std::setw(valueOffset) << std::left << "Tuning strategies "
 					   << ": " << autopas::utils::ArrayUtils::to_string(_autopasContainer.getTuningStrategyOptions())
 					   << "\n"

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -166,6 +166,7 @@ private:
 	std::set<autopas::ContainerOption> _containerChoices;
 	autopas::SelectorStrategyOption _selectorStrategy;
 	std::vector<autopas::TuningStrategyOption> _tuningStrategyOptions;
+	std::set<autopas::TuningMetricOption> _tuningMetricOptions;
 	autopas::ExtrapolationMethodOption _extrapolationMethod;
 	autopas::AcquisitionFunctionOption _tuningAcquisitionFunction;
 	std::set<autopas::DataLayoutOption> _dataLayoutChoices;

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -166,7 +166,7 @@ private:
 	std::set<autopas::ContainerOption> _containerChoices;
 	autopas::SelectorStrategyOption _selectorStrategy;
 	std::vector<autopas::TuningStrategyOption> _tuningStrategyOptions;
-	std::set<autopas::TuningMetricOption> _tuningMetricOptions;
+	autopas::TuningMetricOption _tuningMetricOption;
 	autopas::ExtrapolationMethodOption _extrapolationMethod;
 	autopas::AcquisitionFunctionOption _tuningAcquisitionFunction;
 	std::set<autopas::DataLayoutOption> _dataLayoutChoices;


### PR DESCRIPTION
# Description

Adding options to use the energy tuning feature from Autopas. 

## Resolved Issues

- [ ] #262 

## How Has This Been Tested?

- [ ] Checking that MarDyn reads the tuning metric from config file and runs the simulation accordingly
