### PR TITLE
Update github C/C++ CI for ls1 action to use checkout@v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
@@ -63,7 +63,7 @@ jobs:
         CXX: g++
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
         upload: false # disable upload here, will be done later
@@ -81,6 +81,6 @@ jobs:
         output: sarif-results/${{ matrix.language }}.sarif
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: sarif-results/${{ matrix.language }}.sarif

--- a/.github/workflows/ls1_test.yml
+++ b/.github/workflows/ls1_test.yml
@@ -51,7 +51,7 @@ jobs:
     name: ${{ matrix.vector }}-${{ matrix.target }}-${{ matrix.parall }}-${{ matrix.cc }}-AutoPas=${{ matrix.autopas }}-Ranks=${{ matrix.procs }}-OMP=${{ matrix.openmp }}
     steps:
       # setup github actions runner node
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup
       run: |
         sudo apt-get update


### PR DESCRIPTION
# Description

Update GitHub action to use checkout@v4 and CodeQL @v3 to address deprecation warning.