### PR TITLE
Fix and improvement of Logger

### DIFF
--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -20,6 +20,7 @@ Logger::Logger(logLevel level, std::ostream *os)
 Logger::Logger(logLevel level, std::string prefix) :  _log_level(level), _msg_log_level(Log::Error),
 		_do_output(true), _filename(""), _log_stream(0), logLevelNames(), _starttime(), _rank(0) {
 	init_starting_time();
+	this->init_log_levels();
 	std::stringstream filenamestream;
 	filenamestream << prefix;
 #ifdef ENABLE_MPI

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -6,9 +6,11 @@ namespace Log {
 
 Logger *global_log;
 
-Logger::Logger(logLevel level, std::ostream *os)
-: _log_level(level), _msg_log_level(Log::Error), _do_output(true), _filename(""),
-  _log_stream(os), logLevelNames(), _starttime(), _rank(0) {
+Logger::Logger(logLevel level, std::ostream *os) :
+	_log_level(level), _msg_log_level(Log::Error),
+	_do_output(true), _filename(""),_log_stream(os),
+	logLevelNames(), _starttime(), _rank(0)
+{
 	init_starting_time();
 	this->init_log_levels();
 #ifdef ENABLE_MPI
@@ -17,8 +19,11 @@ Logger::Logger(logLevel level, std::ostream *os)
 }
 
 
-Logger::Logger(logLevel level, std::string prefix) :  _log_level(level), _msg_log_level(Log::Error),
-		_do_output(true), _filename(""), _log_stream(0), logLevelNames(), _starttime(), _rank(0) {
+Logger::Logger(logLevel level, std::string prefix) :
+	_log_level(level), _msg_log_level(Log::Error),
+	_do_output(true), _filename(""), _log_stream(0),
+	logLevelNames(), _starttime(), _rank(0)
+{
 	init_starting_time();
 	this->init_log_levels();
 	std::stringstream filenamestream;

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -16,6 +16,7 @@ Logger::Logger(logLevel level, std::ostream *os) :
 #ifdef ENABLE_MPI
 	MPI_Comm_rank(MPI_COMM_WORLD, &_rank);
 #endif
+	*_log_stream << std::boolalpha;  // Print boolean as true/false
 }
 
 
@@ -35,6 +36,7 @@ Logger::Logger(logLevel level, std::string prefix) :
 	filenamestream << ".log";
 	_filename = filenamestream.str();
 	_log_stream = new std::ofstream(_filename.c_str());
+	*_log_stream << std::boolalpha;  // Print boolean as true/false
 }
 
 Logger::~Logger() {

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -102,7 +102,7 @@ private:
 
 	int _rank;
 
-	/// initilaize the list of log levels with the corresponding short names
+	/// initialize the list of log levels with the corresponding short names
 	void init_log_levels() {
 		logLevelNames.insert(std::pair<logLevel, std::string>(None,    "NONE"));
 		logLevelNames.insert(std::pair<logLevel, std::string>(Fatal,   "FATAL ERROR"));


### PR DESCRIPTION
# Description

Not everything has been set up correctly in the Logger class. Therefore, the type of output (e.g. `INFO`, `WARNING`) was missing, if the `--logfile` option of ls1 was used.

To improve the readibility and to distinguish between bools and numbers, the output of booleans was set to be `true`/`false` instead of `1`/`0`.

The present PR is related to the split-up of PR #255.


## How Has This Been Tested?

A simulation with the logfile option was run and it was checked that the resulting file includes the type of output (first column).
