### PR TITLE
Fix xml parser attribute parsing

### DIFF
--- a/src/utils/xmlfile.cpp
+++ b/src/utils/xmlfile.cpp
@@ -446,7 +446,7 @@ unsigned long XMLfile::query(std::list<Node>& nodeselection, const std::string& 
 				if (! attrname.empty())
 				{ // search for attribute node
 					attr=ele->first_attribute(attrname.c_str());
-					if(0 != attr) {
+					if(NULL != attr) {
 						nodepath.append("@");
 						nodepath.append(attrname);
 						nodeselection.push_back(Node(attr,nodepath));

--- a/src/utils/xmlfile.cpp
+++ b/src/utils/xmlfile.cpp
@@ -446,13 +446,16 @@ unsigned long XMLfile::query(std::list<Node>& nodeselection, const std::string& 
 				if (! attrname.empty())
 				{ // search for attribute node
 					attr=ele->first_attribute(attrname.c_str());
-					nodepath.append("@");
-					nodepath.append(attrname);
-					nodeselection.push_back(Node(attr,nodepath));
+					if(0 != attr) {
+						nodepath.append("@");
+						nodepath.append(attrname);
+						nodeselection.push_back(Node(attr,nodepath));
+						++foundnodes;
+					}
 				} else { // found element node
 					nodeselection.push_back(Node(ele,nodepath));
+					++foundnodes;
 				}
-				++foundnodes;
 			}
 		}
 	}

--- a/src/utils/xmlfileUnits.cpp
+++ b/src/utils/xmlfileUnits.cpp
@@ -402,7 +402,7 @@ unsigned long XMLfileUnits::getNodeValueUnit(const char* nodepath, XMLfileUnits:
 	{
 		value=XMLfileUnits::ValueUnit(v,u);
 	}
-	else {
+	else { /* The XML tag did not include a unit attribute, so use the unscaled value. */
 		value = v;
 	}
 	return found;

--- a/src/utils/xmlfileUnits.cpp
+++ b/src/utils/xmlfileUnits.cpp
@@ -402,6 +402,9 @@ unsigned long XMLfileUnits::getNodeValueUnit(const char* nodepath, XMLfileUnits:
 	{
 		value=XMLfileUnits::ValueUnit(v,u);
 	}
+	else {
+		value = v;
+	}
 	return found;
 }
 


### PR DESCRIPTION
# Description
This fixes the xml parser problem around `nodeValue()` reported in #310.

Some return statements were not checked correctly in the query part for attributes in the code. This affected then also the xml parser part that used reference units and revealed an issue with incomplete reference unit check handling.

- [x] Used the EOX example to verify the xml data are read in correctly (compared against the current master baff96a54)