### PR TITLE
Add names to site in xml

### DIFF
--- a/examples/Adsorption/Generator/adsorption.xml
+++ b/examples/Adsorption/Generator/adsorption.xml
@@ -27,7 +27,7 @@
       </domain>
       <components>
         <moleculetype id="1" name="fluid">
-          <site type="LJ126" id="1">
+          <site type="LJ126" id="1" name="LJTS">
             <coords>
               <x>0.0</x>
               <y>0.0</y>

--- a/examples/Adsorption/Generator/adsorption_autopas_default.xml
+++ b/examples/Adsorption/Generator/adsorption_autopas_default.xml
@@ -27,7 +27,7 @@
       </domain>
       <components>
         <moleculetype id="1" name="fluid">
-          <site type="LJ126" id="1">
+          <site type="LJ126" id="1" name="LJTS">
             <coords>
               <x>0.0</x>
               <y>0.0</y>

--- a/examples/Adsorption/Generator/adsorption_autopas_tuning.xml
+++ b/examples/Adsorption/Generator/adsorption_autopas_tuning.xml
@@ -27,7 +27,7 @@
       </domain>
       <components>
         <moleculetype id="1" name="fluid">
-          <site type="LJ126" id="1">
+          <site type="LJ126" id="1" name="LJTS">
             <coords>
               <x>0.0</x>
               <y>0.0</y>

--- a/examples/Argon/components.xml
+++ b/examples/Argon/components.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="Argon">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="Ar">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>0.039948</mass>
 			<sigma>6.4160007</sigma>

--- a/examples/CO2/components.xml
+++ b/examples/CO2/components.xml
@@ -2,21 +2,21 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="CO2">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="C">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>0.012</mass>
 			<sigma>5.31712452</sigma>
 			<epsilon>3.91811245e-05</epsilon>
 			<shifted>false</shifted>
 		</site>
-		<site type="LJ126" id="2" >
+		<site type="LJ126" id="2" name="O">
 			<coords> <x>0.0</x> <y>0.0</y> <z>-2.43188952</z> </coords>
 			<mass>0.016</mass>
 			<sigma>5.62288233</sigma>
 			<epsilon>0.00031824324</epsilon>
 			<shifted>false</shifted>
 		</site>
-		<site type="LJ126" id="3" >
+		<site type="LJ126" id="3" name="O">
 			<coords> <x>0.0</x> <y>0.0</y> <z>2.43188952</z> </coords>
 			<mass>0.016</mass>
 			<sigma>5.62288233</sigma>

--- a/examples/DropletCoalescence/components.xml
+++ b/examples/DropletCoalescence/components.xml
@@ -3,7 +3,7 @@
 <components>
 
   <moleculetype id="1" name="Argon">
-    <site type="LJ126" id="1" >
+    <site type="LJ126" id="1" name="Ar">
       <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
       <mass>39.948</mass>
       <sigma>3.3916</sigma>
@@ -18,7 +18,7 @@
   </moleculetype>
 
   <moleculetype id="2" name="Argon">
-    <site type="LJ126" id="1" >
+    <site type="LJ126" id="1" name="Ar">
       <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
       <mass>39.948</mass>
       <sigma>3.3916</sigma>

--- a/examples/Evaporation/stationary/components_3c.xml
+++ b/examples/Evaporation/stationary/components_3c.xml
@@ -2,7 +2,7 @@
 
 <components>
 	<moleculetype id="1" name="1CLJTS_freeze">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJTS">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
@@ -17,7 +17,7 @@
 	</moleculetype>
 
 	<moleculetype id="2" name="1CLJTS_j+">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJTS">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
@@ -32,7 +32,7 @@
 	</moleculetype>
 
 	<moleculetype id="3" name="1CLJTS_j-">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJTS">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>

--- a/examples/Evaporation/stationary/sphereparams_3c.xml
+++ b/examples/Evaporation/stationary/sphereparams_3c.xml
@@ -28,7 +28,7 @@
 		<color>
 			<r>0</r>
 			<g>0</g>
-			<b>255</b>>
+			<b>255</b>
 			<alpha>255</alpha>
 		</color>
 	</site>

--- a/examples/ExplodingLiquid/components.xml
+++ b/examples/ExplodingLiquid/components.xml
@@ -2,7 +2,7 @@
 
 <components>
 	<moleculetype id="1" name="1CLJTS">
-	<site type="LJ126" id="1" >
+	<site type="LJ126" id="1" name="LJTS">
 		<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 		<mass>1</mass>
 		<sigma>1</sigma>

--- a/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/components.xml
+++ b/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/components.xml
@@ -3,7 +3,7 @@
 <components>
 
 	<moleculetype id="1" name="1CLJ_c1">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJfull">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1</mass>
 			<sigma>1</sigma>
@@ -18,7 +18,7 @@
 	</moleculetype>
 
 	<moleculetype id="2" name="1CLJ_c2">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJfull">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>2</mass>
 			<sigma>1</sigma>

--- a/examples/Generators/PerCellGenerator/components.xml
+++ b/examples/Generators/PerCellGenerator/components.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="1CLJ">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJfull">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>

--- a/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_220K/components_co2_merker.xml
+++ b/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_220K/components_co2_merker.xml
@@ -8,21 +8,21 @@
 	</refunits>
 
 	<moleculetype id="1" name="CO2_Merker">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="C">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>12.012</mass>
 			<sigma>2.8137</sigma>
 			<epsilon>12.3724</epsilon>
 			<shifted>false</shifted>
 		</site>
-		<site type="LJ126" id="2" >
+		<site type="LJ126" id="2" name="O">
 			<coords> <x>0.0</x> <y>0.0</y> <z>-1.2869</z> </coords>
 			<mass>15.999</mass>
 			<sigma>2.9755</sigma>
 			<epsilon>100.493</epsilon>
 			<shifted>false</shifted>
 		</site>
-		<site type="LJ126" id="3" >
+		<site type="LJ126" id="3" name="O">
 			<coords> <x>0.0</x> <y>0.0</y> <z>1.2869</z> </coords>
 			<mass>15.999</mass>
 			<sigma>2.9755</sigma>

--- a/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_242-15K/components_co2_merker.xml
+++ b/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_242-15K/components_co2_merker.xml
@@ -8,21 +8,21 @@
 	</refunits>
 
 	<moleculetype id="1" name="CO2_Merker">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="C">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>12.012</mass>
 			<sigma>2.8137</sigma>
 			<epsilon>12.3724</epsilon>
 			<shifted>false</shifted>
 		</site>
-		<site type="LJ126" id="2" >
+		<site type="LJ126" id="2" name="O">
 			<coords> <x>0.0</x> <y>0.0</y> <z>-1.2869</z> </coords>
 			<mass>15.999</mass>
 			<sigma>2.9755</sigma>
 			<epsilon>100.493</epsilon>
 			<shifted>false</shifted>
 		</site>
-		<site type="LJ126" id="3" >
+		<site type="LJ126" id="3" name="O">
 			<coords> <x>0.0</x> <y>0.0</y> <z>1.2869</z> </coords>
 			<mass>15.999</mass>
 			<sigma>2.9755</sigma>

--- a/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/N2_118K/components.xml
+++ b/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/N2_118K/components.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <components version="20100525" >
     <moleculetype id="1" name="n2" >
-    <site type="LJ126" id="1" >
+    <site type="LJ126" id="1" name="N">
       <coords> <x>0.0</x> <y>0.0</y> <z>-0.5232</z> </coords>
       <mass>14.0</mass>
       <sigma>3.3211</sigma>
       <epsilon>34.897</epsilon>
     </site>
-    <site type="LJ126" id="2" >
+    <site type="LJ126" id="2" name="N">
       <coords> <x>0.0</x> <y>0.0</y> <z>0.5232</z> </coords>
       <mass>14.0</mass>
       <sigma>3.3211</sigma>

--- a/examples/Generators/ReplicaGenerator/homogeneous/1CLJ-full_cubic/components.xml
+++ b/examples/Generators/ReplicaGenerator/homogeneous/1CLJ-full_cubic/components.xml
@@ -3,7 +3,7 @@
 <components>
 
   <moleculetype id="1" name="1CLJ">
-  <site type="LJ126" id="1" >
+  <site type="LJ126" id="1" name="LJfull">
     <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
     <mass>1.0</mass>
     <sigma>1.0</sigma>

--- a/examples/Generators/cubic_grid_generator/components.xml
+++ b/examples/Generators/cubic_grid_generator/components.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="1CLJ">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJfull">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>

--- a/examples/Generators/mkTcTS/components.xml
+++ b/examples/Generators/mkTcTS/components.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="1CLJ">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJfull">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>

--- a/examples/Generators/mkesfera/components.xml
+++ b/examples/Generators/mkesfera/components.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="1CLJ">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJfull">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>

--- a/examples/Injection/comp/components_4c.xml
+++ b/examples/Injection/comp/components_4c.xml
@@ -3,7 +3,7 @@
 <components>
 
 	<moleculetype id="1" name="1CLJTS">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJTS">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
@@ -18,7 +18,7 @@
 	</moleculetype>
 
 	<moleculetype id="2" name="1CLJTS_freeze_fluid">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJTS">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>
@@ -33,7 +33,7 @@
 	</moleculetype>
 
     <moleculetype id="3" name="1CLJTS_tube">
-        <site type="LJ126" id="1" >
+        <site type="LJ126" id="1" name="LJTS">
             <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>
@@ -48,7 +48,7 @@
     </moleculetype>
 
     <moleculetype id="4" name="1CLJTS_freeze_tube">
-        <site type="LJ126" id="1" >
+        <site type="LJ126" id="1" name="LJTS">
             <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>

--- a/examples/KDD-vectorization-tuner/one-component/components.xml
+++ b/examples/KDD-vectorization-tuner/one-component/components.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="Argon">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="Ar">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>0.039948</mass>
 			<sigma>6.4160007</sigma>

--- a/examples/KDD-vectorization-tuner/two-components/components.xml
+++ b/examples/KDD-vectorization-tuner/two-components/components.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="Argon">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="Ar">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>0.039948</mass>
 			<sigma>6.4160007</sigma>

--- a/examples/Mamico-couette/ls1config.xml
+++ b/examples/Mamico-couette/ls1config.xml
@@ -25,7 +25,7 @@
 			</domain>
 			<components>
 				<moleculetype id="1" name="Arbitrary">
-					<site type="LJ126" id="1" >
+					<site type="LJ126" id="1" name="LJfull">
 						<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 						<mass>1.0</mass>
 						<sigma>1.0</sigma>

--- a/examples/Mamico-couette/ls1configNoCP.xml
+++ b/examples/Mamico-couette/ls1configNoCP.xml
@@ -26,7 +26,7 @@
 			</domain>
 			<components>
 				<moleculetype id="1" name="Arbitrary">
-					<site type="LJ126" id="1" >
+					<site type="LJ126" id="1" name="LJfull">
 						<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 						<mass>1.0</mass>
 						<sigma>1.0</sigma>

--- a/examples/SpinodalDecomposition/components_1c.xml
+++ b/examples/SpinodalDecomposition/components_1c.xml
@@ -3,7 +3,7 @@
 <components>
 
     <moleculetype id="1" name="1CLJTS">
-        <site type="LJ126" id="1" >
+        <site type="LJ126" id="1" name="LJTS">
             <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>

--- a/examples/adios/write/config_mix.xml
+++ b/examples/adios/write/config_mix.xml
@@ -31,7 +31,7 @@
 
 			<components>
 				<moleculetype id="1" name="1CLJ_c1">
-					<site type="LJ126" id="1" >
+					<site type="LJ126" id="1" name="LJfull">
 						<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 						<mass>1</mass>
 						<sigma>1</sigma>
@@ -46,7 +46,7 @@
 				</moleculetype>
 
 				<moleculetype id="2" name="1CLJ_c2">
-					<site type="LJ126" id="1" >
+					<site type="LJ126" id="1" name="LJfull">
 						<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 						<mass>2</mass>
 						<sigma>1</sigma>

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -46,7 +46,7 @@
       <components>
           <moleculetype id="1" >
             <coord_base>principal_axes</coord_base>
-            <site type="LJ126" id="1" >
+            <site type="LJ126" id="1" name="C">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>12.00</mass>
               <sigma>2.900109</sigma>

--- a/examples/comparison.xml
+++ b/examples/comparison.xml
@@ -24,7 +24,7 @@
       </domain>
       <components>
         <moleculetype id="1" name="Test">
-          <site type="LJ126" id="1" >
+          <site type="LJ126" id="1" name="LJfull">
             <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>

--- a/examples/force-exchange/cube-dense-fs.xml
+++ b/examples/force-exchange/cube-dense-fs.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>1.0</mass>
               <sigma>1.0</sigma>

--- a/examples/force-exchange/cube-dense-hs.xml
+++ b/examples/force-exchange/cube-dense-hs.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>1.0</mass>
               <sigma>1.0</sigma>

--- a/examples/force-exchange/cube-dense-mp.xml
+++ b/examples/force-exchange/cube-dense-mp.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>1.0</mass>
               <sigma>1.0</sigma>

--- a/examples/force-exchange/cube-dense-nt.xml
+++ b/examples/force-exchange/cube-dense-nt.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>1.0</mass>
               <sigma>1.0</sigma>

--- a/examples/force-exchange/testcube-dense-fs.xml
+++ b/examples/force-exchange/testcube-dense-fs.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>1.0</mass>
               <sigma>1.0</sigma>

--- a/examples/force-exchange/testcube-dense-hs.xml
+++ b/examples/force-exchange/testcube-dense-hs.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>1.0</mass>
               <sigma>1.0</sigma>

--- a/examples/force-exchange/testcube-dense-mp.xml
+++ b/examples/force-exchange/testcube-dense-mp.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>1.0</mass>
               <sigma>1.0</sigma>

--- a/examples/general-plugins/CavityWriter/CavityWriterTest.xml
+++ b/examples/general-plugins/CavityWriter/CavityWriterTest.xml
@@ -40,8 +40,8 @@ It detects the less dense space around the dense drop as a cavity.
 			</domain>
 			
 			<components>
-		        <moleculetype id="1" name="Test">
-		    	    <site type="LJ126" id="1" >
+		        <moleculetype id="1" name="1CLJ">
+		    	    <site type="LJ126" id="1" name="LJTS">
 		  	        	<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 		  	        	<mass>1.0</mass>
 		  	        	<sigma>1.0</sigma>

--- a/examples/general-plugins/RegionSampling/case01/components.xml
+++ b/examples/general-plugins/RegionSampling/case01/components.xml
@@ -3,7 +3,7 @@
 <components>
 
 	<moleculetype id="1" name="Argon_ts">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="Ar">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>39.948</mass>
 			<sigma>3.3916</sigma>

--- a/examples/general-plugins/SpatialProfiles/CartesianSampling/CartesianSampling.xml
+++ b/examples/general-plugins/SpatialProfiles/CartesianSampling/CartesianSampling.xml
@@ -23,8 +23,8 @@
         <lz>50.0</lz>
       </domain>
       <components>
-        <moleculetype id="1" name="Test">
-          <site type="LJ126" id="1" >
+        <moleculetype id="1" name="LJTS">
+          <site type="LJ126" id="1" name="LJTS">
             <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>

--- a/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
+++ b/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
@@ -30,8 +30,8 @@
 			</domain>
 			
 			<components>
-		        <moleculetype id="1" name="Test">
-		    	    <site type="LJ126" id="1" >
+		        <moleculetype id="1" name="LJTS">
+		    	    <site type="LJ126" id="1" name="LJTS">
 		  	        	<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 		  	        	<mass>1.0</mass>
 		  	        	<sigma>1.0</sigma>

--- a/examples/general-plugins/components-1clj.xml
+++ b/examples/general-plugins/components-1clj.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="1CLJ">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJfull">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>

--- a/examples/in-memory-checkpointing/components.xml
+++ b/examples/in-memory-checkpointing/components.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="1CLJ">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJfull">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>

--- a/examples/insitu-test/components.xml
+++ b/examples/insitu-test/components.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="1CLJ">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJfull">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>

--- a/examples/resilience-test/components.xml
+++ b/examples/resilience-test/components.xml
@@ -2,7 +2,7 @@
 <components version="20100525" >
 
 	<moleculetype id="1" name="1CLJ">
-		<site type="LJ126" id="1" >
+		<site type="LJ126" id="1" name="LJfull">
 			<coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
 			<mass>1.0</mass>
 			<sigma>1.0</sigma>

--- a/examples/surface-tension_LRC/2CLJ/components_2clj.xml
+++ b/examples/surface-tension_LRC/2CLJ/components_2clj.xml
@@ -8,14 +8,14 @@
     </refunits>
 
     <moleculetype id="1" name="2CLJ">
-        <site type="LJ126" id="1" >
+        <site type="LJ126" id="1" name="LJfull">
             <coords> <x>0.0</x> <y>0.0</y> <z>-0.5</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
             <shifted>false</shifted>
         </site>
-        <site type="LJ126" id="2" >
+        <site type="LJ126" id="2" name="LJfull">
             <coords> <x>0.0</x> <y>0.0</y> <z>0.5</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>

--- a/examples/surface-tension_LRC/C6H12/components_C6H12_dfg.xml
+++ b/examples/surface-tension_LRC/C6H12/components_C6H12_dfg.xml
@@ -8,37 +8,37 @@
     </refunits>
 
  <moleculetype id="1" name="C6H12_dfg - normalized pm-file">
-    <site type="LJ126" id="1">
+    <site type="LJ126" id="1" name="CH2">
      <coords> <x>-0.2896765250</x> <y>1.190491767</y> <z>-1.368040355</z> </coords>
      <sigma>3.497</sigma>
      <epsilon>87.009</epsilon>
      <mass>14.027</mass>
     </site>
-    <site type="LJ126" id="2">
+    <site type="LJ126" id="2" name="CH2">
      <coords> <x>0.2896765480</x> <y>-0.5895116071</y> <z>-1.715016498</z> </coords>
      <sigma>3.497</sigma>
      <epsilon>87.009</epsilon>
      <mass>14.027</mass>
     </site>
-    <site type="LJ126" id="3">
+    <site type="LJ126" id="3" name="CH2">
      <coords> <x>-0.2896768241</x> <y>-1.780002817</y> <z>-0.3469760056</z> </coords>
      <sigma>3.497</sigma>
      <epsilon>87.009</epsilon>
      <mass>14.027</mass>
     </site>
-    <site type="LJ126" id="4">
+    <site type="LJ126" id="4" name="CH2">
      <coords> <x>0.2896768317</x> <y>-1.190491517</y> <z>1.368040090</z> </coords>
      <sigma>3.497</sigma>
      <epsilon>87.009</epsilon>
      <mass>14.027</mass>
     </site>
-    <site type="LJ126" id="5">
+    <site type="LJ126" id="5" name="CH2">
      <coords> <x>-0.2896767127</x> <y>0.5895116065</y> <z>1.715016734</z> </coords>
      <sigma>3.497</sigma>
      <epsilon>87.009</epsilon>
      <mass>14.027</mass>
     </site>
-    <site type="LJ126" id="6">
+    <site type="LJ126" id="6" name="CH2">
      <coords> <x>0.2896766821</x> <y>1.780002567</y> <z>0.3469760343</z> </coords>
      <sigma>3.497</sigma>
      <epsilon>87.009</epsilon>

--- a/src/molecules/Component.h
+++ b/src/molecules/Component.h
@@ -19,10 +19,10 @@ public:
 	 *
 	 * The following xml object structure is handled by this method:
 	 * \code{.xml}
-	   <component id=INT name="STRING">
-	     <site type="LJ126|Charge|Dipole|Quadrupole"> <!-- see Site class documentation --> </site>
+	   <moleculetype id=UINT name="STRING">
+	     <site type="LJ126|Charge|Dipole|Quadrupole" id="UINT" name="STRING"> <!-- see Site class documentation --> </site>
 	     <momentsofinertia> <Ixx>DOUBLE</Ixx> <Iyy>DOUBLE</Iyy> <Izz>DOUBLE</Izz> </momentsofinertia>
-	   </component>
+	   </moleculetype>
 	   \endcode
 	 */
 	void readXML(XMLfileUnits& xmlconfig);

--- a/src/molecules/Site.h
+++ b/src/molecules/Site.h
@@ -44,7 +44,7 @@ public:
 	 *
 	 * The following xml object structure is handled by this method:
 	 * \code{.xml}
-	   <site>
+	   <site type="LJ126|Charge|Dipole|Quadrupole" id="UINT" name="STRING">
 	     <coords> <x>DOUBLE</x> <y>DOUBLE</y> <z>DOUBLE</z> </coords>
 	     <mass>DOUBLE</mass>
 	   </site>

--- a/validation/validationInput/LRC_planar_2020/components_2clj.xml
+++ b/validation/validationInput/LRC_planar_2020/components_2clj.xml
@@ -8,14 +8,14 @@
     </refunits>
 
     <moleculetype id="1" name="2CLJ">
-        <site type="LJ126" id="1" >
+        <site type="LJ126" id="1" name="LJfull">
             <coords> <x>0.0</x> <y>0.0</y> <z>-0.5</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>
             <epsilon>1.0</epsilon>
             <shifted>false</shifted>
         </site>
-        <site type="LJ126" id="2" >
+        <site type="LJ126" id="2" name="LJfull">
             <coords> <x>0.0</x> <y>0.0</y> <z>0.5</z> </coords>
             <mass>1.0</mass>
             <sigma>1.0</sigma>

--- a/validation/validationInput/simple-lj-direct-mp/config.xml
+++ b/validation/validationInput/simple-lj-direct-mp/config.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>10000.0</mass>
               <sigma>1.0</sigma>

--- a/validation/validationInput/simple-lj-direct/config.xml
+++ b/validation/validationInput/simple-lj-direct/config.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>10000.0</mass>
               <sigma>1.0</sigma>

--- a/validation/validationInput/simple-lj-mp/config.xml
+++ b/validation/validationInput/simple-lj-mp/config.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>10000.0</mass>
               <sigma>1.0</sigma>

--- a/validation/validationInput/simple-lj/config.xml
+++ b/validation/validationInput/simple-lj/config.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>10000.0</mass>
               <sigma>1.0</sigma>

--- a/validation/validationInput/simple-lj_kdd/config.xml
+++ b/validation/validationInput/simple-lj_kdd/config.xml
@@ -24,8 +24,8 @@
       </domain>
 
       <components>
-          <moleculetype id="1" name="Argon">
-            <site type="LJ126" id="1" >
+          <moleculetype id="1" name="1CLJ">
+            <site type="LJ126" id="1" name="LJfull">
               <coords> <x>0.0</x> <y>0.0</y> <z>0.0</z> </coords>
               <mass>10000.0</mass>
               <sigma>1.0</sigma>

--- a/validation/validationInput/surface-tension_LRC_CO2_Merker_280/config.xml
+++ b/validation/validationInput/surface-tension_LRC_CO2_Merker_280/config.xml
@@ -30,19 +30,19 @@
 
       <components>
        <moleculetype id="1" name="co2_merker" >
-    <site type="LJ126" id="1" >
+    <site type="LJ126" id="1" name="O">
       <coords> <x>0.0</x> <y>0.0</y> <z>-2.4319</z> </coords>
       <mass>0.015999</mass>
       <sigma>5.62288</sigma>
       <epsilon>0.000318243</epsilon>
     </site>
-    <site type="LJ126" id="2" >
+    <site type="LJ126" id="2" name="O">
       <coords> <x>0.0</x> <y>0.0</y> <z>2.4319</z> </coords>
       <mass>0.015999</mass>
       <sigma>5.62288</sigma>
       <epsilon>0.000318243</epsilon>
     </site>
-    <site type="LJ126" id="3" >
+    <site type="LJ126" id="3" name="C">
       <coords> <x></x> <y></y> <z></z> </coords>
       <mass>0.012</mass>
       <sigma>5.31712</sigma>


### PR DESCRIPTION
# Description

Together with ADIOS (PR #192), the option to set a name for the single sites were introduced.
This name should be something like the element or functional group which is modeled by the respective site.
It could later be used for some kind of automated selection of the [color](https://en.wikipedia.org/wiki/CPK_coloring) during visualization.

With issue #310 it was revealed that the name was not handled correctly if not set in the xml file. After fixing this bug, a warning is now printed if the name is not given. To get rid of these warnings, this PR introduces site names in the xml files if possible.
In some cases, it is not really feasible to set meaningful site names, e.g. for the Stoll CO2 model, which simplifies the 3 elements by just 2 sites. Therefore, one site does not represent a single element (e.g. C or O) or a functional group (e.g. methyl or methylene group).

Furthermore, some documentation regarding the xml structure of the sites was added.

