### PR TITLE
Set initial simulation time step earlier

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -691,7 +691,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 
 	// _simulationTime might be updated by readers -> also update _initSimulation
 	_simstep = _initSimulation = (unsigned long) round(_simulationTime / _integrator->getTimestepLength() );
-	Log::global_log->info() << "Set initial time step to start from to " << _initSimulation << std::endl;
+	Log::global_log->info() << "Set initial time step to " << _initSimulation << std::endl;
 }
 
 

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -690,7 +690,10 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 	xmlconfig.changecurrentnode(oldpath);
 
 	// _simulationTime might be updated by readers -> also update _initSimulation
-	_simstep = _initSimulation = (unsigned long) round(_simulationTime / _integrator->getTimestepLength() );
+	// In theory, the division of the physical time (_simulationTime) and the time step width,
+	// should give a whole number. However, due to numerical errors, the result of the
+	// division must be rounded
+	_simstep = _initSimulation = static_cast<unsigned long>(std::round(_simulationTime / _integrator->getTimestepLength()));
 	Log::global_log->info() << "Set initial time step to " << _initSimulation << std::endl;
 }
 


### PR DESCRIPTION
# Description

Until now, the initial time step is set at the end of `Simulation::prepare_start()`. At this point, the plugins are already initialized which could lead to a wrong initializations of them. An example is the MMPLDWriter, which uses the number of simulation steps to calculate the file header of the .mmpld files during initialization.

The simulationTime (physical time, not time step) can be either changed by the config (`currenttime`) or the checkpoints. The calculation of the initial time step is now moved to right after the simulationTime was changed the last time before the actual simulation starts.


Test:
- [x] Run the [surface tension example](https://github.com/ls1mardyn/ls1-mardyn/blob/baff96a5401d3987de48d122864fd138fddfe827/examples/surface-tension_LRC/2CLJ/vle/T1-508/run02/config.xml#L1) with MMPLDWriter. Observe and compare mmpld file with [mmpld tool](https://github.com/UniStuttgart-VISUS/megamol/blob/2749f638928ad034fa648e14992458bf4c379240/utils/MMPLD/mmpldinfo.py).

Result of test:
- master: `warning: dead data trailing header: position after reading frame table (156) is not the start of the first frame (8156)`
- This PR: No warnings/errors