### PR TITLE
Revision of some python scripts in ppls1

### DIFF
--- a/tools/ppls1/ppls1/exp/chp.py
+++ b/tools/ppls1/ppls1/exp/chp.py
@@ -85,12 +85,8 @@ def exp_chp_bin_DF(fname, chp, append=False):
         writeMode = 'wb'
     
     with open(fname, writeMode) as f:
-        ba=bytearray()
-        for pi, row in chp.iterrows():
-            ba.extend(pack('<QIddddddddddddd',chp['pid'][pi],chp['cid'][pi],chp['rx'][pi],chp['ry'][pi],chp['rz'][pi],
-                                              chp['vx'][pi], chp['vy'][pi], chp['vz'][pi],chp['q0'][pi],chp['q1'][pi],
-                                              chp['q2'][pi], chp['q3'][pi], chp['Dx'][pi],chp['Dy'][pi],chp['Dz'][pi] ))
-        f.write(ba)
+        records = chp.to_records(index=False)
+        records.tofile(f)
         f.close()
 
 #%% Export ASCII ls1 checkpoint (representation: data frame)

--- a/tools/ppls1/ppls1/fluids/shear_visco.py
+++ b/tools/ppls1/ppls1/fluids/shear_visco.py
@@ -251,8 +251,8 @@ if __name__ == '__main__':
     print('Eta Galliero: '+str(eta_galliero(T,rho)))
 
     fluid = 'Argon'
-    T = 200
-    rho = 10
+    T = 200.0
+    rho = 10.0
     print(f'Running test with {fluid} ...')
     print('Eta Lemmon:     '+str(eta_lemmon(T,rho,fluid)))
-    print('Eta Lemmon Lit: 25.5662')
+    print('Eta Lemmon Lit: 25.5662')  # Value from Table V in Lemmon2004

--- a/tools/ppls1/ppls1/fluids/therm_cond.py
+++ b/tools/ppls1/ppls1/fluids/therm_cond.py
@@ -35,23 +35,6 @@ def lambda_lemmon(T,rho,fluid,units='reduced'):
         #eta0=(0.168729283*np.sqrt(T)) / (sig**2*Omega(Tstar,fluid))  # Monika
         return eta0 #8.18940 #22.7241 #8.18940 #eta0
 
-    def etar(tau,delta,fluid):
-        summe=0
-        for ri in range(0,len(tab3[fluid])):
-            i,Ni,ti,di,li=tab3[fluid]['i'][ri],tab3[fluid]['Ni'][ri],tab3[fluid]['ti'][ri],tab3[fluid]['di'][ri],tab3[fluid]['li'][ri]
-            if li==0:
-                gamma=0
-            else:
-                gamma=1
-            summe+=Ni*tau**ti*delta**di*np.exp(-gamma*delta**li)
-        return summe
-
-    def eta(T,rho,fluid):
-        Tc,rhoc=tab1[fluid][0],tab1[fluid][1]
-        tau,delta=Tc/T,rho/rhoc
-        eta=eta0(T,fluid)+etar(tau,delta,fluid)
-        return eta
-
     def lam0(T,fluid):
         Tc=tab1[fluid][0]
         tau=Tc/T
@@ -272,28 +255,6 @@ def lambda_fernandez(T,rho,L,QQ):
             lambda_f = lambda_f + coeff[i,j]*(T**(i))*(rho**(j))
     return lambda_f
 
-#%% Get thermal conductivity of LJTS fluid with data/fit by Guevara/Homes
-def lambda_guevara_homes(T,rho):
-    '''
-    Get thermal conductivity of LJTS fluid (Guevara/Homes)
-
-    :param float T: Temperature
-    :param float rho: Density
-    :return: float lambda_l: Thermal conductivity
-    '''
-    
-    p00=-364.1
-    p10=-1003
-    p01=2292
-    p20=-21.11
-    p11=2238
-    p02=-3751
-    p30=601.2
-    p21=-1482
-    p12=13.63
-    p03=1494
-    lambda_gh = p00 + p10*T + p01*rho + p20*T**2 + p11*T*rho + p02*rho**2 + p30*T**3 + p21*T**2*rho + p12*T*rho**2 + p03*rho**3
-    return lambda_gh
 
 #%% Tests
 if __name__ == '__main__':
@@ -303,4 +264,10 @@ if __name__ == '__main__':
     print(f'Running test with {fluid} ...')
     print('Lambda Lemmon:         '+str(lambda_lemmon(T,rho,fluid)))
     print('Lambda Lautenschlager: '+str(lambda_lauten(T,rho)))
-    print('Lambda Guevara/Homes:  '+str(lambda_guevara_homes(T,rho)))
+
+    fluid = 'Argon'
+    T = 100.0
+    rho = 33.0
+    print(f'Running test with {fluid} ...')
+    print('Eta Lemmon:     '+str(lambda_lemmon(T,rho,fluid)))
+    print('Eta Lemmon Lit: 111.266')  # Value from Table V in Lemmon2004

--- a/tools/ppls1/ppls1/fluids/therm_cond.py
+++ b/tools/ppls1/ppls1/fluids/therm_cond.py
@@ -35,6 +35,23 @@ def lambda_lemmon(T,rho,fluid,units='reduced'):
         #eta0=(0.168729283*np.sqrt(T)) / (sig**2*Omega(Tstar,fluid))  # Monika
         return eta0 #8.18940 #22.7241 #8.18940 #eta0
 
+    def etar(tau,delta,fluid):
+        summe=0
+        for ri in range(0,len(tab3[fluid])):
+            i,Ni,ti,di,li=tab3[fluid]['i'][ri],tab3[fluid]['Ni'][ri],tab3[fluid]['ti'][ri],tab3[fluid]['di'][ri],tab3[fluid]['li'][ri]
+            if li==0:
+                gamma=0
+            else:
+                gamma=1
+            summe+=Ni*tau**ti*delta**di*np.exp(-gamma*delta**li)
+        return summe
+
+    def eta(T,rho,fluid):
+        Tc,rhoc=tab1[fluid][0],tab1[fluid][1]
+        tau,delta=Tc/T,rho/rhoc
+        eta=eta0(T,fluid)+etar(tau,delta,fluid)
+        return eta
+
     def lam0(T,fluid):
         Tc=tab1[fluid][0]
         tau=Tc/T
@@ -139,6 +156,7 @@ def lambda_lemmon(T,rho,fluid,units='reduced'):
     
     na=6.02214076e23
     kb=1.380649e-23
+    u_mass=1.660539e-27
     
     if fluid == 'LJTS':
         fluid = 'Argon'
@@ -167,8 +185,8 @@ def lambda_lemmon(T,rho,fluid,units='reduced'):
         T = T/tc*150.687
         rho = rho/sig**3*1e30/na*1e-3
         # refTime, refLambda: tref, lref
-        tref=sig*1e-10*np.sqrt(mass*1.660538e-27/(kb*eps))
-        lref=1e3*kb/(sig*1e-10*tref) # [mW/m-K]
+        tref=sig*1e-10*np.sqrt(mass*u_mass/(kb*eps))
+        lref=1e3*kb/(sig*1e-10*tref) # Lemmon gives [mW/m-K] (see Table V in Paper)
     elif units == 'SI':
         pass
     else:
@@ -277,13 +295,12 @@ def lambda_guevara_homes(T,rho):
     lambda_gh = p00 + p10*T + p01*rho + p20*T**2 + p11*T*rho + p02*rho**2 + p30*T**3 + p21*T**2*rho + p12*T*rho**2 + p03*rho**3
     return lambda_gh
 
+#%% Tests
 if __name__ == '__main__':
-    print('Running test with LJTS ...')
     fluid = 'LJTS'
-    T = 0.8
-    rho = 0.55
-
+    T = 0.9
+    rho = 0.75
+    print(f'Running test with {fluid} ...')
     print('Lambda Lemmon:         '+str(lambda_lemmon(T,rho,fluid)))
     print('Lambda Lautenschlager: '+str(lambda_lauten(T,rho)))
     print('Lambda Guevara/Homes:  '+str(lambda_guevara_homes(T,rho)))
-


### PR DESCRIPTION
## Description

Some of the helper python scripts are updated in this PR.

1. Use `records` instead of `bytearray` in export of dataframe to checkpoint. This is a major speedup for checkpoints with a large number of particles.
2. Fix in calculation of shear viscosity.
3. Add another method to get shear viscosity of the LJfull fluid.
4. Add further tests of the calculation of the shear viscosity using different fluids.
5. Add test of the calculation of the thermal conductivity using argon.
6. Remove method to get thermal conductivity as it has a low accuracy (see output of test).
