### PR TITLE
Change 0/1 to true/false in xml configs

### DIFF
--- a/examples/DropletCollision/templates/tpl_2_dropletSingle.xml
+++ b/examples/DropletCollision/templates/tpl_2_dropletSingle.xml
@@ -137,9 +137,9 @@
 	</plugin>
 		
 	<plugin name="COMaligner">
-		<x>1</x>
-		<y>1</y>
-		<z>1</z>
+		<x>true</x>
+		<y>true</y>
+		<z>true</z>
 		<interval>10</interval>
 		<correctionFactor>.5</correctionFactor>
 	</plugin>

--- a/examples/Evaporation/stationary/sim02/run01/config.xml
+++ b/examples/Evaporation/stationary/sim02/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>
@@ -284,7 +284,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -303,7 +303,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="VDF" single_component="1">
+				<sampling type="VDF" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>

--- a/examples/Evaporation/stationary/sim02/run02/config.xml
+++ b/examples/Evaporation/stationary/sim02/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>
@@ -262,7 +262,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>10000</frequency>
@@ -281,7 +281,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="VDF" single_component="1">
+				<sampling type="VDF" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>10000</frequency>

--- a/examples/Evaporation/stationary/sim02/run03/config.xml
+++ b/examples/Evaporation/stationary/sim02/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>
@@ -273,7 +273,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>10000</frequency>
@@ -292,7 +292,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="VDF" single_component="1">
+				<sampling type="VDF" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>10000</frequency>

--- a/examples/Evaporation/stationary/sim03/run01/config.xml
+++ b/examples/Evaporation/stationary/sim03/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>
@@ -284,7 +284,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -303,7 +303,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="VDF" single_component="1">
+				<sampling type="VDF" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>

--- a/examples/Evaporation/stationary/sim03/run02/config.xml
+++ b/examples/Evaporation/stationary/sim03/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>
@@ -262,7 +262,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>10000</frequency>
@@ -281,7 +281,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="VDF" single_component="1">
+				<sampling type="VDF" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>10000</frequency>

--- a/examples/Evaporation/stationary/sim03/run03/config.xml
+++ b/examples/Evaporation/stationary/sim03/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>
@@ -273,7 +273,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>10000</frequency>
@@ -292,7 +292,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="VDF" single_component="1">
+				<sampling type="VDF" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>10000</frequency>

--- a/examples/FMM/config.xml
+++ b/examples/FMM/config.xml
@@ -64,7 +64,7 @@
 			<orderOfExpansions>10</orderOfExpansions>
 			<LJCellSubdivisionFactor>1</LJCellSubdivisionFactor>
 			<adaptiveContainer>false</adaptiveContainer>
-			<systemIsPeriodic>1</systemIsPeriodic>
+			<systemIsPeriodic>true</systemIsPeriodic>
 	  </electrostatic>
 
 	  <!-- TODO: we will probably want to disable ReactionField, when FMM is used?

--- a/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_220K/vle/run01/config.xml
+++ b/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_220K/vle/run01/config.xml
@@ -60,7 +60,7 @@
       </electrostatic>
       <longrange type="planar">
         <slabs>1200</slabs>
-        <smooth>0</smooth>
+        <smooth>false</smooth>
         <frequency>10</frequency>
         <writecontrol>
           <start>10000</start>

--- a/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_242-15K/vle/run01/config.xml
+++ b/examples/Generators/ReplicaGenerator/heterogeneous/Standard-VLE/CO2_Merker_242-15K/vle/run01/config.xml
@@ -60,7 +60,7 @@
       </electrostatic>
       <longrange type="planar">
         <slabs>240</slabs>
-        <smooth>0</smooth>
+        <smooth>false</smooth>
         <frequency>10</frequency>
         <writecontrol>
           <start>10000</start>

--- a/examples/Injection/liq/sim01/run01/config.xml
+++ b/examples/Injection/liq/sim01/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/Injection/liq/sim01/run02/config.xml
+++ b/examples/Injection/liq/sim01/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/Injection/liq/sim02/run01/config.xml
+++ b/examples/Injection/liq/sim02/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/Injection/liq/sim02/run02/config.xml
+++ b/examples/Injection/liq/sim02/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/Injection/nemd/sim01/run02/config.xml
+++ b/examples/Injection/nemd/sim01/run02/config.xml
@@ -9,7 +9,7 @@
 
 	<simulation type="MD" >
 		<options>
-			<option name="refreshIDs">1</option>
+			<option name="refreshIDs">true</option>
 		</options>
 		
 		<integrator type="Leapfrog" >

--- a/examples/Injection/nemd/sim02/run02/config.xml
+++ b/examples/Injection/nemd/sim02/run02/config.xml
@@ -9,7 +9,7 @@
 
 	<simulation type="MD" >
 		<options>
-			<option name="refreshIDs">1</option>
+			<option name="refreshIDs">true</option>
 		</options>
 		
 		<integrator type="Leapfrog" >

--- a/examples/general-plugins/CavityWriter/CavityWriterTest.xml
+++ b/examples/general-plugins/CavityWriter/CavityWriterTest.xml
@@ -141,9 +141,9 @@ It detects the less dense space around the dense drop as a cavity.
 
 		<!-- CENTER OF MASS ALIGNMENT  --> 
 		<plugin name="COMaligner" enabled="1">
-			<x>1</x>
-			<y>0</y>
-			<z>1</z>
+			<x>true</x>
+			<y>false</y>
+			<z>true</z>
 			<interval>10</interval>
 			<correctionFactor>.5</correctionFactor>
 		</plugin>

--- a/examples/general-plugins/CavityWriter/CavityWriterTest.xml
+++ b/examples/general-plugins/CavityWriter/CavityWriterTest.xml
@@ -133,14 +133,14 @@ It detects the less dense space around the dense drop as a cavity.
 		
 		<!-- VTK OUTPUT -->
 		<output>
-	      <outputplugin name="VTKMoleculeWriter" enabled="0">
+	      <outputplugin name="VTKMoleculeWriter" enabled="no">
 	        <outputprefix>vtkOutput</outputprefix>
 	        <writefrequency>100</writefrequency>
 	      </outputplugin>
    		</output>
 
 		<!-- CENTER OF MASS ALIGNMENT  --> 
-		<plugin name="COMaligner" enabled="1">
+		<plugin name="COMaligner" enabled="yes">
 			<x>true</x>
 			<y>false</y>
 			<z>true</z>
@@ -149,7 +149,7 @@ It detects the less dense space around the dense drop as a cavity.
 		</plugin>
 
 	    <!-- KARTESIAN/CYLINDER PROFILE -->
-	    <plugin name="SpatialProfile" enabled="0">
+	    <plugin name="SpatialProfile" enabled="no">
 	      <mode>cylinder</mode>
 	      <x>1</x>
 	      <y>20</y>
@@ -172,7 +172,7 @@ It detects the less dense space around the dense drop as a cavity.
 	      </profiles>
 	    </plugin>
 
-	    <plugin name="CavityWriter" enabled="1">
+	    <plugin name="CavityWriter" enabled="yes">
 	    	<outputprefix>drop_cavity.</outputprefix>
 	    	<writefrequency>10</writefrequency>
 	    	<componentid>0</componentid>

--- a/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
+++ b/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
@@ -131,9 +131,9 @@
 
 		<!-- CENTER OF MASS ALIGNMENT  --> 
 		<plugin name="COMaligner">
-			<x>1</x>
-			<y>0</y>
-			<z>1</z>
+			<x>true</x>
+			<y>false</y>
+			<z>true</z>
 			<interval>100</interval>
 			<correctionFactor>.5</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/2CLJ/liq/T0-979/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T0-979/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.000182367</timestep>

--- a/examples/surface-tension_LRC/2CLJ/liq/T0-979/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T0-979/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/2CLJ/liq/T0-979/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T0-979/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-508/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-508/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.000182367</timestep>

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-508/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-508/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-508/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-508/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-691/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-691/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.000182367</timestep>

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-691/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-691/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-691/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-691/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/2CLJ/vle/T0-979/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T0-979/run01/config.xml
@@ -105,7 +105,7 @@
 			
 			<longrange type="planar">
 				<slabs>400</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -201,7 +201,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -236,9 +236,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/2CLJ/vle/T0-979/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T0-979/run02/config.xml
@@ -69,7 +69,7 @@
 			
 			<longrange type="planar">
 				<slabs>400</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -165,7 +165,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -200,9 +200,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/2CLJ/vle/T0-979/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T0-979/run03/config.xml
@@ -68,7 +68,7 @@
 			
 			<longrange type="planar">
 				<slabs>400</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -164,7 +164,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -199,9 +199,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-508/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-508/run01/config.xml
@@ -105,7 +105,7 @@
 			
 			<longrange type="planar">
 				<slabs>400</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -201,7 +201,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -236,9 +236,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-508/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-508/run02/config.xml
@@ -69,7 +69,7 @@
 			
 			<longrange type="planar">
 				<slabs>400</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -165,7 +165,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -200,9 +200,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-508/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-508/run03/config.xml
@@ -79,7 +79,7 @@
 			
 			<longrange type="planar">
 				<slabs>400</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -175,7 +175,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -210,9 +210,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-691/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-691/run01/config.xml
@@ -105,7 +105,7 @@
 			
 			<longrange type="planar">
 				<slabs>400</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -201,7 +201,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -236,9 +236,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-691/run02/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-691/run02/config.xml
@@ -69,7 +69,7 @@
 			
 			<longrange type="planar">
 				<slabs>400</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -165,7 +165,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -200,9 +200,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/2CLJ/vle/T1-691/run03/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/vle/T1-691/run03/config.xml
@@ -79,7 +79,7 @@
 			
 			<longrange type="planar">
 				<slabs>400</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -175,7 +175,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -210,9 +210,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/C6H12/liq/330K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/330K/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.000182367</timestep>

--- a/examples/surface-tension_LRC/C6H12/liq/330K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/330K/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/C6H12/liq/330K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/330K/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/C6H12/liq/415K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/415K/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.000182367</timestep>

--- a/examples/surface-tension_LRC/C6H12/liq/415K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/415K/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/C6H12/liq/415K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/415K/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/C6H12/liq/500K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/500K/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.000182367</timestep>

--- a/examples/surface-tension_LRC/C6H12/liq/500K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/500K/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/C6H12/liq/500K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/500K/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/C6H12/vle/330K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/330K/run02/config.xml
@@ -69,7 +69,7 @@
 			
 			<longrange type="planar">
 				<slabs>200</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -165,7 +165,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -200,9 +200,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/C6H12/vle/330K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/330K/run03/config.xml
@@ -79,7 +79,7 @@
 			
 			<longrange type="planar">
 				<slabs>200</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -175,7 +175,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -210,9 +210,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/C6H12/vle/415K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/415K/run02/config.xml
@@ -69,7 +69,7 @@
 			
 			<longrange type="planar">
 				<slabs>200</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -165,7 +165,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -200,9 +200,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/C6H12/vle/415K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/415K/run03/config.xml
@@ -79,7 +79,7 @@
 			
 			<longrange type="planar">
 				<slabs>200</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -175,7 +175,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -210,9 +210,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/C6H12/vle/500K/run02/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/500K/run02/config.xml
@@ -69,7 +69,7 @@
 			
 			<longrange type="planar">
 				<slabs>200</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -165,7 +165,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -200,9 +200,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/C6H12/vle/500K/run03/config.xml
+++ b/examples/surface-tension_LRC/C6H12/vle/500K/run03/config.xml
@@ -79,7 +79,7 @@
 			
 			<longrange type="planar">
 				<slabs>200</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -175,7 +175,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -210,9 +210,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/220K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/220K/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/220K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/220K/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/220K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/220K/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/250K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/250K/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/250K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/250K/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/250K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/250K/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/280K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/280K/run01/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/280K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/280K/run02/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/280K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/280K/run03/config.xml
@@ -8,7 +8,7 @@
 	</refunits>
 
 	<simulation type="MD" >
-		<options> <option name="refreshIDs">1</option> </options>
+		<options> <option name="refreshIDs">true</option> </options>
 		
 		<integrator type="Leapfrog" >
 			<timestep unit="reduced" >0.00182367</timestep>

--- a/examples/surface-tension_LRC/CO2_Merker/vle/220K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/220K/run02/config.xml
@@ -69,7 +69,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -165,7 +165,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -200,9 +200,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/CO2_Merker/vle/220K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/220K/run03/config.xml
@@ -79,7 +79,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -175,7 +175,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -210,9 +210,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/CO2_Merker/vle/250K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/250K/run02/config.xml
@@ -69,7 +69,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -165,7 +165,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -200,9 +200,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/CO2_Merker/vle/250K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/250K/run03/config.xml
@@ -79,7 +79,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -175,7 +175,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -210,9 +210,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/CO2_Merker/vle/280K/run02/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/280K/run02/config.xml
@@ -69,7 +69,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -165,7 +165,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -200,9 +200,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/examples/surface-tension_LRC/CO2_Merker/vle/280K/run03/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/vle/280K/run03/config.xml
@@ -79,7 +79,7 @@
 			
 			<longrange type="planar">
 				<slabs>300</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -175,7 +175,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -210,9 +210,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/src/io/CavityWriter.h
+++ b/src/io/CavityWriter.h
@@ -28,7 +28,7 @@ public:
      *	for non-overlapping coverage: radius*N_xyz = domainSize_xyz<br>
      *	<br>
      * \code{.xml}
-     * <plugin name="CavityWriter" enabled="1">
+     * <plugin name="CavityWriter" enabled="yes">
                 <writefrequency>10</writefrequency>
                 <componentid>0</componentid>
                 <componentid>1</componentid>

--- a/src/plugins/NEMD/RegionSampling.h
+++ b/src/plugins/NEMD/RegionSampling.h
@@ -336,7 +336,7 @@ public:
 				<ucx>FLOAT</ucx> <ucy refcoordsID="0">FLOAT</ucy> <ucz>FLOAT</ucz>
 			</coords>
 
-			<sampling type="profiles">   <!-- Sampling profiles of various scalar and vector quantities, e.g. temperature, density, force, hydrodynamic velocity -->
+			<sampling type="profiles" single_component="true">   <!-- Sampling profiles of various scalar and vector quantities, e.g. temperature, density, force, hydrodynamic velocity -->
 				<control>
 					<start>INT</start>           <!-- start time step -->
 					<frequency>INT</frequency>   <!-- frequency of writing profiles -->
@@ -348,7 +348,7 @@ public:
 				</subdivision>
 			</sampling>
 
-			<sampling type="VDF" single_component="1">                <!-- Sampling of velocity distribution functions (VDF); Do not differ between components, if single_component is 1-->
+			<sampling type="VDF" single_component="true">                <!-- Sampling of velocity distribution functions (VDF); Do not differ between components, if single_component is 1-->
 				<control>
 					<start>INT</start>           <!-- start time step -->
 					<frequency>INT</frequency>   <!-- frequency of writing profiles -->

--- a/src/utils/xmlfile.cpp
+++ b/src/utils/xmlfile.cpp
@@ -580,8 +580,8 @@ template<> bool XMLfile::Node::getValue<bool>(bool& value) const
 		} else if (v == "FALSE" || v == "NO" || v == "OFF") {
 			value = false;
 		} else {
-			std::cerr << "ERROR parsing \"" << v << "\" to boolean from tag \"<" << name() << ">\" in xml file."
-				<< "Valid values are: true, false, yes, no, on, off. " << std::endl;
+			std::cerr << "ERROR parsing \"" << v << "\" to boolean from tag \"" << name() << "\" in xml file."
+				<< " Valid values are: true, false, yes, no, on, off. " << std::endl;
 			Simulation::exit(1);
 		}
 	}

--- a/validation/validationInput/LRC_planar_2020/config.xml
+++ b/validation/validationInput/LRC_planar_2020/config.xml
@@ -67,7 +67,7 @@
 			
 			<longrange type="planar">
 				<slabs>400</slabs>
-				<smooth>0</smooth>
+				<smooth>false</smooth>
 				<frequency>10</frequency>
 				<writecontrol>
 					<start>10000</start>
@@ -163,7 +163,7 @@
 					<ucx>box</ucx> <ucy refcoordsID="0">box</ucy> <ucz>box</ucz>
 				</coords>
 
-				<sampling type="profiles" single_component="1">
+				<sampling type="profiles" single_component="true">
 					<control>
 						<start>0</start>
 						<frequency>50000</frequency>
@@ -198,9 +198,9 @@
 		</plugin>
 		
 		<plugin name="COMaligner">
-			<x>0</x>
-			<y>1</y>
-			<z>0</z>
+			<x>false</x>
+			<y>true</y>
+			<z>false</z>
 			<interval>1000</interval>
 			<correctionFactor>1.0</correctionFactor>
 		</plugin>

--- a/validation/validationInput/surface-tension_LRC_CO2_Merker_280/config.xml
+++ b/validation/validationInput/surface-tension_LRC_CO2_Merker_280/config.xml
@@ -80,7 +80,7 @@
       
       <longrange type="planar">
         <slabs>500</slabs>
-        <smooth>0</smooth>
+        <smooth>false</smooth>
         <frequency>10</frequency>
         <writecontrol>
           <start>0</start>


### PR DESCRIPTION
# Description

Not all booleans in the configs had been set to true/false with PR #286. This PR fixes the remaining bools in the configs.

Additionally, in the xmlfile.cpp a whitespace is added and `<`/`>` in an error print is removed since also an xml-attribute (e.g. `enable`) can contain a boolean value.

## Related Pull Requests

- #286

## Resolved Issues

- [x] #317

