### PR TITLE
Fixes regarding component ID

### DIFF
--- a/examples/Adsorption/Generator/adsorption.xml
+++ b/examples/Adsorption/Generator/adsorption.xml
@@ -48,7 +48,7 @@
               <lattice system="cubic" centering="face"/>
               <basis>
                 <site>
-                  <componentid>0</componentid>
+                  <componentid>1</componentid>
                   <coordinate>
                     <x>0</x>
                     <y>0</y>

--- a/examples/Adsorption/Generator/adsorption_autopas_default.xml
+++ b/examples/Adsorption/Generator/adsorption_autopas_default.xml
@@ -48,7 +48,7 @@
               <lattice system="cubic" centering="face"/>
               <basis>
                 <site>
-                  <componentid>0</componentid>
+                  <componentid>1</componentid>
                   <coordinate>
                     <x>0</x>
                     <y>0</y>

--- a/examples/Adsorption/Generator/adsorption_autopas_tuning.xml
+++ b/examples/Adsorption/Generator/adsorption_autopas_tuning.xml
@@ -48,7 +48,7 @@
               <lattice system="cubic" centering="face"/>
               <basis>
                 <site>
-                  <componentid>0</componentid>
+                  <componentid>1</componentid>
                   <coordinate>
                     <x>0</x>
                     <y>0</y>

--- a/examples/DropletCoalescence/liq/config_1_generateLiq.xml
+++ b/examples/DropletCoalescence/liq/config_1_generateLiq.xml
@@ -44,7 +44,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/DropletCoalescence/vap/config_3_generateVap.xml
+++ b/examples/DropletCoalescence/vap/config_3_generateVap.xml
@@ -44,7 +44,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/Evaporation/stationary/sim01/run01/config.xml
+++ b/examples/Evaporation/stationary/sim01/run01/config.xml
@@ -44,7 +44,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>1</componentid>
+									<componentid>2</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/liq1/run01/config.xml
+++ b/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/liq1/run01/config.xml
@@ -50,9 +50,9 @@
 													<vec id="b"> <x>0</x> <y>1</y> <z>0</z> </vec>
 													<vec id="c"> <x>0</x> <y>0</y> <z>1</z> </vec>
 											</lattice>
-											<basis>
+											enabled="
 													<site>
-															<componentid>0</componentid>
+															<componentid>1</componentid>
 															<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 													</site>
 											</basis>

--- a/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/liq2/run01/config.xml
+++ b/examples/Generators/MultiObjectGenerator/mixing_isotopic_1CLJ/liq2/run01/config.xml
@@ -52,7 +52,7 @@
 											</lattice>
 											<basis>
 													<site>
-															<componentid>1</componentid>
+															<componentid>2</componentid>
 															<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 													</site>
 											</basis>

--- a/examples/Injection/liq/sim02/run01/config.xml
+++ b/examples/Injection/liq/sim02/run01/config.xml
@@ -46,7 +46,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/Injection/nemd/sim01/run01/config.xml
+++ b/examples/Injection/nemd/sim01/run01/config.xml
@@ -60,7 +60,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>2</componentid>
+									<componentid>3</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/Injection/nemd/sim02/run01/config.xml
+++ b/examples/Injection/nemd/sim02/run01/config.xml
@@ -60,7 +60,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>2</componentid>
+									<componentid>3</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/KDD-vectorization-tuner/one-component/config.xml
+++ b/examples/KDD-vectorization-tuner/one-component/config.xml
@@ -36,7 +36,7 @@
               </lattice>
               <basis>
                 <site>
-                  <componentid>0</componentid>
+                  <componentid>1</componentid>
                   <coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
                 </site>
               </basis>
@@ -58,7 +58,7 @@
               </lattice>
               <basis>
                 <site>
-                  <componentid>0</componentid>
+                  <componentid>1</componentid>
                   <coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
                 </site>
               </basis>

--- a/examples/KDD-vectorization-tuner/two-components/config.xml
+++ b/examples/KDD-vectorization-tuner/two-components/config.xml
@@ -36,7 +36,7 @@
               </lattice>
               <basis>
                 <site>
-                  <componentid>1</componentid>
+                  <componentid>2</componentid>
                   <coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
                 </site>
               </basis>
@@ -58,7 +58,7 @@
               </lattice>
               <basis>
                 <site>
-                  <componentid>0</componentid>
+                  <componentid>1</componentid>
                   <coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
                 </site>
               </basis>

--- a/examples/Mamico-couette/ls1configNoCP.xml
+++ b/examples/Mamico-couette/ls1configNoCP.xml
@@ -45,7 +45,7 @@
 							</lattice>
 							<basis>
 								<site>
-								<componentid>0</componentid>
+								<componentid>1</componentid>
 								<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/SpinodalDecomposition/config_1_genGrid.xml
+++ b/examples/SpinodalDecomposition/config_1_genGrid.xml
@@ -43,7 +43,7 @@
                             </lattice>
                             <basis>
                                 <site>
-                                    <componentid>0</componentid>
+                                    <componentid>1</componentid>
                                     <coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
                                 </site>
                             </basis>

--- a/examples/adios/write/config_mix.xml
+++ b/examples/adios/write/config_mix.xml
@@ -78,7 +78,7 @@
 											</lattice>
 											<basis>
 													<site>
-															<componentid>0</componentid>
+															<componentid>1</componentid>
 															<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 													</site>
 											</basis>
@@ -102,7 +102,7 @@
 											</lattice>
 											<basis>
 													<site>
-															<componentid>1</componentid>
+															<componentid>2</componentid>
 															<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 													</site>
 											</basis>

--- a/examples/general-plugins/CavityWriter/CavityWriterTest.xml
+++ b/examples/general-plugins/CavityWriter/CavityWriterTest.xml
@@ -68,7 +68,7 @@ It detects the less dense space around the dense drop as a cavity.
 											</lattice>
 											<basis>
 													<site>
-															<componentid>0</componentid>
+															<componentid>1</componentid>
 															<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 													</site>
 											</basis>
@@ -92,7 +92,7 @@ It detects the less dense space around the dense drop as a cavity.
 											</lattice>
 											<basis>
 													<site>
-															<componentid>0</componentid>
+															<componentid>1</componentid>
 															<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 													</site>
 											</basis>

--- a/examples/general-plugins/RegionSampling/case01/run01/config.xml
+++ b/examples/general-plugins/RegionSampling/case01/run01/config.xml
@@ -52,7 +52,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
+++ b/examples/general-plugins/SpatialProfiles/CylinderProfileDrop/CylinderOutputDrop.xml
@@ -58,7 +58,7 @@
 											</lattice>
 											<basis>
 													<site>
-															<componentid>0</componentid>
+															<componentid>1</componentid>
 															<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 													</site>
 											</basis>
@@ -82,7 +82,7 @@
 											</lattice>
 											<basis>
 													<site>
-															<componentid>0</componentid>
+															<componentid>1</componentid>
 															<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 													</site>
 											</basis>

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-508/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-508/run01/config.xml
@@ -45,7 +45,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/surface-tension_LRC/2CLJ/liq/T1-691/run01/config.xml
+++ b/examples/surface-tension_LRC/2CLJ/liq/T1-691/run01/config.xml
@@ -45,7 +45,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/surface-tension_LRC/C6H12/liq/330K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/330K/run01/config.xml
@@ -45,7 +45,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/surface-tension_LRC/C6H12/liq/415K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/415K/run01/config.xml
@@ -45,7 +45,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/surface-tension_LRC/C6H12/liq/500K/run01/config.xml
+++ b/examples/surface-tension_LRC/C6H12/liq/500K/run01/config.xml
@@ -45,7 +45,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/220K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/220K/run01/config.xml
@@ -45,7 +45,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/250K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/250K/run01/config.xml
@@ -45,7 +45,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/examples/surface-tension_LRC/CO2_Merker/liq/280K/run01/config.xml
+++ b/examples/surface-tension_LRC/CO2_Merker/liq/280K/run01/config.xml
@@ -45,7 +45,7 @@
 							</lattice>
 							<basis>
 								<site>
-									<componentid>0</componentid>
+									<componentid>1</componentid>
 									<coordinate> <x>0.5</x> <y>0.5</y> <z>0.5</z> </coordinate>
 								</site>
 							</basis>

--- a/src/utils/generator/Basis.cpp
+++ b/src/utils/generator/Basis.cpp
@@ -24,8 +24,17 @@ void Basis::readXML(XMLfileUnits& xmlconfig) {
 		Molecule molecule;
 		xmlconfig.changecurrentnode(siteIter);
 		int componentid;
-		xmlconfig.getNodeValue("componentid", componentid);
-		molecule.setComponent(ensemble->getComponent(componentid));
+		if (xmlconfig.getNodeValue("componentid", componentid)) {
+			const size_t numComps = ensemble->getComponents()->size();
+			if ((componentid < 1) || (componentid > numComps)) {
+				Log::global_log->error() << "[Basis] Specified componentid is invalid. Valid range: 1 <= componentid <= " << numComps << std::endl;
+				Simulation::exit(1);
+			}
+		} else {
+			Log::global_log->error() << "[Basis] No componentid specified. Set <componentid>!" << std::endl;
+			Simulation::exit(1);
+		}
+		molecule.setComponent(ensemble->getComponent(componentid - 1));  // Internally stored in vector starting at index 0
 		double r[3];
 		Coordinate3D sitePosition(xmlconfig, "coordinate");
 		sitePosition.get(r);


### PR DESCRIPTION
# Description

The components are internally stored as a vector. Therefore, the component IDs start with 0. However, in the specification of the components in the xml file, the ID starts with a 1. This leads to a bug in the Basis.cpp class, which doesn't convert the external ID (starting with 1) to the internally used one (starting with 0). This bug was also described in issue #315.
Besides the fix in Basis.cpp, also the specified componentIDs in the xml files were incremented to preserve the simulations' results.

## Resolved Issues

- [x] #315 
