### PR TITLE
Scalable check for duplicated particle IDs

### DIFF
--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -2,7 +2,7 @@
  * DomainDecompBaseMPI.cpp
  *
  *  Created on: Nov 15, 2015
- *	  Author: tchipevn
+ *      Author: tchipevn
  */
 #include <memory>
 #include <algorithm>


### PR DESCRIPTION
# Description

Until now, the check for duplicates does [not really scale](https://github.com/ls1mardyn/ls1-mardyn/blob/b5a132e0c64b833bd05bc6cf8a223315f4d1077b/src/parallel/DomainDecompMPIBase.cpp#L221).
This PR suggests an alternative solution.

Benefits:
- Faster

Downside:
- More memory consumption


## How Has This Been Tested?

- [x] Run simulation with duplicate ID inside/outside of same rank. Use different number of particles (e.g. 1000, 1e6 and 1e8). Check execution time of check.

Execution times of `DomainDecompMPIBase::assertDisjunctivity()` for simulation run with 8 cores on an Intel i9-7940X:
| Number of particles 	| master   	| PR       	|
|---------------------	|----------	|----------	|
| 1000                	| 0.00016  	| 0.00018  	|
| 1e6                 	| 0.270161 	| 0.036375 	|
| 1e8                 	| 72.65190	| 4.7937		|

**Note** that the method in this PR needs more memory compared to the one of the master!