### PR TITLE
Add molecule-wise virial correction

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -565,7 +565,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			{
 				delete _longRangeCorrection;
 				Log::global_log->info() << "Initializing homogeneous LRC." << std::endl;
-				_longRangeCorrection = new Homogeneous(_cutoffRadius, _LJCutoffRadius, _domain, global_simulation);
+				_longRangeCorrection = new Homogeneous(_cutoffRadius, _LJCutoffRadius, _domain, _moleculeContainer, global_simulation);
 			}
 			else if("none" == type)
 			{
@@ -581,7 +581,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			delete _longRangeCorrection;
 			Log::global_log->info() << "Initializing default homogeneous LRC, as no LRC was defined." << std::endl;
-			_longRangeCorrection = new Homogeneous(_cutoffRadius, _LJCutoffRadius, _domain, global_simulation);
+			_longRangeCorrection = new Homogeneous(_cutoffRadius, _LJCutoffRadius, _domain, _moleculeContainer, global_simulation);
 		}
 
 		xmlconfig.changecurrentnode(".."); /* algorithm section */

--- a/src/longRange/Homogeneous.cpp
+++ b/src/longRange/Homogeneous.cpp
@@ -5,14 +5,16 @@
 #include "Simulation.h"
 #include "longRange/Homogeneous.h"
 //#include "LongRangeCorrection.h"
+#include "particleContainer/ParticleContainer.h"
 
 #include "utils/Logger.h"
 
 
-Homogeneous::Homogeneous(double cutoffRadius, double cutoffRadiusLJ, Domain* domain, Simulation* simulation) {
+Homogeneous::Homogeneous(double cutoffRadius, double cutoffRadiusLJ, Domain* domain, ParticleContainer* particleContainer, Simulation* simulation) {
 	_cutoff = cutoffRadius;
 	_cutoffLJ = cutoffRadiusLJ;
 	_domain = domain;
+	_particleContainer = particleContainer;
 	_components = simulation->getEnsemble()->getComponents();
 }
 
@@ -135,6 +137,18 @@ void Homogeneous::calculateLongRange() {
 					   << std::endl;
 	_domain->setUpotCorr(UpotCorr);
 	_domain->setVirialCorr(VirialCorr);
+
+	const double virialCorrPerMol[3] = {
+		VirialCorr/(3.*globalNumMolecules),
+		VirialCorr/(3.*globalNumMolecules),
+		VirialCorr/(3.*globalNumMolecules),
+	};
+	// double uPotCorrPerMol = UpotCorr/globalNumMolecules;
+
+	for (auto tempMol = _particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tempMol.isValid(); ++tempMol) {
+		tempMol->Viadd(virialCorrPerMol);
+		// tempMol->Uadd(uPotCorrPerMol);  // Not implemented in Molecule class yet
+	}
 }
 
 double Homogeneous::_TICCu(int n, double rc, double sigma2) {

--- a/src/longRange/Homogeneous.h
+++ b/src/longRange/Homogeneous.h
@@ -5,6 +5,7 @@
 #include "LongRangeCorrection.h"
 #include "molecules/Component.h"
 #include "molecules/Comp2Param.h"
+#include "particleContainer/ParticleContainer.h"
 #include <cmath>
 
 class Simulation;
@@ -16,7 +17,7 @@ class Homogeneous: public LongRangeCorrection{
 
 public:
 //	Homogeneous();
-	Homogeneous(double cutoffRadius, double cutoffRadiusLJ,  Domain* domain, Simulation* simulation);
+	Homogeneous(double cutoffRadius, double cutoffRadiusLJ,  Domain* domain, ParticleContainer* particleContainer, Simulation* simulation);
 	virtual ~Homogeneous() {}
 
 	virtual void init();
@@ -40,6 +41,7 @@ private:
 	Comp2Param _comp2params;
 
 	Domain* _domain{nullptr};
+	ParticleContainer* _particleContainer{nullptr};
 
 	double _cutoff{std::numeric_limits<double>::quiet_NaN()};
 	double _cutoffLJ{std::numeric_limits<double>::quiet_NaN()};


### PR DESCRIPTION
# Description

In accordance to the [planar LRC](https://github.com/ls1mardyn/ls1-mardyn/blob/b5a132e0c64b833bd05bc6cf8a223315f4d1077b/src/longRange/Planar.cpp#L438), the homogeneous LRC should not only correct the [global virial](https://github.com/ls1mardyn/ls1-mardyn/blob/b5a132e0c64b833bd05bc6cf8a223315f4d1077b/src/longRange/Homogeneous.cpp#L137), but also the virial of the single molecules. This way, the global pressure and the pressure sampled by some plugins, e.g. [RegionSampling](https://github.com/ls1mardyn/ls1-mardyn/blob/b5a132e0c64b833bd05bc6cf8a223315f4d1077b/src/plugins/NEMD/RegionSampling.cpp#L1008-L1010), match.


## How Has This Been Tested?

- [x] Run simulation with master branch and compare global pressure with pressure from RegionSampling
- [x] Do the same with the present PR

Result for the CO2 example (added RegionSampling plugin):
|				| master      		| PR          	|
|----------------		|-------------		|-------------	|
| Direct output        	| 1.17778E-06 	| 1.17778E-06 |
| ResultWriter   	| 1.17778E-06 	| 1.17778E-06 |
| RegionSampling 	| 1.22360E-06 	| 1.17782E-06 |

The agreement between _Direct output_ and _ResultWriter_ is not surprising as both rely on the very same data from the Domain class.