### PR TITLE
Replace Simulation::exit with mardyn_exit

### DIFF
--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -11,6 +11,7 @@
 #include "molecules/Molecule.h"
 //#include "CutoffCorrections.h"
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "ensemble/EnsembleBase.h"
 
 #ifdef ENABLE_MPI
@@ -701,6 +702,15 @@ void Domain::enableComponentwiseThermostat()
 			this->_componentToThermostatIdMap[ tc->ID() ] = -1;
 		}
 	}
+}
+
+void Domain::setComponentThermostat(int cid, int thermostat) {
+	if ((0 > cid) || (0 >= thermostat)) {
+		Log::global_log->error() << "Domain::setComponentThermostat: cid or thermostat id too low" << std::endl;
+		mardyn_exit(787);
+	}
+	this->_componentToThermostatIdMap[cid] = thermostat;
+	this->_universalThermostatN[thermostat] = 0;
 }
 
 void Domain::enableUndirectedThermostat(int tst)

--- a/src/Domain.h
+++ b/src/Domain.h
@@ -10,7 +10,6 @@
 #include "molecules/Comp2Param.h"
 #include "molecules/Component.h"
 #include "ensemble/EnsembleBase.h"
-#include "Simulation.h"
 #include "utils/CommVar.h"
 /*
  * TODO add comments for variables
@@ -349,11 +348,8 @@ public:
 	//! @brief associates a component with a thermostat
 	//! @param cid internal ID of the component
 	//! @param th internal ID of the thermostat
-	void setComponentThermostat(int cid, int thermostat) {
-		if((0 > cid) || (0 >= thermostat)) Simulation::exit(787);
-		this->_componentToThermostatIdMap[cid] = thermostat;
-		this->_universalThermostatN[thermostat] = 0;
-	}
+	void setComponentThermostat(int cid, int thermostat);
+
 	//! @brief enables the "undirected" flag for the specified thermostat
 	//! @param tst internal ID of the respective thermostat
 	void enableUndirectedThermostat(int thermostat);

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -194,7 +194,7 @@ int main(int argc, char** argv) {
 	if(numArgs != 1) {
 		Log::global_log->error() << "Incorrect number of arguments provided." << std::endl;
 		op.print_usage();
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 	/* First read the given config file if it exists, then overwrite parameters with command line arguments. */
 	std::string configFileName(args[0]);
@@ -203,7 +203,7 @@ int main(int argc, char** argv) {
 		simulation.readConfigFile(configFileName);
 	} else {
 		Log::global_log->error() << "Cannot open config file '" << configFileName << "'" << std::endl;
-		Simulation::exit(-2);
+		mardyn_exit(-2);
 	}
 
 	/* processing command line arguments */

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -387,11 +387,11 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			}
 		#else /* serial */
 			if(parallelisationtype != "DummyDecomposition") {
-				Log::global_log->error()
+				Log::global_log->warning()
 						<< "Executable was compiled without support for parallel execution: "
 						<< parallelisationtype
 						<< " not available. Using serial mode." << std::endl;
-				mardyn_exit(1);
+				//mardyn_exit(1);
 			}
 			//_domainDecomposition = new DomainDecompBase();  // already set in initialize()
 		#endif

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -387,11 +387,11 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			}
 		#else /* serial */
 			if(parallelisationtype != "DummyDecomposition") {
-				Log::global_log->warning()
+				Log::global_log->error()
 						<< "Executable was compiled without support for parallel execution: "
 						<< parallelisationtype
 						<< " not available. Using serial mode." << std::endl;
-				//mardyn_exit(1);
+				mardyn_exit(1);
 			}
 			//_domainDecomposition = new DomainDecompBase();  // already set in initialize()
 		#endif

--- a/src/Simulation.h
+++ b/src/Simulation.h
@@ -125,14 +125,6 @@ public:
 	 */
 	void readXML(XMLfileUnits& xmlconfig);
 
-	/** @brief Terminate simulation with given exit code.
-	 *
-	 * The exit method takes care over the right way to terminate the application in a correct way
-	 * for the different parallelization schemes. e.g. terminating other processes in MPI parallel
-	 * execution mode.
-	 */
-	static void exit(int exitcode);
-
 	/** @brief process configuration file
 	 *
 	 * calls initConfigXML

--- a/src/bhfmm/FastMultipoleMethod.cpp
+++ b/src/bhfmm/FastMultipoleMethod.cpp
@@ -8,6 +8,7 @@
 #include <utils/threeDimensionalMapping.h>
 #include "FastMultipoleMethod.h"
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "Domain.h"
 #include "utils/Logger.h"
 #include "bhfmm/containers/UniformPseudoParticleContainer.h"
@@ -69,7 +70,7 @@ void FastMultipoleMethod::init(double globalDomainLength[3], double bBoxMin[3],
 		Log::global_log->error() << "Fast Multipole Method: bad subdivision factor:"
 				<< _LJCellSubdivisionFactor << std::endl;
 		Log::global_log->error() << "expected 1,2,4 or 8" << std::endl;
-		Simulation::exit(5);
+		mardyn_exit(5);
 	}
 	Log::global_log->info()
 			<< "Fast Multipole Method: each LJ cell will be subdivided in "
@@ -107,7 +108,7 @@ void FastMultipoleMethod::init(double globalDomainLength[3], double bBoxMin[3],
 		// TODO: Debugging in Progress!
 #if defined(ENABLE_MPI)
 		Log::global_log->error() << "MPI in combination with adaptive is not supported yet" << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 #endif
 		//int threshold = 100;
 		_pseudoParticleContainer = new AdaptivePseudoParticleContainer(
@@ -313,7 +314,7 @@ void FastMultipoleMethod::runner(int type, void *data) {
 #pragma omp critical
 	{
 	Log::global_log->error() << "Quicksched runner without FMM_FFT not implemented!" << std::endl;
-	Simulation::exit(1);
+	mardyn_exit(1);
 	}
 #endif /* FMM_FFT */
 }

--- a/src/bhfmm/containers/DttNode.cpp
+++ b/src/bhfmm/containers/DttNode.cpp
@@ -1,5 +1,5 @@
 #include "DttNode.h"
-#include "Simulation.h"
+
 #include "Domain.h"
 #include "UniformPseudoParticleContainer.h"
 #include "utils/Logger.h"

--- a/src/bhfmm/containers/UniformPseudoParticleContainer.cpp
+++ b/src/bhfmm/containers/UniformPseudoParticleContainer.cpp
@@ -7,6 +7,7 @@
 
 #include "UniformPseudoParticleContainer.h"
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "Domain.h"
 #include "utils/Logger.h"
 #include "particleContainer/ParticleContainer.h"
@@ -111,7 +112,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 #endif
 #if WIGNER == 1
 	//global_log->error() << "not supported yet" << std::endl;
-	Simulation::exit(-1);
+	mardyn_exit(-1);
 #endif
 #ifdef ENABLE_MPI
 	/*
@@ -175,7 +176,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 	_globalLevel = ceil(log2(numProcessors)/3.0);
 	if(_globalLevel > _maxLevel){
 		std::cout << "too many MPI ranks \n";
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 	//numProcessers has to be a power of 2
 	mardyn_assert(pow(2,log2(numProcessors)) == numProcessors);
@@ -378,7 +379,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 		MPI_Comm_size(_neighbourhoodComms[i], &size2);
 		if(size2 > 8){ //neighbourhood comms need to have size 8
 			std::cout << "Error wrong communicator \n";
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 	}
 #endif

--- a/src/bhfmm/containers/UniformPseudoParticleContainer_old_Wigner_cpp.txt
+++ b/src/bhfmm/containers/UniformPseudoParticleContainer_old_Wigner_cpp.txt
@@ -6,7 +6,7 @@
  */
 
 #include "UniformPseudoParticleContainer.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "Domain.h"
 #include "utils/Logger.h"
 #include "bhfmm/utils/RotationParameterLookUp.h"
@@ -45,7 +45,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 #endif
 #if WIGNER == 1
 	//global_log->error() << "not supported yet" << std::endl;
-	Simulation::exit(-1);
+	mardyn_exit(-1);
 #endif
 #ifdef ENABLE_MPI
 	_timerProcessCells.set_sync(false);
@@ -81,7 +81,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 	_globalLevel = log2(numProcessors)/3;
 	if(_globalLevel > _maxLevel){
 		std::cout << "too many MPI ranks \n";
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 	//numProcessers has to be a power of 8
 	mardyn_assert(log2(numProcessors) == _globalLevel * 3);
@@ -778,7 +778,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 				for (m2z = LoLim(2) + 2; m2z <= HiLim(2) + 2; m2z++) {
 					if (m2z < 0 or m2z >= localMpCells) {
 						std::cout << "Error \n";
-						Simulation::exit(-1);
+						mardyn_exit(-1);
 					}
 
 
@@ -786,7 +786,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 					for (m2y = LoLim(1) + 2; m2y <= HiLim(1) + 2; m2y++) {
 						if (m2y < 0 or m2y >= localMpCells) {
 							std::cout << "Error \n";
-							Simulation::exit(-1);
+							mardyn_exit(-1);
 						}
 
 
@@ -794,7 +794,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 						for (m2x = LoLim(0) + 2; m2x <= HiLim(0) + 2; m2x++) {
 							if (m2x < 0 or m2x >= localMpCells) {
 								std::cout << "Error \n";
-								Simulation::exit(-1);
+								mardyn_exit(-1);
 							}
 
 							m2v[0] = m2x;

--- a/src/ensemble/CanonicalEnsemble.cpp
+++ b/src/ensemble/CanonicalEnsemble.cpp
@@ -15,6 +15,7 @@
 #include "particleContainer/ParticleContainer.h"
 #include "parallel/DomainDecompBase.h"
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "utils/Logger.h"
 #include "utils/xmlfileUnits.h"
 
@@ -195,7 +196,7 @@ void CanonicalEnsemble::readXML(XMLfileUnits& xmlconfig) {
 		_domain = new BoxDomain();
 	} else {
 		Log::global_log->error() << "Volume type not supported." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	xmlconfig.changecurrentnode("domain");
 	_domain->readXML(xmlconfig);

--- a/src/ensemble/CavityEnsemble.cpp
+++ b/src/ensemble/CavityEnsemble.cpp
@@ -4,7 +4,7 @@
 #include "parallel/DomainDecompBase.h"
 #include "utils/Logger.h"
 #include "molecules/Quaternion.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "particleContainer/ParticleContainer.h"
 
 #define COMMUNICATION_THRESHOLD 3
@@ -96,7 +96,7 @@ void CavityEnsemble::setControlVolume(double x0, double y0, double z0, double x1
         Log::global_log->error() << "\nInvalid control volume (" << x0 << " / " << y0
                             << " / " << z0 << ") to (" << x1 << " / " << y1 << " / "
                             << z1 << ")." << std::endl;
-        Simulation::exit(711);
+        mardyn_exit(711);
     }
 
     this->restrictedControlVolume = true;
@@ -112,19 +112,19 @@ void CavityEnsemble::setControlVolume(double x0, double y0, double z0, double x1
 void CavityEnsemble::init(Component *component, unsigned Nx, unsigned Ny, unsigned Nz) {
     if (this->ownrank < 0) {
         Log::global_log->error() << "\nInvalid rank " << ownrank << ".\n";
-        Simulation::exit(712);
+        mardyn_exit(712);
     }
     if (this->initialized) {
         Log::global_log->error() << "\nCavity ensemble initialized twice.\n";
-        Simulation::exit(713);
+        mardyn_exit(713);
     }
     if (0.0 >= this->T) {
         Log::global_log->error() << "\nInvalid temperature T = " << T << ".\n";
-        Simulation::exit(714);
+        mardyn_exit(714);
     }
     if (0.0 >= this->globalV) {
         Log::global_log->error() << "\nInvalid control volume V_ctrl = " << globalV << ".\n";
-        Simulation::exit(715);
+        mardyn_exit(715);
     }
 
     this->componentid = component->ID();

--- a/src/ensemble/ChemicalPotential.cpp
+++ b/src/ensemble/ChemicalPotential.cpp
@@ -285,7 +285,7 @@ bool ChemicalPotential::decideDeletion(double deltaUTilde)
 			return false;
 		}
 		Log::global_log->error() << "No decision is possible." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	float dec = *_remainingDecisions.begin();
 	_remainingDecisions.erase(_remainingDecisions.begin());
@@ -318,7 +318,7 @@ bool ChemicalPotential::decideInsertion(double deltaUTilde)
 			return false;
 		}
 		Log::global_log->error() << "No decision is possible." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	double acc = _globalReducedVolume * exp(_muTilde - deltaUTilde)
 			/ (1.0 + (double) (_globalN));
@@ -376,7 +376,7 @@ void ChemicalPotential::setControlVolume(double x0, double y0, double z0,
 		Log::global_log->error() << "\nInvalid control volume (" << x0 << " / " << y0
 				<< " / " << z0 << ") to (" << x1 << " / " << y1 << " / " << z1
 				<< ")." << std::endl;
-		Simulation::exit(611);
+		mardyn_exit(611);
 	}
 	_restrictedControlVolume = true;
 	_globalV = (x1 - x0) * (y1 - y0) * (z1 - z0);

--- a/src/ensemble/EnsembleBase.cpp
+++ b/src/ensemble/EnsembleBase.cpp
@@ -4,6 +4,7 @@
 #include "molecules/mixingrules/LorentzBerthelot.h"
 #include "utils/xmlfileUnits.h"
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
 #include "Simulation.h"
 #include "Domain.h"
 
@@ -24,7 +25,7 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "Number of components: " << numComponents << std::endl;
 	if (numComponents == 0) {
 		Log::global_log->fatal() << "No components found. Please verify that you have input them correctly." << std::endl;
-		Simulation::exit(96123);
+		mardyn_exit(96123);
 	}
 	_components.resize(numComponents);
 	XMLfile::Query::const_iterator componentIter;
@@ -63,7 +64,7 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 
 		} else {
 			Log::global_log->error() << "Unknown mixing rule " << mixingruletype << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		mixingrule->readXML(xmlconfig);
 		_mixingrules.push_back(mixingrule);

--- a/src/ensemble/GrandCanonicalEnsemble.cpp
+++ b/src/ensemble/GrandCanonicalEnsemble.cpp
@@ -7,6 +7,7 @@
 #include "Domain.h"
 #include "parallel/DomainDecompBase.h"
 #include "ChemicalPotential.h"
+#include "Simulation.h"
 
 GrandCanonicalEnsemble::GrandCanonicalEnsemble() :
 		_N(0), _V(0), _T(0), _mu(0), _p(0), _E(0), _E_trans(0), _E_rot(0) {

--- a/src/ensemble/GrandCanonicalEnsemble.h
+++ b/src/ensemble/GrandCanonicalEnsemble.h
@@ -6,7 +6,7 @@
 
 
 #include "EnsembleBase.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "ChemicalPotential.h"
 
 class Domain;
@@ -41,7 +41,7 @@ public:
 	// TODO: Implement STUB
 	void readXML(XMLfileUnits& xmlconfig) override {
 		Log::global_log->info() << "[GrandCanonicalEnsemble] readXML not implemented!" << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	};
 
 	unsigned long N() override {
@@ -71,7 +71,7 @@ public:
 	// TODO: Implement
 	void updateGlobalVariable(ParticleContainer* particleContainer, GlobalVariable variable) override {
 		Log::global_log->info() << "[GrandCanonicalEnsemble] updateGlobalVariable not implemented!" << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	};
 
 	/*! Runs steps formerly in initConfigXML in simulation.cpp */

--- a/src/ensemble/PressureGradient.cpp
+++ b/src/ensemble/PressureGradient.cpp
@@ -7,7 +7,7 @@
 #include "parallel/DomainDecompBase.h"
 #include "particleContainer/ParticleContainer.h"
 #include "utils/Logger.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 
 
 PressureGradient::PressureGradient(int rank) {
@@ -220,7 +220,7 @@ void PressureGradient::specifyTauPrime(double tauPrime, double dt)
 	if(this->_universalConstantAccelerationTimesteps == 0)
 	{
 		Log::global_log->error() << "SEVERE ERROR: unknown UCAT!\n";
-		Simulation::exit(78);
+		mardyn_exit(78);
 	}
 	unsigned int vql = (unsigned int)ceil(tauPrime / (dt*this->_universalConstantAccelerationTimesteps));
 	std::map<unsigned int, unsigned int>::iterator vqlit;

--- a/src/ensemble/tests/CanonicalEnsembleTest.cpp
+++ b/src/ensemble/tests/CanonicalEnsembleTest.cpp
@@ -10,6 +10,7 @@
 #include "parallel/DomainDecompBase.h"
 #include "molecules/Molecule.h"
 #include "Domain.h"
+#include "Simulation.h"
 
 #include <vector>
 

--- a/src/integrators/Leapfrog.cpp
+++ b/src/integrators/Leapfrog.cpp
@@ -6,7 +6,7 @@
 #include "ensemble/EnsembleBase.h"
 #include "molecules/Molecule.h"
 #include "particleContainer/ParticleContainer.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "utils/Logger.h"
 #include "utils/xmlfileUnits.h"
 

--- a/src/integrators/LeapfrogRMM.cpp
+++ b/src/integrators/LeapfrogRMM.cpp
@@ -1,6 +1,6 @@
 #include "LeapfrogRMM.h"
 
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "utils/Logger.h"
 #include "utils/xmlfileUnits.h"
 

--- a/src/io/ASCIIReader.cpp
+++ b/src/io/ASCIIReader.cpp
@@ -20,6 +20,7 @@
 
 #include "particleContainer/ParticleContainer.h"
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
 
 
 ASCIIReader::ASCIIReader() {}
@@ -53,7 +54,7 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	_phaseSpaceHeaderFileStream >> token;
 	if(token != "mardyn") {
 		Log::global_log->error() << _phaseSpaceHeaderFile << " not a valid mardyn input file." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	std::string inputversion;
@@ -61,12 +62,12 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	// FIXME: remove tag trunk from file specification?
 	if(token != "trunk") {
 		Log::global_log->error() << "Wrong input file specifier (\'" << token << "\' instead of \'trunk\')." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	if(std::stoi(inputversion) < 20080701) {
 		Log::global_log->error() << "Input version too old (" << inputversion << ")" << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	Log::global_log->info() << "Reading phase space header from file " << _phaseSpaceHeaderFile << std::endl;
@@ -161,7 +162,7 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 				if(numtersoff != 0) {
 					Log::global_log->error() << "tersoff no longer supported."
 										<< std::endl;
-					Simulation::exit(-1);
+					mardyn_exit(-1);
 				}
 				double x, y, z, m;
 				for(unsigned int j = 0; j < numljcenters; j++) {
@@ -263,7 +264,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 	_phaseSpaceFileStream.open(_phaseSpaceFile.c_str());
 	if(!_phaseSpaceFileStream.is_open()) {
 		Log::global_log->error() << "Could not open phaseSpaceFile " << _phaseSpaceFile << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	Log::global_log->info() << "Reading phase space file " << _phaseSpaceFile << std::endl;
 #ifdef ENABLE_MPI
@@ -289,7 +290,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 	}
 	if((token != "NumberOfMolecules") && (token != "N")) {
 		Log::global_log->error() << "Expected the token 'NumberOfMolecules (N)' instead of '" << token << "'" << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	_phaseSpaceFileStream >> nummolecules;
 #ifdef ENABLE_MPI
@@ -316,7 +317,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 		else if(ntypestring == "IRV") ntype = Ndatatype::IRV;
 		else {
 			Log::global_log->error() << "Unknown molecule format '" << ntypestring << "'" << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 	} else {
 		_phaseSpaceFileStream.seekg(spos);
@@ -377,7 +378,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 				break;
 			default:
 				Log::global_log->error() << "[ASCIIReader.cpp] Unknown ntype" << std::endl;
-				Simulation::exit(1);
+				mardyn_exit(1);
 		}
 		if((x < 0.0 || x >= domain->getGlobalLength(0))
 		   || (y < 0.0 || y >= domain->getGlobalLength(1))
@@ -391,7 +392,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 								<< componentid
 								<< ">"
 								<< numcomponents << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.

--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -26,6 +26,7 @@
 #include "utils/Logger.h"
 #include "utils/Timer.h"
 #include "utils/xmlfileUnits.h"
+#include "utils/mardyn_assert.h"
 
 #include <climits>
 #include <cstdint>
@@ -77,7 +78,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	if(not inp.changecurrentnode("/mardyn")) {
 		Log::global_log->error() << "Could not find root node /mardyn in XML input file." << std::endl;
 		Log::global_log->fatal() << "Not a valid MarDyn XML input file." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	bool bInputOk = true;
@@ -95,7 +96,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 
 	if(not bInputOk) {
 		Log::global_log->error() << "Content of file: '" << _phaseSpaceHeaderFile << "' corrupted! Program exit ..." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -106,7 +107,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 		_nMoleculeFormat = ICRV;
 	else {
 		Log::global_log->error() << "Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	// Set parameters of Domain and Simulation class
@@ -133,7 +134,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 	if(!_phaseSpaceFileStream.is_open()) {
 		Log::global_log->error() << "Could not open phaseSpaceFile "
 							<< _phaseSpaceFile << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	Log::global_log->info() << "Reading phase space file " << _phaseSpaceFile
 					   << std::endl;
@@ -177,7 +178,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 		if(_phaseSpaceFileStream.eof()) {
 			Log::global_log->error() << "End of file was hit before all " << numMolecules << " expected molecules were read."
 				<< std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
         }
 		_phaseSpaceFileStream.read(reinterpret_cast<char*> (&id), 8);
 		switch (_nMoleculeFormat) {
@@ -220,7 +221,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 			default:
 				Log::global_log->error() << "BinaryReader: Unknown phase space format: " << _nMoleculeFormat << std::endl
 									<< "Aborting simulation." << std::endl;
-				Simulation::exit(12);
+				mardyn_exit(12);
 		}
 		if ((x < 0.0 || x >= domain->getGlobalLength(0)) || (y < 0.0 || y >= domain->getGlobalLength(1)) ||
 			(z < 0.0 || z >= domain->getGlobalLength(2))) {
@@ -233,12 +234,12 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 								<< componentid
 								<< ">"
 								<< numcomponents << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		if(componentid == 0) {
 			Log::global_log->error() << "Molecule id " << id
 								<< " has componentID == 0." << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.

--- a/src/io/CavityWriter.cpp
+++ b/src/io/CavityWriter.cpp
@@ -9,6 +9,7 @@
 #include "parallel/DomainDecompBase.h"
 #include "particleContainer/ParticleContainer.h"
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
 #include "Simulation.h"
 #include "ensemble/CavityEnsemble.h"
 
@@ -37,28 +38,28 @@ void CavityWriter::readXML(XMLfileUnits &xmlconfig) {
     xmlconfig.getNodeValue("maxNeighbours", _maxNeighbors);
     if (_maxNeighbors <= 0) {
         Log::global_log->error() << "[CavityWriter] Invalid number of maxNeighbors: " << _maxNeighbors << std::endl;
-        Simulation::exit(999);
+        mardyn_exit(999);
     }
 
     xmlconfig.getNodeValue("radius", _radius);
     if (_radius <= 0.0f) {
         Log::global_log->error() << "[CavityWriter] Invalid size of radius: " << _radius << std::endl;
-        Simulation::exit(999);
+        mardyn_exit(999);
     }
     xmlconfig.getNodeValue("Nx", _Nx);
     if (_Nx <= 0) {
         Log::global_log->error() << "[CavityWriter] Invalid number of cells Nx: " << _Nx << std::endl;
-        Simulation::exit(999);
+        mardyn_exit(999);
     }
     xmlconfig.getNodeValue("Ny", _Ny);
     if (_Ny <= 0) {
         Log::global_log->error() << "[CavityWriter] Invalid number of cells Ny: " << _Ny << std::endl;
-        Simulation::exit(999);
+        mardyn_exit(999);
     }
     xmlconfig.getNodeValue("Nz", _Nz);
     if (_Nz <= 0) {
         Log::global_log->error() << "[CavityWriter] Invalid number of cells Nz: " << _Nz << std::endl;
-        Simulation::exit(999);
+        mardyn_exit(999);
     }
 
     // Default Control Volume is entire Domain
@@ -76,13 +77,13 @@ void CavityWriter::readXML(XMLfileUnits &xmlconfig) {
         if (_controlVolume[d * 2] > _controlVolume[d * 2 + 1]) {
             Log::global_log->error() << "[CavityWriter] Lower Bound of Control Volume may not be larger than upper bound. "
                                 << std::endl;
-            Simulation::exit(999);
+            mardyn_exit(999);
         }
         if (_controlVolume[d * 2] < 0 ||
             _controlVolume[d * 2 + 1] > global_simulation->getDomain()->getGlobalLength(d)) {
             Log::global_log->error() << "[CavityWriter] Control volume bounds may not be outside of domain boundaries. "
                                 << std::endl;
-            Simulation::exit(999);
+            mardyn_exit(999);
         }
     }
 

--- a/src/io/CheckpointWriter.cpp
+++ b/src/io/CheckpointWriter.cpp
@@ -7,8 +7,10 @@
 
 #include "Common.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "parallel/DomainDecompBase.h"
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
 
 
 void CheckpointWriter::readXML(XMLfileUnits& xmlconfig) {
@@ -18,7 +20,7 @@ void CheckpointWriter::readXML(XMLfileUnits& xmlconfig) {
 
 	if(_writeFrequency == 0) {
 		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	std::string checkpointType = "unknown";
@@ -31,7 +33,7 @@ void CheckpointWriter::readXML(XMLfileUnits& xmlconfig) {
 	}
 	else {
 		Log::global_log->error() << "Unknown CheckpointWriter type '" << checkpointType << "', expected: ASCII|binary." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	_outputPrefix = "mardyn";

--- a/src/io/CommunicationPartnerWriter.cpp
+++ b/src/io/CommunicationPartnerWriter.cpp
@@ -5,6 +5,8 @@
 
 #include "Common.h"
 #include "Domain.h"
+#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "utils/Logger.h"
 #include "parallel/DomainDecompBase.h"
 
@@ -16,7 +18,7 @@ void CommunicationPartnerWriter::readXML(XMLfileUnits& xmlconfig) {
 
 	if(_writeFrequency == 0) {
 		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	std::string HaloParticleType = "unknown";

--- a/src/io/CubicGridGeneratorInternal.cpp
+++ b/src/io/CubicGridGeneratorInternal.cpp
@@ -11,12 +11,14 @@
 #include "CubicGridGeneratorInternal.h"
 
 #include "Domain.h"
+#include "Simulation.h"
 #include "IOHelpers.h"
 #include "WrapOpenMP.h"
 #include "parallel/DomainDecompBase.h"
 #include "particleContainer/ParticleContainer.h"
 #include "utils/Logger.h"
 #include "utils/Random.h"
+#include "utils/mardyn_assert.h"
 
 #include <cmath>
 #include <algorithm>
@@ -39,7 +41,7 @@ void CubicGridGeneratorInternal::readXML(XMLfileUnits& xmlconfig) {
 	// setting both or none is not allowed!
 	if((_numMolecules == 0 && density == -1.) || (_numMolecules != 0 && density != -1.) ){
 		Log::global_log->error() << "Error in CubicGridGeneratorInternal: You have to set either density or numMolecules!" << std::endl;
-		Simulation::exit(2341);
+		mardyn_exit(2341);
 	}
 
 	if(density != -1.){
@@ -48,7 +50,7 @@ void CubicGridGeneratorInternal::readXML(XMLfileUnits& xmlconfig) {
 			Log::global_log->error()
 					<< "Error in CubicGridGeneratorInternal: Density has to be positive and non-zero!"
 					<< std::endl;
-			Simulation::exit(2342);
+			mardyn_exit(2342);
 		}
 		double vol = 1.0;
 		for (int d = 0; d < 3; ++d)
@@ -65,7 +67,7 @@ unsigned long CubicGridGeneratorInternal::readPhaseSpace(ParticleContainer *part
 	if(_numMolecules == 0){
 		Log::global_log->error() << "Error in CubicGridGeneratorInternal: numMolecules is not set!"
 				<< std::endl << "Please make sure to run readXML()!" << std::endl;
-		Simulation::exit(2341);
+		mardyn_exit(2341);
 	}
 
 	// create a body centered cubic layout, by creating by placing the molecules on the

--- a/src/io/FlopRateWriter.cpp
+++ b/src/io/FlopRateWriter.cpp
@@ -10,6 +10,7 @@
 #include "particleContainer/ParticleContainer.h"
 #include "particleContainer/adapter/FlopCounter.h"
 #include "parallel/DomainDecompBase.h"
+#include "utils/mardyn_assert.h"
 #include "Simulation.h"
 
 void FlopRateWriter::readXML(XMLfileUnits& xmlconfig) {
@@ -35,7 +36,7 @@ void FlopRateWriter::readXML(XMLfileUnits& xmlconfig) {
 	// TODO:
 	if(_writeToFile) {
 		Log::global_log->error() << "TODO: file output not yet supported." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	if(_writeToFile) {

--- a/src/io/GammaWriter.cpp
+++ b/src/io/GammaWriter.cpp
@@ -7,6 +7,7 @@
 #include "particleContainer/ParticleContainer.h"
 #include "parallel/DomainDecompBase.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "utils/xmlfileUnits.h"
 #include "utils/FileUtils.h"
 

--- a/src/io/HaloParticleWriter.cpp
+++ b/src/io/HaloParticleWriter.cpp
@@ -5,8 +5,10 @@
 
 #include "Common.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "utils/Logger.h"
 #include "parallel/DomainDecompBase.h"
+#include "utils/mardyn_assert.h"
 
 
 void HaloParticleWriter::readXML(XMLfileUnits& xmlconfig) {
@@ -16,7 +18,7 @@ void HaloParticleWriter::readXML(XMLfileUnits& xmlconfig) {
 
 	if(_writeFrequency == 0) {
 		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	std::string HaloParticleType = "unknown";

--- a/src/io/KDTreePrinter.cpp
+++ b/src/io/KDTreePrinter.cpp
@@ -2,6 +2,7 @@
 
 #include "Common.h"
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "utils/Logger.h"
 #include "utils/xmlfileUnits.h"
 #include "parallel/DomainDecompBase.h"
@@ -19,7 +20,7 @@ void KDTreePrinter::readXML(XMLfileUnits &xmlconfig) {
 	if (_writeFrequency == 0) {
 		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency
 								 << std::endl;
-		Simulation::exit(948947);
+		mardyn_exit(948947);
 	}
 
 	_outputPrefix = "mardyn";

--- a/src/io/LoadBalanceWriter.cpp
+++ b/src/io/LoadBalanceWriter.cpp
@@ -1,6 +1,7 @@
 #include "io/LoadBalanceWriter.h"
 
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "TimerProfiler.h"
 #include "parallel/DomainDecompBase.h"
 

--- a/src/io/MPICheckpointWriter.cpp
+++ b/src/io/MPICheckpointWriter.cpp
@@ -15,6 +15,7 @@
 
 #include "Common.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "utils/Logger.h"
 #include "parallel/DomainDecompBase.h"
 

--- a/src/io/MPI_IOCheckpointWriter.cpp
+++ b/src/io/MPI_IOCheckpointWriter.cpp
@@ -13,7 +13,9 @@
 
 #include "Common.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
 
 #include "molecules/Molecule.h"
 #include "particleContainer/ParticleCell.h"
@@ -434,6 +436,6 @@ void MPI_IOCheckpointWriter::handle_error(int i) {
 
 	Log::global_log->error() << "Writing of file was not successfull " << " , " << i
 			<< " , " << error_string << std::endl;
-	Simulation::exit(1);
+	mardyn_exit(1);
 #endif
 }

--- a/src/io/MPI_IOReader.cpp
+++ b/src/io/MPI_IOReader.cpp
@@ -16,9 +16,10 @@
 #include <climits>
 
 #include "Domain.h"
+#include "Simulation.h"
 #include "ensemble/BoxDomain.h"
 #include "ensemble/EnsembleBase.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "molecules/Molecule.h"
 
 #ifdef ENABLE_MPI
@@ -58,7 +59,7 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	_phaseSpaceHeaderFileStream >> token;
 	if(token != "mardyn") {
 		Log::global_log->error() << _phaseSpaceHeaderFile << " not a valid mardyn input file." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	std::string inputversion;
@@ -66,12 +67,12 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	// FIXME: remove tag trunk from file specification?
 	if(token != "trunk") {
 		Log::global_log->error() << "Wrong input file specifier (\'" << token << "\' instead of \'trunk\')." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	if(strtoul(inputversion.c_str(), NULL, 0) < 20080701) {
 		Log::global_log->error() << "Input version tool old (" << inputversion << ")" << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	Log::global_log->info() << "Reading phase space header from file " << _phaseSpaceHeaderFile << std::endl;
@@ -116,7 +117,7 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 				 || ntypestring == "IRV")) {
 				Log::global_log->error() << "Unknown molecule format: '"
 									<< ntypestring << "'" << std::endl;
-				Simulation::exit(1);
+				mardyn_exit(1);
 			}
 			_moleculeFormat = ntypestring;
 			Log::global_log->info() << " molecule format: " << ntypestring << std::endl;
@@ -182,7 +183,7 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 											>> numquadrupoles >> numtersoff;
 				if(numtersoff != 0) {
 					Log::global_log->error() << "tersoff no longer supported." << std::endl;
-					Simulation::exit(-1);
+					mardyn_exit(-1);
 				}
 				double x, y, z, m;
 				for(unsigned int j = 0; j < numljcenters; j++) {
@@ -664,6 +665,6 @@ void MPI_IOReader::handle_error(int i) {
 
 	Log::global_log->error() << "Writing of file was not successfull " << " , " << i
 			<< " , " << error_string << std::endl;
-	Simulation::exit(1);
+	mardyn_exit(1);
 #endif
 }

--- a/src/io/Mkesfera.cpp
+++ b/src/io/Mkesfera.cpp
@@ -7,10 +7,11 @@
 #include <vector>
 
 #include "Domain.h"
+#include "Simulation.h"
 #include "ensemble/EnsembleBase.h"
 #include "molecules/Component.h"
 #include "particleContainer/ParticleContainer.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "utils/Logger.h"
 #include "utils/Random.h"
 
@@ -175,7 +176,7 @@ MkesferaGenerator::readPhaseSpace(ParticleContainer* particleContainer, Domain* 
 					   idx[2] - startx[2] >= fl_units_local[2] or startx[0] > idx[0] or startx[1] > idx[1] or
 					   startx[2] > idx[2]) {
 						Log::global_log->error() << "Error in calculation of start and end values! \n";
-						Simulation::exit(0);
+						mardyn_exit(0);
 					}
 					fill[idx[0] - startx[0]][idx[1] - startx[1]][idx[2] - startx[2]][p] = tfill;
 					if(tfill) {

--- a/src/io/MmpldWriter.cpp
+++ b/src/io/MmpldWriter.cpp
@@ -22,10 +22,10 @@
 
 #include "Common.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "molecules/Molecule.h"
 #include "particleContainer/ParticleContainer.h"
 #include "parallel/DomainDecompBase.h"
-#include "Simulation.h"
 #include "utils/FileUtils.h"
 #include "utils/Logger.h"
 #include "utils/mardyn_assert.h"
@@ -56,7 +56,7 @@ MmpldWriter::MmpldWriter(uint64_t startTimestep, uint64_t writeFrequency, uint64
 		_color_type(MMPLD_COLOR_NONE)
 {
 	if (0 == _writeFrequency) {
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 }
 
@@ -89,7 +89,7 @@ void MmpldWriter::readXML(XMLfileUnits& xmlconfig)
 			break;
 		default:
 			Log::global_log->error() << "Unsupported MMPLD version:" << _mmpldversion << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 			break;
 	}
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
@@ -102,7 +102,7 @@ void MmpldWriter::readXML(XMLfileUnits& xmlconfig)
 	Log::global_log->info() << "[MMPLD Writer] Number of sites: " << numSites << std::endl;
 	if(numSites < 1) {
 		Log::global_log->fatal() << "[MMPLD Writer] No site parameters specified." << std::endl;
-		Simulation::exit(48973);
+		mardyn_exit(48973);
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator outputSiteIter;
@@ -392,7 +392,7 @@ long MmpldWriter::get_data_frame_header_size() {
 			break;
 		default:
 			Log::global_log->error() << "[MMPLD Writer] Unsupported MMPLD version: " << _mmpldversion << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 			break;
 	}
 	return data_frame_header_size;

--- a/src/io/MmspdWriter.cpp
+++ b/src/io/MmspdWriter.cpp
@@ -9,10 +9,10 @@
 
 #include "Common.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "molecules/Molecule.h"
 #include "particleContainer/ParticleContainer.h"
 #include "parallel/DomainDecompBase.h"
-#include "Simulation.h"
 #include "utils/Logger.h"
 
 

--- a/src/io/MultiObjectGenerator.cpp
+++ b/src/io/MultiObjectGenerator.cpp
@@ -10,7 +10,6 @@
 #endif
 
 #include "Domain.h"
-#include "Simulation.h"
 #include "ensemble/EnsembleBase.h"
 #include "io/ObjectGenerator.h"
 #include "molecules/MoleculeIdPool.h"

--- a/src/io/ODF.cpp
+++ b/src/io/ODF.cpp
@@ -3,6 +3,8 @@
 #include "ODF.h"
 #include "WrapOpenMP.h"
 
+#include "Simulation.h"
+
 void ODF::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->debug() << "[ODF] enabled. Dipole orientations must be set to [0 0 1]!" << std::endl;
 	xmlconfig.getNodeValue("writefrequency", _writeFrequency);

--- a/src/io/ODF.h
+++ b/src/io/ODF.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
-#include <particleContainer/adapter/ODFCellProcessor.h>
+#include <memory>
+
+#include "particleContainer/adapter/ODFCellProcessor.h"
 #include "Domain.h"
 #include "parallel/DomainDecompBase.h"
 #include "particleContainer/ParticleContainer.h"

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -3,7 +3,7 @@
 #include <limits>
 #include <chrono>
 
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "ensemble/EnsembleBase.h"
 #include "molecules/Molecule.h"
 #include "molecules/MoleculeIdPool.h"
@@ -25,14 +25,14 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		_filler = std::shared_ptr<ObjectFillerBase>(objectFillerFactory.create(fillerType));
 		if(!_filler) {
 			Log::global_log->error() << "Object filler could not be created" << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		Log::global_log->debug() << "Using object filler of type: " << _filler->getPluginName() << std::endl;
 		_filler->readXML(xmlconfig);
 		xmlconfig.changecurrentnode("..");
 	} else {
 		Log::global_log->error() << "No filler specified." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	if(xmlconfig.changecurrentnode("object")) {
@@ -49,7 +49,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		xmlconfig.changecurrentnode("..");
 	} else {
 		Log::global_log->error() << "No object specified." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	if(xmlconfig.changecurrentnode("velocityAssigner")) {
@@ -79,7 +79,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 			_velocityAssigner = std::make_shared<MaxwellVelocityAssigner>(0, seed);
 		} else {
 			Log::global_log->error() << "Unknown velocity assigner specified." << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		Ensemble* ensemble = _simulation.getEnsemble();
 		Log::global_log->info() << "Setting temperature for velocity assigner to " << ensemble->T() << std::endl;

--- a/src/io/PerCellGenerator.cpp
+++ b/src/io/PerCellGenerator.cpp
@@ -6,6 +6,7 @@
 #include "Domain.h"
 #include "IOHelpers.h"
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "ensemble/EnsembleBase.h"
 #include "molecules/Molecule.h"
 #include "parallel/DomainDecompBase.h"
@@ -42,7 +43,7 @@ void PerCellGenerator::readXML(XMLfileUnits &xmlconfig) {
 		Log::global_log->info() << "numMoleculesPerCell: " << _numMoleculesPerCell << std::endl;
 	} else {
 		Log::global_log->error() << "Missing required field numMoleculesPerCell. Aborting!" << std::endl;
-		Simulation::exit(1949);
+		mardyn_exit(1949);
 	}
 
 	xmlconfig.getNodeValue("initTemperature", _initTemperature);
@@ -50,7 +51,7 @@ void PerCellGenerator::readXML(XMLfileUnits &xmlconfig) {
 		Log::global_log->info() << "initTemperature: " << _initTemperature << std::endl;
 	} else {
 		Log::global_log->error() << "Missing required field initTemperature. Aborting!" << std::endl;
-		Simulation::exit(1949);
+		mardyn_exit(1949);
 	}
 
 	xmlconfig.getNodeValue("generateAtLeastTwoParticles", _generateAtLeastTwoParticles);

--- a/src/io/RDF.cpp
+++ b/src/io/RDF.cpp
@@ -3,6 +3,7 @@
 #include "Domain.h"
 #include "molecules/Component.h"
 #include "parallel/DomainDecompBase.h"
+#include "utils/mardyn_assert.h"
 #include "Simulation.h"
 #include "utils/Logger.h"
 
@@ -33,7 +34,7 @@ RDF::RDF() :
 void RDF::init() {
 	if(!_readConfig){
 		Log::global_log->error() << "RDF initialized without reading the configuration, exiting" << std::endl;
-		Simulation::exit(25);
+		mardyn_exit(25);
 	}
 
 	_cellProcessor = new RDFCellProcessor(global_simulation->getcutoffRadius(), this);

--- a/src/io/ReplicaGenerator.cpp
+++ b/src/io/ReplicaGenerator.cpp
@@ -9,6 +9,7 @@
 #include <numeric>
 
 #include "Domain.h"
+#include "Simulation.h"
 
 #include "parallel/DomainDecompBase.h"
 
@@ -20,7 +21,7 @@
 #include "ensemble/EnsembleBase.h"
 #include "molecules/Molecule.h"
 #include "particleContainer/ParticleContainer.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "utils/Logger.h"
 
 
@@ -57,7 +58,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	if(not inp.changecurrentnode("/mardyn")) {
 		Log::global_log->error() << "Could not find root node /mardyn in XML input file." << std::endl;
 		Log::global_log->fatal() << "Not a valid MarDyn XML input file." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	bool bInputOk = true;
@@ -81,7 +82,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	if(not bInputOk) {
 		Log::global_log->error() << "Content of file: '" << subDomain.strFilePathHeader << "' corrupted! Program exit ..."
 							<< std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -92,7 +93,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 		_nMoleculeFormat = ICRV;
 	else {
 		Log::global_log->error() << "Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 }
 
@@ -106,7 +107,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceData(SubDomain& subDomain, DomainDec
 	ifs.open(subDomain.strFilePathData.c_str(), std::ios::binary | std::ios::in);
 	if(!ifs.is_open()) {
 		Log::global_log->error() << "Could not open phaseSpaceFile " << subDomain.strFilePathData << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	Log::global_log->info() << "Reading phase space file " << subDomain.strFilePathData << std::endl;
@@ -189,7 +190,7 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		Log::global_log->error() << "Specified wrong type at XML path: " << xmlconfig.getcurrentnodepath() << "/type"
 							<< std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	SubDomain sd;
@@ -240,7 +241,7 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 			Log::global_log->info() << "Number of components to change: " << (uint32_t) numChanges << std::endl;
 			if(numChanges < 1) {
 				Log::global_log->error() << "No component change defined in XML-config file. Program exit ..." << std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 			XMLfile::Query::const_iterator changeIter;
 			for(changeIter = query.begin(); changeIter; changeIter++) {
@@ -263,7 +264,7 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 			Log::global_log->info() << "Number of components to change: " << (uint32_t) numChanges << std::endl;
 			if(numChanges < 1) {
 				Log::global_log->error() << "No component change defined in XML-config file. Program exit ..." << std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 			XMLfile::Query::const_iterator changeIter;
 			for(changeIter = query.begin(); changeIter; changeIter++) {
@@ -531,7 +532,7 @@ ReplicaGenerator::readPhaseSpace(ParticleContainer* particleContainer, Domain* d
 																			   " != "
 						   << (_numParticlesTotal - numAddedParticlesFreespaceGlobal) << " (expected). Program exit ..."
 						   << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	global_simulation->timers()->stop("REPLICA_GENERATOR_VLE_INPUT");

--- a/src/io/TimerProfiler.cpp
+++ b/src/io/TimerProfiler.cpp
@@ -11,7 +11,6 @@
 #include "TimerProfiler.h"
 #include "utils/Logger.h"
 #include "utils/String_utils.h"
-#include "utils/mardyn_assert.h"
 #include "utils/xmlfileUnits.h"
 
 

--- a/src/io/TimerWriter.cpp
+++ b/src/io/TimerWriter.cpp
@@ -9,6 +9,7 @@
 #include "TimerWriter.h"
 
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "parallel/DomainDecompBase.h"
 
 void TimerWriter::readXML(XMLfileUnits& xmlconfig) {
@@ -34,7 +35,7 @@ void TimerWriter::readXML(XMLfileUnits& xmlconfig) {
 	}
 	if (_timerNames.empty()) {
 		Log::global_log->error() << "TimerWriter: no timers given. make sure you specify them correctly." << std::endl;
-		Simulation::exit(242367);
+		mardyn_exit(242367);
 	}
 	xmlconfig.changecurrentnode(oldpath);
 }

--- a/src/io/vtk/VTKGridWriter.cpp
+++ b/src/io/vtk/VTKGridWriter.cpp
@@ -48,7 +48,7 @@ void  VTKGridWriter::endStep(
 #ifndef NDEBUG
 	if (container == NULL) {
 		Log::global_log->error() << "VTKGridWriter works only with plottable LinkedCells!" << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 #endif
 
@@ -114,7 +114,7 @@ void  VTKGridWriter::init(ParticleContainer *particleContainer,
 #ifndef NDEBUG
 	if (dynamic_cast<LinkedCells*>(particleContainer) == NULL) {
 		Log::global_log->error() << "VTKGridWriter works only with LinkCells!" << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 #endif
 }

--- a/src/longRange/Homogeneous.cpp
+++ b/src/longRange/Homogeneous.cpp
@@ -8,6 +8,7 @@
 #include "particleContainer/ParticleContainer.h"
 
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
 
 
 Homogeneous::Homogeneous(double cutoffRadius, double cutoffRadiusLJ, Domain* domain, ParticleContainer* particleContainer, Simulation* simulation) {
@@ -81,7 +82,7 @@ void Homogeneous::init() {
 					double tau2 = sqrt(xj * xj + yj * yj + zj * zj);
 					if (tau1 + tau2 >= _cutoffLJ) {
 						Log::global_log->error() << "Error calculating cutoff corrections, rc too small" << std::endl;
-						Simulation::exit(1);
+						mardyn_exit(1);
 					}
 					double eps24;
 					params >> eps24;

--- a/src/longRange/Planar.cpp
+++ b/src/longRange/Planar.cpp
@@ -14,6 +14,7 @@
 #include "utils/Logger.h"
 #include "utils/xmlfileUnits.h"
 #include "utils/FileUtils.h"
+#include "utils/mardyn_assert.h"
 
 
 Planar::Planar(double /*cutoffT*/, double cutoffLJ, Domain* domain, DomainDecompBase* domainDecomposition,
@@ -149,7 +150,7 @@ void Planar::init()
 			Log::global_log->info() << "Long Range Correction: Subject registered" << std::endl;
 		} else {
 			Log::global_log->error() << "Long Range Correction: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			Simulation::exit(-1);
+			mardyn_exit(-1);
 		}
 	}
 }
@@ -194,12 +195,12 @@ void Planar::readXML(XMLfileUnits& xmlconfig)
 	if(_nWriteFreqProfiles < 1)
 	{
 		Log::global_log->error() << "Long Range Correction: Write frequency < 1! Programm exit ..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 	if(_nStopWritingProfiles <= _nStartWritingProfiles)
 	{
 		Log::global_log->error() << "Long Range Correction: Writing profiles 'stop' <= 'start'! Programm exit ..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 	bool bInputIsValid = (bRet1 && bRet2 && bRet3);
 	if(true == bInputIsValid)
@@ -211,7 +212,7 @@ void Planar::readXML(XMLfileUnits& xmlconfig)
 	else
 	{
 		Log::global_log->error() << "Long Range Correction: Write control parameters not valid! Programm exit ..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 }
 

--- a/src/longRange/Planar.h
+++ b/src/longRange/Planar.h
@@ -13,6 +13,8 @@
 #include <cstdint>
 
 #include "molecules/MoleculeForwardDeclaration.h"
+
+class Simulation;
 class Domain;
 class ParticleContainer;
 

--- a/src/molecules/AutoPasSimpleMolecule.cpp
+++ b/src/molecules/AutoPasSimpleMolecule.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "AutoPasSimpleMolecule.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 
 Component* AutoPasSimpleMolecule::_component = nullptr;
 
@@ -20,7 +20,7 @@ AutoPasSimpleMolecule::AutoPasSimpleMolecule(unsigned long id, Component* compon
 	} else if (_component != component and component != nullptr) {
 		Log::global_log->debug() << "AutoPasSimpleMolecule can only handle one component" << std::endl;
 		_component = component;
-		// Simulation::exit(32);
+		// mardyn_exit(32);
 	}
 }
 

--- a/src/molecules/AutoPasSimpleMolecule.cpp
+++ b/src/molecules/AutoPasSimpleMolecule.cpp
@@ -19,6 +19,7 @@ AutoPasSimpleMolecule::AutoPasSimpleMolecule(unsigned long id, Component* compon
 		_component = component;
 	} else if (_component != component and component != nullptr) {
 		Log::global_log->warning() << "AutoPasSimpleMolecule can only handle one component" << std::endl;
+		_component = component;
 		// mardyn_exit(32);
 	}
 }

--- a/src/molecules/AutoPasSimpleMolecule.cpp
+++ b/src/molecules/AutoPasSimpleMolecule.cpp
@@ -18,9 +18,8 @@ AutoPasSimpleMolecule::AutoPasSimpleMolecule(unsigned long id, Component* compon
 	if (_component == nullptr) {
 		_component = component;
 	} else if (_component != component and component != nullptr) {
-		Log::global_log->debug() << "AutoPasSimpleMolecule can only handle one component" << std::endl;
-		_component = component;
-		// mardyn_exit(32);
+		Log::global_log->error() << "AutoPasSimpleMolecule can only handle one component" << std::endl;
+		mardyn_exit(32);
 	}
 }
 

--- a/src/molecules/AutoPasSimpleMolecule.cpp
+++ b/src/molecules/AutoPasSimpleMolecule.cpp
@@ -18,8 +18,8 @@ AutoPasSimpleMolecule::AutoPasSimpleMolecule(unsigned long id, Component* compon
 	if (_component == nullptr) {
 		_component = component;
 	} else if (_component != component and component != nullptr) {
-		Log::global_log->error() << "AutoPasSimpleMolecule can only handle one component" << std::endl;
-		mardyn_exit(32);
+		Log::global_log->warning() << "AutoPasSimpleMolecule can only handle one component" << std::endl;
+		// mardyn_exit(32);
 	}
 }
 

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -5,7 +5,7 @@
 #include "Site.h"
 #include "utils/xmlfileUnits.h"
 #include "utils/Logger.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 
 
 Component::Component(unsigned int id) {
@@ -77,10 +77,10 @@ void Component::readXML(XMLfileUnits& xmlconfig) {
 			addQuadrupole(quadrupoleSite);
 		} else if (siteType == "Tersoff") {
 			Log::global_log->error() << "Tersoff no longer supported:" << siteType << std::endl;
-			Simulation::exit(-1);
+			mardyn_exit(-1);
 		} else {
 			Log::global_log->error() << "Unknown site type:" << siteType << std::endl;
-			Simulation::exit(-1);
+			mardyn_exit(-1);
 		}
 		// go back to initial level, to be consistent, even if no site information is found.
 		xmlconfig.changecurrentnode("..");

--- a/src/molecules/MoleculeInterface.cpp
+++ b/src/molecules/MoleculeInterface.cpp
@@ -12,7 +12,6 @@
 #include <fstream>
 
 #include "utils/Logger.h"
-#include "Simulation.h"
 
 
 bool MoleculeInterface::isLessThan(const MoleculeInterface& m2) const {
@@ -32,7 +31,7 @@ bool MoleculeInterface::isLessThan(const MoleculeInterface& m2) const {
 				return false;
 			else {
 				Log::global_log->error() << "LinkedCells::isFirstParticle: both Particles have the same position" << std::endl;
-				Simulation::exit(1);
+				mardyn_exit(1);
 			}
 		}
 	}

--- a/src/molecules/MoleculeRMM.cpp
+++ b/src/molecules/MoleculeRMM.cpp
@@ -7,6 +7,7 @@
 
 #include "MoleculeRMM.h"
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "molecules/Component.h"
 #include "molecules/Quaternion.h"
 #include "ensemble/EnsembleBase.h"

--- a/src/parallel/CollectiveCommunication.h
+++ b/src/parallel/CollectiveCommunication.h
@@ -3,7 +3,6 @@
 
 #include <mpi.h>
 
-#include "Simulation.h"
 #include "utils/Logger.h"
 #include "CollectiveCommBase.h"
 #include "CollectiveCommunicationInterface.h"
@@ -172,7 +171,7 @@ public:
 			break;
 		default:
 			Log::global_log->error()<<"invalid reducetype, aborting." << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 
 		MPI_CHECK(
@@ -194,7 +193,7 @@ public:
 				break;
 			default:
 				Log::global_log->error()<<"invalid reducetype, aborting." << std::endl;
-				Simulation::exit(1);
+				mardyn_exit(1);
 			}
 			MPI_CHECK(MPI_Allreduce( MPI_IN_PLACE, &_values[i], 1, _types[i], op, _communicator ));
 		}

--- a/src/parallel/CollectiveCommunicationNonBlocking.h
+++ b/src/parallel/CollectiveCommunicationNonBlocking.h
@@ -11,7 +11,7 @@
 #include <map>
 #include <utils/Logger.h>
 #include "CollectiveCommunicationInterface.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 
 #if MPI_VERSION >= 3
 
@@ -41,7 +41,7 @@ public:
 		if (_currentKey != -1) {
 			Log::global_log->error() << "CollectiveCommunicationNonBlocking: previous communication with key " << _currentKey
 					<< " not yet finalized" << std::endl;
-			Simulation::exit(234);
+			mardyn_exit(234);
 		}
 
 		_currentKey = key;
@@ -59,7 +59,7 @@ public:
 			if (not inserted) {
 				Log::global_log->error() << "CollectiveCommunicationNonBlocking: key " << _currentKey
 									<< " could not be inserted. Aborting!" << std::endl;
-				Simulation::exit(498789);
+				mardyn_exit(498789);
 			}
 		}
 		_comms.at(_currentKey).init(communicator, numValues, _currentKey);

--- a/src/parallel/CommunicationBuffer.cpp
+++ b/src/parallel/CommunicationBuffer.cpp
@@ -8,6 +8,7 @@
 #include "CommunicationBuffer.h"
 #include "molecules/Molecule.h"
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "ensemble/EnsembleBase.h"
 
 #include <climits> /* UINT64_MAX */

--- a/src/parallel/CommunicationPartner.cpp
+++ b/src/parallel/CommunicationPartner.cpp
@@ -12,6 +12,7 @@
 #include "ForceHelper.h"
 #include "ParticleData.h"
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "WrapOpenMP.h"
 #include "molecules/Molecule.h"
 #include "parallel/DomainDecompBase.h"
@@ -195,7 +196,7 @@ void CommunicationPartner::initSend(ParticleContainer* moleculeContainer, const 
 		}
 		default:
 			Log::global_log->error() << "[CommunicationPartner] MessageType unknown!" << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 	}
 
 	#ifndef NDEBUG
@@ -599,7 +600,7 @@ void CommunicationPartner::collectLeavingMoleculesFromInvalidParticles(std::vect
 	auto shiftAndAdd = [domain, lowCorner, highCorner, shift, this, &numMolsAlreadyIn](Molecule& m) {
 		if (not m.inBox(lowCorner, highCorner)) {
 			Log::global_log->error() << "trying to remove a particle that is not in the halo region" << std::endl;
-			Simulation::exit(456);
+			mardyn_exit(456);
 		}
 		for (int dim = 0; dim < 3; dim++) {
 			if (shift[dim] != 0) {

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -2,7 +2,6 @@
 #include <fstream>
 
 #include "parallel/DomainDecompBase.h"
-#include "Simulation.h"
 #include "Domain.h"
 #include "ensemble/EnsembleBase.h"
 #include "particleContainer/ParticleContainer.h"
@@ -233,7 +232,7 @@ void DomainDecompBase::handleDomainLeavingParticlesDirect(const HaloRegion& halo
 	auto shiftAndAdd = [&moleculeContainer, haloRegion, shift](Molecule& m) {
 		if (not m.inBox(haloRegion.rmin, haloRegion.rmax)) {
 			Log::global_log->error() << "trying to remove a particle that is not in the halo region" << std::endl;
-			Simulation::exit(456);
+			mardyn_exit(456);
 		}
 		for (int dim = 0; dim < 3; dim++) {
 			if (shift[dim] != 0) {

--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -10,6 +10,7 @@
 #include "DomainDecompMPIBase.h"
 #include "molecules/Molecule.h"
 #include "particleContainer/ParticleContainer.h"
+#include "utils/mardyn_assert.h"
 #include "Simulation.h"
 #include "parallel/NeighbourCommunicationScheme.h"
 #include "ParticleData.h"
@@ -150,7 +151,7 @@ void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, cons
 	} else {
 		Log::global_log->error() << "DomainDecompMPIBase: invalid zonal method specified. Valid values are 'fs', 'es', 'hs', 'mp' and 'nt'"
 				<< std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	Log::global_log->info() << "Using zonal method: " << zonalMethod << std::endl;
 
@@ -166,7 +167,7 @@ void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, cons
 	} else {
 		Log::global_log->error() << "DomainDecompMPIBase: invalid NeighbourCommunicationScheme specified. Valid values are 'direct' and 'indirect'"
 				<< std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 }
 

--- a/src/parallel/DomainDecomposition.cpp
+++ b/src/parallel/DomainDecomposition.cpp
@@ -28,7 +28,7 @@ void DomainDecomposition::initMPIGridDims() {
 			Log::global_log->error() << "\tbut grid is " << _gridSize[0] << " x " << _gridSize[1] << " x " << _gridSize[2] << std::endl;
 			Log::global_log->error() << "\tresulting in " << numProcsGridSize << " subdomains!" << std::endl;
 			Log::global_log->error() << "\tplease check your input file!" << std::endl;
-			Simulation::exit(2134);
+			mardyn_exit(2134);
 		}
 	}
 
@@ -62,7 +62,7 @@ void DomainDecomposition::prepareNonBlockingStage(bool /*forceRebalancing*/, Par
 		Log::global_log->error() << "nonblocking P2P using separate messages for leaving and halo is currently not "
 							   "supported. Please use the indirect neighbor communication scheme!"
 							<< std::endl;
-		Simulation::exit(235861);
+		mardyn_exit(235861);
 	}
 }
 
@@ -75,7 +75,7 @@ void DomainDecomposition::finishNonBlockingStage(bool /*forceRebalancing*/, Part
 		// Would first need to send leaving, then halo -> not good for overlapping!
 		Log::global_log->error()
 			<< "nonblocking P2P using separate messages for leaving and halo is currently not supported." << std::endl;
-		Simulation::exit(235861);
+		mardyn_exit(235861);
 	}
 }
 

--- a/src/parallel/ForceHelper.cpp
+++ b/src/parallel/ForceHelper.cpp
@@ -1,6 +1,12 @@
-#include <particleContainer/ParticleContainer.h>
-#include <particleContainer/ParticleIterator.h>
+
+#include "ForceHelper.h"
+
 #include <variant>
+
+#include "particleContainer/ParticleContainer.h"
+#include "particleContainer/ParticleIterator.h"
+
+#include "utils/mardyn_assert.h"
 
 std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> addValuesAndGetIterator(
 	ParticleContainer* moleculeContainer, const double* position,

--- a/src/parallel/ForceHelper.cpp
+++ b/src/parallel/ForceHelper.cpp
@@ -3,9 +3,6 @@
 
 #include <variant>
 
-#include "particleContainer/ParticleContainer.h"
-#include "particleContainer/ParticleIterator.h"
-
 #include "utils/mardyn_assert.h"
 
 std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> addValuesAndGetIterator(

--- a/src/parallel/ForceHelper.h
+++ b/src/parallel/ForceHelper.h
@@ -2,6 +2,9 @@
 
 #include <variant>
 
+#include "particleContainer/ParticleContainer.h"
+#include "particleContainer/ParticleIterator.h"
+
 /**
  * Adds the force values (force (F), torque (M) and virial (Vi)) of haloMolecule to the particle at the given position.
  * The function will reuse the previousIterator if after an increment it points to a particle at the given position.

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -12,6 +12,9 @@
 #include "NeighborAcquirer.h"
 #include "NeighbourCommunicationScheme.h"
 
+#include "utils/String_utils.h"
+#include "utils/mardyn_assert.h"
+
 #include <numeric>
 #include <memory>
 #include <string>
@@ -56,7 +59,7 @@ void GeneralDomainDecomposition::initializeALL() {
 													  gridCoords, minimalDomainSize);
 #else
 	Log::global_log->error() << "ALL load balancing library not enabled. Aborting." << std::endl;
-	Simulation::exit(24235);
+	mardyn_exit(24235);
 #endif
 	Log::global_log->info() << "GeneralDomainDecomposition initial box: [" << _boxMin[0] << ", " << _boxMax[0] << "] x ["
 					   << _boxMin[1] << ", " << _boxMax[1] << "] x [" << _boxMin[2] << ", " << _boxMax[2] << "]"
@@ -193,7 +196,7 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 				<< particleContainer->getBoundingBoxMax(2) << "\n"
 				<< "Particle: \n" << *iter
 				<< std::endl;
-			Simulation::exit(2315);
+			mardyn_exit(2315);
 		}
 	}
 	particleContainer->clear();
@@ -287,7 +290,7 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 				Log::global_log->error()
 					<< "GeneralDomainDecomposition's gridSize should have three entries if a list is given, but has "
 					<< strings.size() << "!" << std::endl;
-				Simulation::exit(8134);
+				mardyn_exit(8134);
 			}
 			_gridSize = {std::stod(strings[0]), std::stod(strings[1]), std::stod(strings[2])};
 		} else {
@@ -299,7 +302,7 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 				Log::global_log->error() << "GeneralDomainDecomposition's gridSize (" << gridSize
 									<< ") is smaller than the interactionLength (" << _interactionLength
 									<< "). This is forbidden, as it leads to errors! " << std::endl;
-				Simulation::exit(8136);
+				mardyn_exit(8136);
 			}
 		}
 	}
@@ -316,12 +319,12 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			Log::global_log->error() << "GeneralDomainDecomposition: Unknown load balancer " << loadBalancerString
 								<< ". Aborting! Please select a valid option! Valid options: ALL";
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		_loadBalancer->readXML(xmlconfig);
 	} else {
 		Log::global_log->error() << "loadBalancer section missing! Aborting!" << std::endl;
-		Simulation::exit(8466);
+		mardyn_exit(8466);
 	}
 	xmlconfig.changecurrentnode("..");
 }

--- a/src/parallel/GeneralDomainDecomposition.h
+++ b/src/parallel/GeneralDomainDecomposition.h
@@ -8,6 +8,9 @@
 
 #include <optional>
 
+#include "Domain.h"
+
+#include "particleContainer/ParticleContainer.h"
 #include "DomainDecompMPIBase.h"
 #include "LoadBalancer.h"
 

--- a/src/parallel/LoadCalc.cpp
+++ b/src/parallel/LoadCalc.cpp
@@ -8,6 +8,8 @@
 #include <armadillo>
 #endif
 
+#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "utils/nnls.h"
 #include "LoadCalc.h"
 #include "DomainDecompBase.h"
@@ -44,7 +46,7 @@ std::vector<double> TunerLoad::readVec(std::istream& in, int& count1, int& count
 				Log::global_log->error_always_output()
 						<< "This means the files is corrupted. Please remove it (or disallow the tuner to read from inputfiles) before restarting!"
 						<< std::endl;
-				Simulation::exit(1);
+				mardyn_exit(1);
 			}
 		}
 	}
@@ -146,7 +148,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	if (inStr != "Vectorization Tuner File") {
 		Log::global_log->error() << "The tunerfile is corrupted! Missing header \"Vectorization Tuner File\"";
 		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	int count1;
@@ -156,7 +158,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	if (inStr != "own") {
 		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"own\"";
 		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	auto ownTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
@@ -164,7 +166,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	if (inStr != "face") {
 		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"face\"";
 		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	auto faceTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
@@ -172,7 +174,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	if (inStr != "edge") {
 		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"edge\"";
 		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	auto edgeTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
@@ -180,7 +182,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	if (inStr != "corner") {
 		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"corner\"";
 		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	auto cornerTime = readVec(stream, count1, count2);
 	return TunerLoad { count1, count2, std::move(ownTime), std::move(faceTime), std::move(edgeTime), std::move(

--- a/src/parallel/LoadCalc.h
+++ b/src/parallel/LoadCalc.h
@@ -18,8 +18,6 @@
 
 class DomainDecompBase;
 
-#include "Simulation.h"
-
 
 class LoadCalc {
 public:

--- a/src/parallel/NeighbourCommunicationScheme.cpp
+++ b/src/parallel/NeighbourCommunicationScheme.cpp
@@ -11,9 +11,10 @@ class IndirectNeighbourCommunicationScheme;
 #include <mpi.h>
 #include "NeighbourCommunicationScheme.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "DomainDecompMPIBase.h"
 #include "NeighborAcquirer.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "ZonalMethods/ZonalMethod.h"
 #include "molecules/Molecule.h"
 #include "particleContainer/ParticleContainer.h"
@@ -265,7 +266,7 @@ void DirectNeighbourCommunicationScheme::initExchangeMoleculesMPI(ParticleContai
 			neighbour.print(ss);
 			Log::global_log->error_always_output() << ss.str() << std::endl;
 		}
-		Simulation::exit(544);
+		mardyn_exit(544);
 	}
 }
 
@@ -395,7 +396,7 @@ void DirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI(ParticleCo
 				});
 			}
 
-			Simulation::exit(457);
+			mardyn_exit(457);
 		}
 
 	}  // while not allDone
@@ -424,7 +425,7 @@ void NeighbourCommunicationScheme::selectNeighbours(MessageType msgType, bool im
 			Log::global_log->error() << "WRONG type in selectNeighbours - this should not be used for push-pull-partners "
 								   "selectNeighbours method"
 								<< std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 			break;
 	}
 }
@@ -593,7 +594,7 @@ void IndirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI1D(Partic
 			for (int i = 0; i < numNeighbours; ++i) {
 				(*_neighbours)[d][i].deadlockDiagnosticSendRecv();
 			}
-			Simulation::exit(457);
+			mardyn_exit(457);
 		}
 
 	} // while not allDone

--- a/src/parallel/NonBlockingMPIHandlerBase.cpp
+++ b/src/parallel/NonBlockingMPIHandlerBase.cpp
@@ -7,6 +7,7 @@
 
 #include "NonBlockingMPIHandlerBase.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "parallel/DomainDecompMPIBase.h"
 #include "particleContainer/ParticleContainer.h"
 #include "particleContainer/adapter/CellProcessor.h"

--- a/src/parallel/ParticleDataRMM.cpp
+++ b/src/parallel/ParticleDataRMM.cpp
@@ -5,6 +5,7 @@
 
 #include "ensemble/EnsembleBase.h"
 #include "molecules/Molecule.h"
+#include "utils/mardyn_assert.h"
 #include "Simulation.h"
 #include "utils/Logger.h"
 
@@ -29,7 +30,7 @@ void ParticleDataRMM::getMPIType(MPI_Datatype &sendPartType) {
 		types[1] = MPI_FLOAT;
 	} else {
 		Log::global_log->error() << "invalid size of vcp_real_calc";
-		Simulation::exit(4852);
+		mardyn_exit(4852);
 	}
 
 	//if the following statement is not true, then the 6 double values do not follow one after the other.

--- a/src/parallel/ParticleForceData.cpp
+++ b/src/parallel/ParticleForceData.cpp
@@ -3,7 +3,7 @@
 #include <mpi.h>
 
 #include "molecules/Molecule.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "utils/Logger.h"
 
 

--- a/src/parallel/ResilienceComm.cpp
+++ b/src/parallel/ResilienceComm.cpp
@@ -11,7 +11,9 @@
 #include <climits> /* UINT64_MAX */
 
 #include <sstream>
+
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
 
 //pretty much default
 ResilienceComm::ResilienceComm(int numProcs, int rank)

--- a/src/parallel/ResilienceComm.h
+++ b/src/parallel/ResilienceComm.h
@@ -8,7 +8,6 @@
 #define SRC_PARALLEL_RESILIENCECOMM_H_
 
 #ifdef ENABLE_MPI
-#include "utils/mardyn_assert.h"
 
 #include <memory>
 #include <vector>

--- a/src/parallel/StaticIrregDomainDecomposition.cpp
+++ b/src/parallel/StaticIrregDomainDecomposition.cpp
@@ -74,7 +74,7 @@ void StaticIrregDomainDecomposition::readXML(XMLfileUnits &xmlconfig) {
                 << " axis have a non-natural number! Only integer weights > "
                    "0 allowed, please check XML file!"
                 << std::endl;
-            Simulation::exit(5003);
+            mardyn_exit(5003);
           }
           _subdomainWeights[i].push_back(temp);
           if (ss.peek() == ',' || ss.peek() == ' ') // skip commas and spaces

--- a/src/parallel/ZonalMethods/Midpoint.h
+++ b/src/parallel/ZonalMethods/Midpoint.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include "Simulation.h"
 #include "ZonalMethod.h"
 
 /**

--- a/src/parallel/ZonalMethods/ZonalMethod.cpp
+++ b/src/parallel/ZonalMethods/ZonalMethod.cpp
@@ -6,7 +6,8 @@
  */
 
 #include "ZonalMethod.h"
-#include "Simulation.h"
+
+#include <algorithm>
 
 ZonalMethod::ZonalMethod() = default;
 

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -8,6 +8,7 @@
 #include <particleContainer/adapter/VectorizedCellProcessor.h>
 #include <exception>
 #include "Domain.h"
+#include "Simulation.h"
 #include "utils/mardyn_assert.h"
 #include "autopas/utils/StringUtils.h"
 #include "autopas/utils/logging/Logger.h"

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -8,7 +8,7 @@
 #include <particleContainer/adapter/VectorizedCellProcessor.h>
 #include <exception>
 #include "Domain.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "autopas/utils/StringUtils.h"
 #include "autopas/utils/logging/Logger.h"
 #include "parallel/DomainDecompBase.h"
@@ -186,7 +186,7 @@ auto parseAutoPasOption(XMLfileUnits &xmlconfig, const std::string &xmlString,
 		Log::global_log->error() << e.what() << std::endl;
 		Log::global_log->error() << "Possible options: "
 							<< autopas::utils::ArrayUtils::to_string(OptionType::getAllOptions()) << std::endl;
-		Simulation::exit(4432);
+		mardyn_exit(4432);
 		// dummy return
 		return decltype(OptionType::template parseOptions<OutputContainer>(""))();
 	}
@@ -398,7 +398,7 @@ void AutoPasContainer::update() {
 							   "Remaining invalid particles:\n"
 							<< autopas::utils::ArrayUtils::to_string(_invalidParticles, "\n", {"", ""})
 							<< std::endl;
-		Simulation::exit(434);
+		mardyn_exit(434);
 	}
 
 	_invalidParticles = _autopasContainer.updateContainer();

--- a/src/particleContainer/FullParticleCell.cpp
+++ b/src/particleContainer/FullParticleCell.cpp
@@ -9,9 +9,8 @@
 #include "particleContainer/FullParticleCell.h"
 #include "molecules/Molecule.h"
 #include "utils/UnorderedVector.h"
-#include "Simulation.h"
-
 #include "utils/mardyn_assert.h"
+
 #include <vector>
 
 

--- a/src/particleContainer/LinkedCellTraversals/C08CellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/C08CellPairTraversal.h
@@ -79,7 +79,7 @@ void C08CellPairTraversal<CellTemplate, eighthShell>::traverseCellPairsOuter(
 		CellProcessor& cellProcessor) {
 	if(eighthShell){
 		Log::global_log->error() << "eightshell + overlapping not yet supported." << std::endl;
-		Simulation::exit(-2);
+		mardyn_exit(-2);
 	}
 	using std::array;
 

--- a/src/particleContainer/LinkedCellTraversals/NeutralTerritoryTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/NeutralTerritoryTraversal.h
@@ -125,14 +125,14 @@ void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairs(CellProcessor& c
 template <class CellTemplate>
 void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairsOuter(CellProcessor& cellProcessor) {
 	Log::global_log->error() << "NT: overlapping Comm not implemented." << std::endl;
-	Simulation::exit(46);
+	mardyn_exit(46);
 }
 
 template <class CellTemplate>
 void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairsInner(CellProcessor& cellProcessor, unsigned stage,
 																	 unsigned stageCount) {
 	Log::global_log->error() << "NT: overlapping Comm not implemented." << std::endl;
-	Simulation::exit(47);
+	mardyn_exit(47);
 }
 
 template <class CellTemplate>

--- a/src/particleContainer/LinkedCellTraversals/OriginalCellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/OriginalCellPairTraversal.h
@@ -75,7 +75,7 @@ void OriginalCellPairTraversal<CellTemplate>::rebuild(std::vector<CellTemplate> 
 		}
 	} else {
 		Log::global_log->error() << "OriginalCellPairTraversalDat::rebuild was called with incompatible Traversal data!" << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 }
 

--- a/src/particleContainer/LinkedCellTraversals/QuickschedTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/QuickschedTraversal.h
@@ -10,7 +10,7 @@
 
 #include "C08BasedTraversals.h"
 #include "utils/Logger.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "particleContainer/LinkedCells.h"
 
 #ifdef QUICKSCHED
@@ -111,7 +111,7 @@ void QuickschedTraversal<CellTemplate>::init() {
                     Log::global_log->error() << "Blocksize is bigger than number of cells in dimension "
                                         << (char) ('x' + i) << ". (" << _taskBlocksize[i] << " > "
                                         << this->_dims[i] << ")" << std::endl;
-                    Simulation::exit(1);
+                    mardyn_exit(1);
                 }
             }
 

--- a/src/particleContainer/LinkedCells.cpp
+++ b/src/particleContainer/LinkedCells.cpp
@@ -95,7 +95,7 @@ LinkedCells::LinkedCells(double bBoxMin[3], double bBoxMax[3],
 		Log::global_log->error_always_output() << "_boxWidthInNumCells: " << _boxWidthInNumCells[0]
 				<< " / " << _boxWidthInNumCells[1] << " / "
 				<< _boxWidthInNumCells[2] << std::endl;
-		Simulation::exit(5);
+		mardyn_exit(5);
 	}
 
 	initializeCells();
@@ -156,7 +156,7 @@ bool LinkedCells::rebuild(double bBoxMin[3], double bBoxMax[3]) {
 		// in each dimension at least one layer of (inner+boundary) cells necessary
 		if (_cellsPerDimension[dim] == 2 * _haloWidthInNumCells[dim]) {
 			Log::global_log->error_always_output() << "LinkedCells::rebuild: region too small" << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 
 		numberOfCells *= _cellsPerDimension[dim];
@@ -233,7 +233,7 @@ void LinkedCells::check_molecules_in_box() {
 				<< ") x [" << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMax[1] << ") x [" << _haloBoundingBoxMin[2]
 				<< ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
 		Log::global_log->error() << "Particles will be lost. Aborting simulation." << std::endl;
-		Simulation::exit(311);
+		mardyn_exit(311);
 	}
 }
 
@@ -293,7 +293,7 @@ void LinkedCells::update() {
 
 	if (numBadMolecules > 0) {
 		Log::global_log->error() << "Found " << numBadMolecules << " outside of their correct cells. Aborting." << std::endl;
-		Simulation::exit(311);
+		mardyn_exit(311);
 	}
 #endif
 }
@@ -543,7 +543,7 @@ void LinkedCells::addParticles(std::vector<Molecule>& particles, bool checkWheth
 void LinkedCells::traverseNonInnermostCells(CellProcessor& cellProcessor) {
 	if (not _cellsValid) {
 		Log::global_log->error() << "Cell structure in LinkedCells (traverseNonInnermostCells) invalid, call update first" << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	_traversalTuner->traverseCellPairsOuter(cellProcessor);
@@ -552,7 +552,7 @@ void LinkedCells::traverseNonInnermostCells(CellProcessor& cellProcessor) {
 void LinkedCells::traversePartialInnermostCells(CellProcessor& cellProcessor, unsigned int stage, int stageCount) {
 	if (not _cellsValid) {
 		Log::global_log->error() << "Cell structure in LinkedCells (traversePartialInnermostCells) invalid, call update first" << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	_traversalTuner->traverseCellPairsInner(cellProcessor, stage, stageCount);
@@ -563,7 +563,7 @@ void LinkedCells::traverseCells(CellProcessor& cellProcessor) {
 		Log::global_log->error()
 				<< "Cell structure in LinkedCells (traversePairs) invalid, call update first"
 				<< std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	cellProcessor.initTraversal();
@@ -612,7 +612,7 @@ void LinkedCells::deleteOuterParticles() {
 		Log::global_log->error()
 				<< "Cell structure in LinkedCells (deleteOuterParticles) invalid, call update first"
 				<< std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}*/
 
 	const size_t numHaloCells = _haloCellIndices.size();
@@ -837,7 +837,7 @@ unsigned long int LinkedCells::getCellIndexOfMolecule(Molecule* molecule) const 
 			Log::global_log->error() << "Molecule:\n" << *molecule << std::endl;
 			Log::global_log->error() << "_haloBoundingBoxMin = (" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMin[2] << ")" << std::endl;
 			Log::global_log->error() << "_haloBoundingBoxMax = (" << _haloBoundingBoxMax[0] << ", " << _haloBoundingBoxMax[1] << ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		#endif
 		//this version is sensitive to roundoffs, if we have molecules (initialized) precisely at position 0.0:
@@ -886,7 +886,7 @@ unsigned long int LinkedCells::getCellIndexOfPoint(const double point[3]) const 
 			Log::global_log->error() << "Point p = (" << localPoint[0] << ", " << localPoint[1] << ", " << localPoint[2] << ")" << std::endl;
 			Log::global_log->error() << "_haloBoundingBoxMin = (" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMin[2] << ")" << std::endl;
 			Log::global_log->error() << "_haloBoundingBoxMax = (" << _haloBoundingBoxMax[0] << ", " << _haloBoundingBoxMax[1] << ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		#endif
 
@@ -1009,7 +1009,7 @@ void LinkedCells::deleteMolecule(ParticleIterator &moleculeIter, const bool& reb
           Log::global_log->error_always_output()
               << "coordinates for atom deletion lie outside bounding box."
               << std::endl;
-          Simulation::exit(1);
+          mardyn_exit(1);
         }
 		_cells[cellid].buildSoACaches();
 	}

--- a/src/particleContainer/TraversalTuner.h
+++ b/src/particleContainer/TraversalTuner.h
@@ -155,7 +155,7 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 		Log::global_log->info() << "Using QuickschedTraversal." << std::endl;
 #ifndef QUICKSCHED
 		Log::global_log->error() << "MarDyn was compiled without Quicksched Support. Aborting!" << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 #endif
 	} else if (dynamic_cast<SlicedCellPairTraversal<CellTemplate> *>(_optimalTraversal))
 		Log::global_log->info() << "Using SlicedCellPairTraversal." << std::endl;
@@ -165,7 +165,7 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 	if (_cellsInCutoff > _optimalTraversal->maxCellsInCutoff()) {
 		Log::global_log->error() << "Traversal supports up to " << _optimalTraversal->maxCellsInCutoff()
 							<< " cells in cutoff, but value is chosen as " << _cellsInCutoff << std::endl;
-		Simulation::exit(45);
+		mardyn_exit(45);
 	}
 }
 
@@ -245,7 +245,7 @@ void TraversalTuner<CellTemplate>::readXML(XMLfileUnits &xmlconfig) {
 												<< " direction is <2 and thereby invalid! ("
 												<< quiData->taskBlockSize[j] << ")"
 												<< std::endl;
-							Simulation::exit(1);
+							mardyn_exit(1);
 						}
 					}
 					break;
@@ -307,7 +307,7 @@ void TraversalTuner<CellTemplate>::rebuild(std::vector<CellTemplate> &cells, con
 				} break;
 				default:
 					Log::global_log->error() << "Unknown traversal data found in TraversalTuner._traversals!" << std::endl;
-					Simulation::exit(1);
+					mardyn_exit(1);
 			}
 		}
 		traversalPointerReference->rebuild(cells, dims, cellLength, cutoff, traversalData);

--- a/src/particleContainer/adapter/ParticlePairs2PotForceAdapter.h
+++ b/src/particleContainer/adapter/ParticlePairs2PotForceAdapter.h
@@ -175,7 +175,7 @@ public:
                 FluidPot(molecule1, molecule2, params, distanceVector, dummy1, dummy2, dummy3, calculateLJ);
                 return dummy1 / 6.0 + dummy2 + dummy3;
             default:
-                Simulation::exit(666);
+                mardyn_exit(666);
         }
         return 0.0;
 	}

--- a/src/particleContainer/adapter/tests/RealAccumVecTest.cpp
+++ b/src/particleContainer/adapter/tests/RealAccumVecTest.cpp
@@ -10,7 +10,6 @@
 #include "particleContainer/adapter/vectorization/SIMD_DEFINITIONS.h"
 #include "particleContainer/adapter/vectorization/MaskVec.h"
 #include "utils/AlignedArray.h"
-#include "utils/mardyn_assert.h"
 
 TEST_SUITE_REGISTRATION(RealAccumVecTest);
 

--- a/src/particleContainer/adapter/tests/RealCalcVecTest.cpp
+++ b/src/particleContainer/adapter/tests/RealCalcVecTest.cpp
@@ -6,7 +6,6 @@
 #include "RealCalcVecTest.h"
 #include "particleContainer/adapter/vectorization/SIMD_DEFINITIONS.h"
 #include "utils/AlignedArray.h"
-#include "utils/mardyn_assert.h"
 
 #if VCP_VEC_TYPE == VCP_VEC_AVX2 or \
 	VCP_VEC_TYPE == VCP_VEC_KNL or \

--- a/src/particleContainer/adapter/vectorization/RealVec.h
+++ b/src/particleContainer/adapter/vectorization/RealVec.h
@@ -10,7 +10,7 @@
 
 #include "SIMD_TYPES.h"
 #include "MaskVec.h"
-#include "utils/mardyn_assert.h"
+
 #include <fstream>
 #include <cmath>
 

--- a/src/particleContainer/adapter/vectorization/RealVecDouble.h
+++ b/src/particleContainer/adapter/vectorization/RealVecDouble.h
@@ -10,6 +10,8 @@
 
 #include "RealVec.h"
 
+#include "utils/mardyn_assert.h"
+
 // keep this file and RealVecFloat as close as possible, so that they can be examined via diff!
 
 namespace vcp {

--- a/src/particleContainer/adapter/vectorization/RealVecFloat.h
+++ b/src/particleContainer/adapter/vectorization/RealVecFloat.h
@@ -10,6 +10,8 @@
 
 #include "RealVec.h"
 
+#include "utils/mardyn_assert.h"
+
 // keep this file and RealVecDouble as close as possible, so that they can be examined via diff!
 
 namespace vcp {

--- a/src/particleContainer/tests/ParticleContainerFactory.cpp
+++ b/src/particleContainer/tests/ParticleContainerFactory.cpp
@@ -14,6 +14,7 @@
 #include "parallel/DomainDecomposition.h"
 #endif
 #include "Domain.h"
+#include "Simulation.h"
 
 #include "io/ASCIIReader.h"
 #include "utils/Logger.h"

--- a/src/plugins/COMaligner.cpp
+++ b/src/plugins/COMaligner.cpp
@@ -31,7 +31,7 @@ void COMaligner::readXML(XMLfileUnits& xmlconfig){
         Log::global_log -> error() << "[COMaligner] HALTING SIMULATION" << std::endl;
         _enabled = false;
         // HALT SIM
-        Simulation::exit(1);
+        mardyn_exit(1);
         return;
     }
 

--- a/src/plugins/DirectedPM.cpp
+++ b/src/plugins/DirectedPM.cpp
@@ -112,7 +112,7 @@ void DirectedPM::beforeForces(ParticleContainer* particleContainer, DomainDecomp
 							Log::global_log->error()
 								<< "Coordinates off center (" << xc << " / " << yc << " / " << zc << ").\n";
 							Log::global_log->error() << "unID = " << unID << "\n";
-							Simulation::exit(707);
+							mardyn_exit(707);
 						}
 						// ADD VELOCITCY AND VIRIAL TO RESPECTIVE BIN
 						_localnumberOfParticles[unID] += 1.;

--- a/src/plugins/Dropaccelerator.cpp
+++ b/src/plugins/Dropaccelerator.cpp
@@ -7,6 +7,9 @@
 
 #include "Dropaccelerator.h"
 
+#include "Simulation.h"
+#include "utils/mardyn_assert.h"
+
 #ifdef ENABLE_MPI
 #include "mpi.h"
 #endif
@@ -32,7 +35,7 @@ void Dropaccelerator::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->error() << "[Dropaccelerator] HALTING SIMULATION" << std::endl;
 		_enabled = false;
 		// HALT SIM
-		Simulation::exit(1);
+		mardyn_exit(1);
 		return;
 	}
 

--- a/src/plugins/Dropaligner.cpp
+++ b/src/plugins/Dropaligner.cpp
@@ -27,7 +27,7 @@ void Dropaligner::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->error() << "[Dropaligner] HALTING SIMULATION" << std::endl;
 		_enabled = false;
 		// HALT SIM
-		Simulation::exit(1);
+		mardyn_exit(1);
 		return;
 	}
 

--- a/src/plugins/ExamplePlugin.cpp
+++ b/src/plugins/ExamplePlugin.cpp
@@ -11,6 +11,8 @@
 #include "utils/xmlfileUnits.h"
 #include "utils/Logger.h"
 
+#include <string>
+
 
 void ExamplePlugin::readXML(XMLfileUnits& xmlconfig) {
 	_writeFrequency = 1;

--- a/src/plugins/ExamplePlugin.cpp
+++ b/src/plugins/ExamplePlugin.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "ExamplePlugin.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 
 #include "utils/xmlfileUnits.h"
 #include "utils/Logger.h"
@@ -58,7 +58,7 @@ void ExamplePlugin::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->error()
 				<< "Valid options are: all, beforeEventNewTimestep, beforeForces, afterForces, endStep, init, finish."
 				<< std::endl;
-		Simulation::exit(11);
+		mardyn_exit(11);
 	}
 }
 

--- a/src/plugins/ExamplePlugin.cpp
+++ b/src/plugins/ExamplePlugin.cpp
@@ -11,7 +11,7 @@
 #include "utils/xmlfileUnits.h"
 #include "utils/Logger.h"
 
-#include <string>
+#include <cstring>
 
 
 void ExamplePlugin::readXML(XMLfileUnits& xmlconfig) {

--- a/src/plugins/ExamplePlugin.cpp
+++ b/src/plugins/ExamplePlugin.cpp
@@ -6,8 +6,8 @@
  */
 
 #include "ExamplePlugin.h"
-#include "utils/mardyn_assert.h"
 
+#include "utils/mardyn_assert.h"
 #include "utils/xmlfileUnits.h"
 #include "utils/Logger.h"
 

--- a/src/plugins/ExamplePlugin.cpp
+++ b/src/plugins/ExamplePlugin.cpp
@@ -30,27 +30,27 @@ void ExamplePlugin::readXML(XMLfileUnits& xmlconfig) {
 			<< std::endl;
 
 	const char* str = displaySelectorString.c_str();
-	if (strcmp(str, "all") == 0) {
+	if (std::strcmp(str, "all") == 0) {
 		_displaySelector = WhereToDisplay::ALL;
 		Log::global_log->info() << "Displaying at all plugin positions."
 				<< std::endl;
-	} else if (strcmp(str, "beforeEventNewTimestep") == 0) {
+	} else if (std::strcmp(str, "beforeEventNewTimestep") == 0) {
 		_displaySelector = WhereToDisplay::BEFORE_EVENT_NEW_TIMESTEP;
 		Log::global_log->info() << "Displaying at beforeEventNewTimestep."
 				<< std::endl;
-	} else if (strcmp(str, "beforeForces") == 0) {
+	} else if (std::strcmp(str, "beforeForces") == 0) {
 		_displaySelector = WhereToDisplay::BEFORE_FORCES;
 		Log::global_log->info() << "Displaying at beforeForces." << std::endl;
-	} else if (strcmp(str, "afterForces") == 0) {
+	} else if (std::strcmp(str, "afterForces") == 0) {
 		_displaySelector = WhereToDisplay::AFTER_FORCES;
 		Log::global_log->info() << "Displaying at afterForces." << std::endl;
-	} else if (strcmp(str, "endStep") == 0) {
+	} else if (std::strcmp(str, "endStep") == 0) {
 		_displaySelector = WhereToDisplay::END_STEP;
 		Log::global_log->info() << "Displaying at endStep." << std::endl;
-	} else if (strcmp(str, "init") == 0) {
+	} else if (std::strcmp(str, "init") == 0) {
 		_displaySelector = WhereToDisplay::AT_INIT;
 		Log::global_log->info() << "Displaying at init." << std::endl;
-	} else if (strcmp(str, "finish") == 0) {
+	} else if (std::strcmp(str, "finish") == 0) {
 		_displaySelector = WhereToDisplay::AT_FINISH;
 		Log::global_log->info() << "Displaying at finish." << std::endl;
 	} else {

--- a/src/plugins/ExamplePlugin.h
+++ b/src/plugins/ExamplePlugin.h
@@ -10,6 +10,8 @@
 
 #include "PluginBase.h"
 
+#include <string>
+
 /**
  * The purpose of this class is to show the basic usage of Plugins.
  * It just outputs a string that the user specified in the XML at the

--- a/src/plugins/FixRegion.cpp
+++ b/src/plugins/FixRegion.cpp
@@ -32,7 +32,7 @@ void FixRegion::init(ParticleContainer* particleContainer, DomainDecompBase* dom
 		Log::global_log->error() << "[FixRegion] INVALID INPUT!!! DISABLED!" << std::endl;
 		Log::global_log->error() << "[FixRegion] HALTING SIMULATION" << std::endl;
 		// HALT SIM
-		Simulation::exit(1);
+		mardyn_exit(1);
 		return;
 	}
 

--- a/src/plugins/MaxCheck.cpp
+++ b/src/plugins/MaxCheck.cpp
@@ -6,11 +6,15 @@
  */
 
 #include "MaxCheck.h"
+
 #include "particleContainer/ParticleContainer.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "parallel/DomainDecompBase.h"
 #include "molecules/Molecule.h"
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
+
 #include <array>
 
 
@@ -72,7 +76,7 @@ void MaxCheck::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "[MaxCheck] Number of component targets: " << numTargets << std::endl;
 	if (numTargets < 1) {
 		Log::global_log->warning() << "[MaxCheck] No target parameters specified. Program exit ..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator nodeIter;

--- a/src/plugins/Mirror.cpp
+++ b/src/plugins/Mirror.cpp
@@ -1,9 +1,12 @@
 #include "Mirror.h"
 #include "particleContainer/ParticleContainer.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "parallel/DomainDecompBase.h"
 #include "molecules/Molecule.h"
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
+
 #include "plugins/NEMD/DistControl.h"
 
 #include <string>
@@ -83,7 +86,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 			subject->registerObserver(this);
 		else {
 			Log::global_log->error() << "[Mirror] Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			Simulation::exit(-1);
+			mardyn_exit(-1);
 		}
 	}
 	Log::global_log->info() << "[Mirror] Enabled at position: y = " << _position.coord << std::endl;
@@ -122,14 +125,14 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 	if(MT_ZERO_GRADIENT == _type)
 	{
 		Log::global_log->error() << "[Mirror] Method 3 (MT_ZERO_GRADIENT) is deprecated. Use 5 (MT_MELAND_2004) instead. Program exit ..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	/** normal distributions */
 	if(MT_NORMDISTR_MB == _type)
 	{
 		Log::global_log->error() << "[Mirror] Method 4 (MT_NORMDISTR_MB) is deprecated. Use 5 (MT_MELAND_2004) instead. Program exit ..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	/** Meland2004 */
@@ -140,7 +143,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 		if(!xmlconfig.getNodeValue("meland/velo_target", _melandParams.velo_target))
 		{
 			Log::global_log->error() << "[Mirror] Meland: Parameters for method 5 (MT_MELAND_2004) provided in config-file *.xml corrupted/incomplete. Program exit ..." << std::endl;
-			Simulation::exit(-2004);
+			mardyn_exit(-2004);
 		}
 		else {
 			Log::global_log->info() << "[Mirror] Meland: target velocity = " << _melandParams.velo_target << std::endl;
@@ -166,12 +169,12 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 
 		if (not bRet) {
 			Log::global_log->error() << "[Mirror] Ramping: Parameters for method 5 (MT_RAMPING) provided in config-file *.xml corrupted/incomplete. Program exit ..." << std::endl;
-			Simulation::exit(-1);
+			mardyn_exit(-1);
 		}
 		else {
 			if(_rampingParams.startStep > _rampingParams.stopStep) {
 				Log::global_log->error() << "[Mirror] Ramping: Start > Stop. Program exit ..." << std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 			else {
 				Log::global_log->info() << "[Mirror] Ramping from " << _rampingParams.startStep << " to " << _rampingParams.stopStep << std::endl;
@@ -183,7 +186,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 						break;
 					default:
 						Log::global_log->error() << "[Mirror] Ramping: No proper treatment was set. Use 0 (Deletion) or 1 (Transmission). Program exit ..." << std::endl;
-						Simulation::exit(-1);
+						mardyn_exit(-1);
 				}
 				Log::global_log->info() << "[Mirror] Ramping: Treatment for non-reflected particles: " << _rampingParams.treatment << " ( " << treatmentStr << " ) " << std::endl;
 			}

--- a/src/plugins/MirrorSystem.cpp
+++ b/src/plugins/MirrorSystem.cpp
@@ -1,6 +1,7 @@
 #include "MirrorSystem.h"
 #include "particleContainer/ParticleContainer.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "parallel/DomainDecompBase.h"
 #include "molecules/Molecule.h"
 #include "utils/Logger.h"

--- a/src/plugins/NEMD/DensityControl.cpp
+++ b/src/plugins/NEMD/DensityControl.cpp
@@ -22,11 +22,13 @@
 
 #include "DensityControl.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "molecules/Molecule.h"
 #include "parallel/DomainDecompBase.h"
 #include "particleContainer/ParticleContainer.h"
 #include "utils/CommVar.h"
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
 
 DensityControl::DensityControl() = default;
 DensityControl::~DensityControl() = default;
@@ -85,7 +87,7 @@ void DensityControl::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->error() << "[DensityControl] Number of component IDs specified in element <priority>...</priority>"
 							<< " does not match the number of components in the simulation. Programm exit ..."
 							<< std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	// targets
@@ -110,7 +112,7 @@ void DensityControl::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "[DensityControl] Number of component targets: " << numTargets << std::endl;
 	if (numTargets < 1) {
 		Log::global_log->error() << "[DensityControl] No target parameters specified. Program exit ..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 	const std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator nodeIter;

--- a/src/plugins/NEMD/DistControl.cpp
+++ b/src/plugins/NEMD/DistControl.cpp
@@ -15,6 +15,7 @@
 #include "utils/DynAlloc.h"
 #include "utils/Math.h"
 #include "utils/xmlfileUnits.h"
+#include "utils/mardyn_assert.h"
 #include "plugins/Mirror.h"  // TODO: Not so nice that DistControl has to know Mirror plugin explicitly
 
 #include <iostream>
@@ -79,7 +80,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 	if( !xmlconfig.getNodeValue("subdivision@type", strSubdivisionType) )
 	{
 		Log::global_log->error() << "[DistControl] Missing attribute \"subdivision@type\"! Programm exit..." << std::endl;
-		exit(-1);
+		mardyn_exit(-1);
 	}
 	if("number" == strSubdivisionType)
 	{
@@ -87,7 +88,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		if( !xmlconfig.getNodeValue("subdivision/number", nNumSlabs) )
 		{
 			Log::global_log->error() << "[DistControl] Missing element \"subdivision/number\"! Programm exit..." << std::endl;
-			exit(-1);
+			mardyn_exit(-1);
 		}
 		else
 			this->SetSubdivision(nNumSlabs);
@@ -98,7 +99,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		if( !xmlconfig.getNodeValue("subdivision/width", dSlabWidth) )
 		{
 			Log::global_log->error() << "[DistControl] Missing element \"subdivision/width\"! Programm exit..." << std::endl;
-			exit(-1);
+			mardyn_exit(-1);
 		}
 		else
 			this->SetSubdivision(dSlabWidth);
@@ -106,7 +107,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 	else
 	{
 		Log::global_log->error() << "[DistControl] Wrong attribute \"subdivision@type\". Expected: type=\"number|width\"! Programm exit..." << std::endl;
-		exit(-1);
+		mardyn_exit(-1);
 	}
 
 	// init method
@@ -137,7 +138,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "[DistControl] Missing elements \"init/values/left\" or \"init/values/right\" or both! Programm exit..." << std::endl;
-			exit(-1);
+			mardyn_exit(-1);
 		}
 	}
 	else if("file" == strInitMethodType)
@@ -154,14 +155,14 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "[DistControl] Missing elements \"init/file\" or \"init/simstep\" or both! Programm exit..." << std::endl;
-			exit(-1);
+			mardyn_exit(-1);
 		}
 	}
 	else
 	{
 		Log::global_log->error() << "[DistControl] Wrong attribute \"init@type\", type = " << strInitMethodType << ", "
 				"expected: type=\"startconfig|values|file\"! Programm exit..." << std::endl;
-		exit(-1);
+		mardyn_exit(-1);
 	}
 
 	// update method
@@ -189,7 +190,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "[DistControl] Missing elements \"method/componentID\" or \"method/density\" or both! Programm exit..." << std::endl;
-			exit(-1);
+			mardyn_exit(-1);
 		}
 	}
 	else if("denderiv" == strUpdateMethodType)
@@ -213,14 +214,14 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "[DistControl] Missing elements \"method/componentID\" or \"method/density\" or both! Programm exit..." << std::endl;
-			exit(-1);
+			mardyn_exit(-1);
 		}
 	}
 	else
 	{
 		Log::global_log->error() << "[DistControl] Wrong attribute \"method@type\", type = " << strUpdateMethodType << ", "
 				"expected: type=\"density|denderiv\"! Programm exit..." << std::endl;
-		exit(-1);
+		mardyn_exit(-1);
 	}
 }
 
@@ -266,7 +267,7 @@ void DistControl::PrepareSubdivision()
 	case SDOPT_UNKNOWN:
 	default:
 		Log::global_log->error() << "[DistControl] PrepareSubdivision(): Neither _binParams.width nor _binParams.count was set correctly! Programm exit..." << std::endl;
-		exit(-1);
+		mardyn_exit(-1);
 	}
 
 	_binParams.invWidth = 1. / _binParams.width;
@@ -702,7 +703,7 @@ void DistControl::UpdatePositionsInit(ParticleContainer* particleContainer)
 	case DCIM_UNKNOWN:
 	default:
 		Log::global_log->error() << "[DistControl] Wrong Init Method! Programm exit..." << std::endl;
-		exit(-1);
+		mardyn_exit(-1);
 	}
 
 #ifndef NDEBUG
@@ -738,7 +739,7 @@ void DistControl::UpdatePositions(const uint64_t& simstep)
 	case DCUM_UNKNOWN:
 	default:
 		Log::global_log->error() << "[DistControl] UpdatePositions() Corrupted code!!! Programm exit..." << std::endl;
-		exit(-1);
+		mardyn_exit(-1);
 	}
 
 	// update positions

--- a/src/plugins/NEMD/DriftCtrl.cpp
+++ b/src/plugins/NEMD/DriftCtrl.cpp
@@ -1,6 +1,7 @@
 #include "DriftCtrl.h"
 #include "particleContainer/ParticleContainer.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "parallel/DomainDecompBase.h"
 #include "molecules/Molecule.h"
 #include "utils/Logger.h"

--- a/src/plugins/NEMD/ExtractPhase.cpp
+++ b/src/plugins/NEMD/ExtractPhase.cpp
@@ -8,6 +8,7 @@
 #include "ExtractPhase.h"
 #include "particleContainer/ParticleContainer.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "parallel/DomainDecompBase.h"
 #include "molecules/Molecule.h"
 #include "utils/Logger.h"

--- a/src/plugins/NEMD/MettDeamon.h
+++ b/src/plugins/NEMD/MettDeamon.h
@@ -12,6 +12,7 @@
 #include "molecules/Molecule.h"
 #include "Domain.h"
 #include "utils/CommVar.h"
+#include "utils/Random.h"
 //#include "NEMD/Request.h"
 
 #include <map>

--- a/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
+++ b/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
@@ -1,10 +1,12 @@
 #include "MettDeamonFeedrateDirector.h"
 #include "particleContainer/ParticleContainer.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "parallel/DomainDecompBase.h"
 #include "molecules/Molecule.h"
 #include "utils/Logger.h"
 #include "utils/FileUtils.h"
+#include "utils/mardyn_assert.h"
 #include "plugins/Mirror.h"
 #include "plugins/NEMD/MettDeamon.h"
 
@@ -133,11 +135,11 @@ void MettDeamonFeedrateDirector::beforeForces(
 	// Check if other plugins were found
 	if(nullptr == mirror) {
 		Log::global_log->error() << "[MettDeamonFeedrateDirector] No Mirror plugin found in plugin list. Program exit ..." << std::endl;
-		Simulation::exit(-2004);
+		mardyn_exit(-2004);
 	}
 	if(nullptr == mettDeamon) {
 		Log::global_log->error() << "[MettDeamonFeedrateDirector] No MettDeamon plugin found in plugin list. Program exit ..." << std::endl;
-		Simulation::exit(-2004);
+		mardyn_exit(-2004);
 	}
 
 	// Get number of deleted/reflected particles from Mirror plugin

--- a/src/plugins/NEMD/PosNegComp.cpp
+++ b/src/plugins/NEMD/PosNegComp.cpp
@@ -8,6 +8,7 @@
 #include "PosNegComp.h"
 #include "particleContainer/ParticleContainer.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "parallel/DomainDecompBase.h"
 #include "molecules/Molecule.h"
 #include "utils/Logger.h"

--- a/src/plugins/NEMD/RegionSampling.cpp
+++ b/src/plugins/NEMD/RegionSampling.cpp
@@ -13,6 +13,7 @@
 #include "molecules/Molecule.h"
 #include "utils/FileUtils.h"
 #include "utils/xmlfileUnits.h"
+#include "utils/mardyn_assert.h"
 #include "DistControl.h"
 
 #include <iostream>
@@ -171,7 +172,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "RegionSampling->region["<<this->GetID()<<"]: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			Simulation::exit(-1);
+			mardyn_exit(-1);
 		}
 	}
 
@@ -183,7 +184,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 	Log::global_log->info() << "RegionSampling->region["<<this->GetID()-1<<"]: Number of sampling modules: " << numSamplingModules << std::endl;
 	if(numSamplingModules < 1) {
 		Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: No sampling module parameters specified. Program exit ..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	XMLfile::Query::const_iterator outputSamplingIter;
@@ -219,7 +220,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			if( !xmlconfig.getNodeValue("subdivision@type", strSubdivisionType) )
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing attribute subdivision@type! Program exit..." << std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 			if("number" == strSubdivisionType)
 			{
@@ -227,7 +228,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if( !xmlconfig.getNodeValue("subdivision/number", nNumSlabs) )
 				{
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/number! Program exit..." << std::endl;
-					Simulation::exit(-1);
+					mardyn_exit(-1);
 				}
 				else
 				{
@@ -241,7 +242,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if( !xmlconfig.getNodeValue("subdivision/width", dSlabWidth) )
 				{
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/width! Program exit..." << std::endl;
-					Simulation::exit(-1);
+					mardyn_exit(-1);
 				}
 				else
 				{
@@ -252,7 +253,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			else
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Wrong attribute subdivision@type. Expected type=\"number|width\"! Program exit..." << std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 		}
 		else if("VDF" == strSamplingModuleType || "FDF" == strSamplingModuleType)
@@ -296,7 +297,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				Log::global_log->info() << "RegionSampling->region["<<this->GetID()-1<<"]: Number of velocity discretizations: " << numDiscretizations << std::endl;
 				if(numDiscretizations < 1) {
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: No velocity discretizations specified for VDF sampling. Program exit ..." << std::endl;
-					Simulation::exit(-1);
+					mardyn_exit(-1);
 				}
 				XMLfile::Query::const_iterator nodeIter;
 				for( nodeIter = query_vd.begin(); nodeIter != query_vd.end(); nodeIter++ )
@@ -306,7 +307,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 					bool bVal = xmlconfig.getNodeValue("@cid", cid);
 					if( (cid > _numComponents) || ((not bVal) && (not _boolSingleComp)) ){
 						Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: VDF velocity discretization corrupted. Program exit ..." << std::endl;
-						Simulation::exit(-1);
+						mardyn_exit(-1);
 					}
 
 					if(_boolSingleComp){
@@ -333,7 +334,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			if( !xmlconfig.getNodeValue("subdivision@type", strSubdivisionType) )
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing attribute subdivision@type! Program exit..." << std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 			if("number" == strSubdivisionType)
 			{
@@ -341,7 +342,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if( !xmlconfig.getNodeValue("subdivision/number", nNumSlabs) )
 				{
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/number! Program exit..." << std::endl;
-					Simulation::exit(-1);
+					mardyn_exit(-1);
 				}
 				else
 				{
@@ -355,7 +356,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if( !xmlconfig.getNodeValue("subdivision/width", dSlabWidth) )
 				{
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/width! Program exit..." << std::endl;
-					Simulation::exit(-1);
+					mardyn_exit(-1);
 				}
 				else
 				{
@@ -366,7 +367,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			else
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Wrong attribute subdivision@type. Expected type=\"number|width\"! Program exit..." << std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 		}
 		else if("fieldYR" == strSamplingModuleType)
@@ -397,7 +398,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			else
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters of element: 'outputfile' corrupted! Program exit..." << std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 
 			// control
@@ -414,7 +415,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			else
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters of element: 'control' corrupted! Program exit..." << std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 
 			// subdivision of region
@@ -424,7 +425,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			if(numSubdivisions != 2) {
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: Found " << numSubdivisions << " 'subdivision' elements, "
 						"expected: 2. Program exit ..." << std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 			std::string oldpath = xmlconfig.getcurrentnodepath();
 			XMLfile::Query::const_iterator outputSubdivisionIter;
@@ -473,7 +474,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if(not bInputIsValid)
 				{
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters for elements: 'subdivision' corrupted! Program exit..." << std::endl;
-					Simulation::exit(-1);
+					mardyn_exit(-1);
 				}
 			}  // for( outputSubdivisionIter = query.begin(); outputSubdivisionIter; outputSubdivisionIter++ )
 			xmlconfig.changecurrentnode(oldpath);
@@ -481,7 +482,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: Wrong attribute 'sampling@type', expected type='profiles|VDF|fieldYR'! Program exit..." << std::endl;
-			Simulation::exit(-1);
+			mardyn_exit(-1);
 		}
 	}  // for( outputSamplingIter = query.begin(); outputSamplingIter; outputSamplingIter++ )
 }
@@ -554,7 +555,7 @@ void SampleRegion::prepareSubdivisionFieldYR()
 	case SDOPT_UNKNOWN:
 	default:
 		Log::global_log->error() << "SampleRegion::PrepareSubdivisionFieldYR(): Unknown subdivision type! Program exit..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	dWidth = (this->GetWidth(0) < this->GetWidth(2) ) ? this->GetWidth(0) : this->GetWidth(2);
@@ -573,7 +574,7 @@ void SampleRegion::prepareSubdivisionFieldYR()
 	case SDOPT_UNKNOWN:
 	default:
 		Log::global_log->error() << "SampleRegion::PrepareSubdivisionFieldYR(): Unknown subdivision type! Program exit..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 }
 
@@ -2047,7 +2048,7 @@ void RegionSampling::readXML(XMLfileUnits& xmlconfig)
 	Log::global_log->info() << "RegionSampling: Number of sampling regions: " << numRegions << std::endl;
 	if(numRegions < 1) {
 		Log::global_log->warning() << "RegionSampling: No region parameters specified. Program exit ..." << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator outputRegionIter;

--- a/src/plugins/NEMD/VelocityExchange.cpp
+++ b/src/plugins/NEMD/VelocityExchange.cpp
@@ -7,6 +7,7 @@
 
 #include "particleContainer/ParticleContainer.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "parallel/DomainDecompBase.h"
 #include "molecules/Molecule.h"
 #include "utils/Logger.h"

--- a/src/plugins/Permittivity.cpp
+++ b/src/plugins/Permittivity.cpp
@@ -9,6 +9,9 @@
  // Important: Always plot the running average data to make sure convergence has been achieved. Permittivity may take a long time to converge, i.e. a few million steps with ~1000 particles. Reducing number of slabs for the thermostat can drastically improve results/convergence!
  // If a simulation is resumed from a restart file, then the existing running average file is ammended but the computation of the running averages starts anew at the time step of the restart file
 #include "Permittivity.h"
+
+#include "Simulation.h"
+
 void Permittivity::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "Calculation of relative permittivity enabled." << std::endl;
 	xmlconfig.getNodeValue("writefrequency", _writeFrequency);

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -4,7 +4,7 @@
 
 #include "PluginFactory.h"
 #include "Domain.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 
 #include <map>
 #include <string>
@@ -194,7 +194,7 @@ long PluginFactory<PluginBase>::enablePlugins(std::list<PluginBase*>& _plugins, 
 			} else {
 				Log::global_log->error() << "[MMPLD Writer] Unknown sphere representation type: " << sphere_representation
 									<< std::endl;
-				Simulation::exit(-1);
+				mardyn_exit(-1);
 			}
 		} else if (pluginname == "DomainProfiles") {
 			plugin = this->create("DensityProfileWriter");

--- a/src/plugins/SpatialProfile.cpp
+++ b/src/plugins/SpatialProfile.cpp
@@ -46,7 +46,7 @@ void SpatialProfile::readXML(XMLfileUnits& xmlconfig) {
 		samplInfo.cylinder = false;
 	} else {
 		Log::global_log->error() << "[SpatialProfile] Invalid mode. cylinder/cartesian" << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 
 	Log::global_log->info() << "[SpatialProfile] Binning units: " << samplInfo.universalProfileUnit[0] << " "
@@ -404,7 +404,7 @@ long SpatialProfile::getCylUID(ParticleIterator& thismol) {
 		Log::global_log->error() << "Severe error!! Invalid profile unit (" << R2 << " / " << yc << " / " << phi << ").\n\n";
 		Log::global_log->error() << "Coordinates off center (" << xc << " / " << yc << " / " << zc << ").\n";
 		Log::global_log->error() << "unID = " << unID << "\n";
-		Simulation::exit(707);
+		mardyn_exit(707);
 	}
 	return unID;
 }

--- a/src/plugins/VectorizationTuner.cpp
+++ b/src/plugins/VectorizationTuner.cpp
@@ -12,6 +12,7 @@
 #include "ensemble/EnsembleBase.h"
 #include "molecules/Component.h"
 #include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "particleContainer/ParticleCell.h"
 #include "particleContainer/adapter/CellDataSoA.h"
 #include "Domain.h"
@@ -34,7 +35,7 @@ void VectorizationTuner::readXML(XMLfileUnits& xmlconfig) {
 		vtWriter.reset(new VTWriter());
 	} else {
 		Log::global_log->error() << R"(Unknown FlopRateOutputPlugin::mode. Choose "stdout" or "file".)" << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	_outputPrefix = "mardyn";
@@ -63,7 +64,7 @@ void VectorizationTuner::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->error()
 			<< R"(Unknown FlopRateOutputPlugin::moleculecntincreasetype. Choose "linear" or "exponential" or "both".)"
 			<< std::endl;
-		Simulation::exit(798123);
+		mardyn_exit(798123);
 	}
 	Log::global_log->info() << "Molecule count increase type: " << incTypeStr << std::endl;
 
@@ -282,7 +283,7 @@ void VectorizationTuner::tune(std::vector<Component>& componentList, TunerLoad& 
 
 		if(componentList.size() > 2){
 			Log::global_log->error_always_output() << "The tuner currently supports only two different particle types!" << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 
 		int maxMols = particleNums.at(0);

--- a/src/plugins/WallPotential.cpp
+++ b/src/plugins/WallPotential.cpp
@@ -5,6 +5,9 @@
 
 #include "WallPotential.h"
 
+#include "Simulation.h"
+#include "utils/mardyn_assert.h"
+
 /**
  * @brief reads in configuration from config.xml. see class doc for example .xml
  *
@@ -37,7 +40,7 @@ void WallPotential::readXML(XMLfileUnits &xmlconfig) {
         _potential = LJ9_3;
         // TODO: is this allowed or should simulation be halted
         // HALT SIM
-        //global_simulation -> exit(1);
+        //mardyn_exit(1);
     }
 
     XMLfile::Query query = xmlconfig.query("component");
@@ -85,7 +88,7 @@ void WallPotential::readXML(XMLfileUnits &xmlconfig) {
     }
     else{
         Log::global_log -> error() << "[WallPotential] UNKNOWN WALL POTENTIAL! EXITING!" << std::endl;
-        global_simulation -> exit(11);
+        mardyn_exit(11);
     }
 
 }

--- a/src/plugins/profiles/Virial2DProfile.cpp
+++ b/src/plugins/profiles/Virial2DProfile.cpp
@@ -3,10 +3,12 @@
 //
 
 #include "Virial2DProfile.h"
+
 #include "DensityProfile.h"
 #include "DOFProfile.h"
 #include "KineticProfile.h"
 #include "../FixRegion.h"
+#include "Simulation.h"
 
 void Virial2DProfile::output(std::string prefix, long unsigned accumulatedDatasets) {
 

--- a/src/plugins/profiles/VirialProfile.cpp
+++ b/src/plugins/profiles/VirialProfile.cpp
@@ -3,7 +3,9 @@
 //
 
 #include "VirialProfile.h"
+
 #include "DensityProfile.h"
+#include "Simulation.h"
 
 void VirialProfile::output(std::string prefix, long unsigned accumulatedDatasets) {
 

--- a/src/thermostats/TemperatureControl.cpp
+++ b/src/thermostats/TemperatureControl.cpp
@@ -7,12 +7,14 @@
 
 #include "thermostats/TemperatureControl.h"
 #include "Domain.h"
+#include "Simulation.h"
 #include "WrapOpenMP.h"
 #include "molecules/Molecule.h"
 #include "parallel/DomainDecompBase.h"
 #include "particleContainer/ParticleContainer.h"
 #include "utils/FileUtils.h"
 #include "utils/xmlfileUnits.h"
+#include "utils/mardyn_assert.h"
 
 #include <algorithm>
 #include <cmath>
@@ -166,7 +168,7 @@ void ControlRegionT::readXML(XMLfileUnits& xmlconfig) {
 			_nuDt = _nuAndersen * _timestep;
 		} else {
 			Log::global_log->error() << "[TemperatureControl] REGION: Invalid 'method' param: " << methods << std::endl;
-			Simulation::exit(-1);
+			mardyn_exit(-1);
 		}
 		Log::global_log->info() << "[TemperatureControl] REGION 'method' param: " << methods << std::endl;
 	}
@@ -190,7 +192,7 @@ void ControlRegionT::VelocityScalingInit(XMLfileUnits& xmlconfig, std::string st
 	xmlconfig.getNodeValue("settings/numslabs", _nNumSlabs);
 	if (_nNumSlabs < 1) {
 		Log::global_log->fatal() << "TemperatureControl: need at least one slab! (settings/numslabs)";
-		Simulation::exit(932);
+		mardyn_exit(932);
 	}
 	xmlconfig.getNodeValue("settings/exponent", _dTemperatureExponent);
 	xmlconfig.getNodeValue("settings/directions", strDirections);
@@ -416,7 +418,7 @@ void ControlRegionT::ControlTemperature(Molecule* mol) {
 		}
 	} else {
 		Log::global_log->error() << "[TemperatureControl] Invalid localMethod param: " << _localMethod << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 }
 
@@ -504,7 +506,7 @@ void ControlRegionT::registerAsObserver() {
 		else {
 			Log::global_log->error() << "TemperatureControl->region[" << this->GetID()
 								<< "]: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			Simulation::exit(-1);
+			mardyn_exit(-1);
 		}
 	}
 }

--- a/src/utils/MPI_Info_object.cpp
+++ b/src/utils/MPI_Info_object.cpp
@@ -1,6 +1,5 @@
 #include "utils/MPI_Info_object.h"
 
-#include "Simulation.h"
 #include "utils/Logger.h"
 
 #ifdef ENABLE_MPI

--- a/src/utils/OptionParser.cpp
+++ b/src/utils/OptionParser.cpp
@@ -6,7 +6,8 @@
  */
 
 #include "OptionParser.h"
-#include "Simulation.h"
+
+#include "utils/mardyn_assert.h"
 
 #include <cstdlib>
 #include <algorithm>
@@ -344,11 +345,11 @@ void OptionParser::process_opt(const Option& o, const std::string& opt, const st
 	}
 	else if (o.action() == "help") {
 		print_help();
-		Simulation::exit(0);
+		mardyn_exit(0);
 	}
 	else if (o.action() == "version") {
 		print_version();
-		Simulation::exit(0);
+		mardyn_exit(0);
 	}
 	else if (o.action() == "callback" && o.callback()) {
 		(*o.callback())(o, opt, value, *this);
@@ -436,12 +437,12 @@ void OptionParser::print_version() const {
 }
 
 void OptionParser::exit() const {
-	Simulation::exit(2);
+	mardyn_exit(2);
 }
 void OptionParser::error(const std::string& msg) const {
 	print_usage(std::cerr);
 	std::cerr << prog() << ": " << _("error") << ": " << msg << std::endl;
-	Simulation::exit(-4);
+	mardyn_exit(-4);
 }
 ////////// } class OptionParser //////////
 

--- a/src/utils/SigsegvHandler.h
+++ b/src/utils/SigsegvHandler.h
@@ -15,7 +15,7 @@
 #include <unistd.h>
 
 #include "mardyn_assert.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 
 
 void handler(int sig) {
@@ -28,7 +28,7 @@ void handler(int sig) {
   // print out all the frames to stderr
   fprintf(stderr, "Error: signal %d:\n", sig);
   backtrace_symbols_fd(array, size, STDERR_FILENO);
-  Simulation::exit(1);
+  mardyn_exit(1);
 }
 
 void registerSigsegvHandler() {

--- a/src/utils/Testing.cpp
+++ b/src/utils/Testing.cpp
@@ -8,7 +8,7 @@
 #include "utils/Testing.h"
 #include "utils/Logger.h"
 #include "utils/FileUtils.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 
 Log::Logger* test_log;
 
@@ -94,7 +94,7 @@ utils::Test::~Test() { }
 void utils::Test::setTestDataDirectory(std::string& testDataDir) {
 	if (!fileExists(testDataDir.c_str())) {
 		test_log->error() << "Directory '" << testDataDirectory << "' for test input data does not exist!" << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 	testDataDirectory = testDataDir;
 }
@@ -105,7 +105,7 @@ std::string utils::Test::getTestDataFilename(const std::string& file, bool check
 
 	if (!fileExists(fullPath.c_str()) and checkExistence) {
 		test_log->error() << "File " << fullPath << " for test input data does not exist!" << std::endl;
-		Simulation::exit(-1);
+		mardyn_exit(-1);
 	}
 	return fullPath;
 }

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -6,12 +6,13 @@
 #include <limits>
 #include <vector>
 
+#include "Simulation.h"
 #include "molecules/Molecule.h"
 #include "io/InputBase.h"
 #include "io/BinaryReader.h"
 #include "utils/Logger.h"
 #include "utils/Coordinate3D.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #include "particleContainer/ParticleContainer.h"
 #include "particleContainer/ParticleCellBase.h"
 
@@ -146,18 +147,18 @@ void ReplicaFiller::readXML(XMLfileUnits& xmlconfig) {
 		xmlconfig.getNodeValue("@type", inputPluginName);
 		if (inputPluginName != "BinaryReader") {
 			Log::global_log->error() << "[ReplicaFiller] ReplicaFiller only works with inputPlugins: BinaryReader at the moment" << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		setInputReader(std::make_shared<BinaryReader>());
 		_inputReader->readXML(xmlconfig);
 		if (_inputReader == nullptr) {
 			Log::global_log->error() << "[ReplicaFiller] Could not create input reader " << inputPluginName << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		xmlconfig.changecurrentnode("..");
 	} else {
 		Log::global_log->error() << "[ReplicaFiller] Input reader for original not specified." << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	if (xmlconfig.changecurrentnode("origin")) {
 		Coordinate3D origin;
@@ -176,7 +177,7 @@ void ReplicaFiller::readXML(XMLfileUnits& xmlconfig) {
 		const size_t numComps = global_simulation->getEnsemble()->getComponents()->size();
 		if ((componentid < 1) || (componentid > numComps)) {
 			Log::global_log->error() << "[ReplicaFiller] Specified componentid is invalid. Valid range: 1 <= componentid <= " << numComps << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		_componentid = componentid - 1;  // Internally stored in array starting at index 0
 		_keepComponent = false;
@@ -205,7 +206,7 @@ void ReplicaFiller::init() {
 
 	if (numberOfParticles == 0) {
 		Log::global_log->error_always_output() << "[ReplicaFiller] No molecules in replica, aborting! " << std::endl;
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 
 	Log::global_log->info() << "[ReplicaFiller] Setting simulation time to 0.0" << std::endl;

--- a/src/utils/xmlfile.cpp
+++ b/src/utils/xmlfile.cpp
@@ -16,7 +16,6 @@
 #include "utils/mardyn_assert.h"
 #include "rapidxml/rapidxml_print.hpp"
 #include "String_utils.h"
-#include "Simulation.h"
 
 //#include <cstdio>	// fseek(),fread(); should be included after mpi.h
 //#ifdef __linux__
@@ -196,7 +195,7 @@ bool XMLfile::initfile_local(const std::string& filepath) {
 	if(!fstrm) {
 		std::cerr << "ERROR opening " << filepathTrimmed << std::endl;
 		clear();
-		Simulation::exit(1);
+		mardyn_exit(1);
 	}
 	std::ifstream::pos_type filesize=fstrm.tellg();
 	fstrm.close(); fstrm.clear();
@@ -541,7 +540,7 @@ template<typename T> bool XMLfile::Node::getValue(T& value) const
 			if (ss.str().find_first_of("-") != std::string::npos) {
 				std::cerr << "ERROR parsing \"" << ss.str() << "\" to data type " << typeid(T).name() << " from tag \"<" << name() << ">\" in xml file" << std::endl;
 				std::cerr << "The tag contains a negative value but an unsigned value was expected." << std::endl;
-				Simulation::exit(1);
+				mardyn_exit(1);
 			}
 		}
 		ss >> value;
@@ -549,7 +548,7 @@ template<typename T> bool XMLfile::Node::getValue(T& value) const
 		if (!ss.eof() || ss.fail()) {
 			std::cerr << "ERROR parsing all chars of \"" << ss.str() << "\" from tag \"<" << name() << ">\" in xml file" << std::endl;
 			std::cerr << "This might be the result of using a float while an integer is expected." << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 		return true;
 	}
@@ -585,7 +584,7 @@ template<> bool XMLfile::Node::getValue<bool>(bool& value) const
 		} else {
 			std::cerr << "ERROR parsing \"" << v << "\" to boolean from tag \"" << name() << "\" in xml file."
 				<< " Valid values are: true, false, yes, no, on, off. " << std::endl;
-			Simulation::exit(1);
+			mardyn_exit(1);
 		}
 	}
 	return found;

--- a/tools/gui/generators/MDGenerator.cpp
+++ b/tools/gui/generators/MDGenerator.cpp
@@ -17,7 +17,7 @@
 #ifndef MARDYN
 #include "common/DrawableMolecule.h"
 #include "QObjects/ScenarioGenerator.h"
-#include "Simulation.h"
+#include "utils/mardyn_assert.h"
 #endif
 
 


### PR DESCRIPTION
# Description

`Simulation.h` is included in many files and can easily lead to some chaos due to [circular dependency](https://github.com/ls1mardyn/ls1-mardyn/pull/333#discussion_r1692906160) (as @FG-TUM mentioned).
Therefore, this PR replaces the `Simulation::exit()` method with `mardyn_exit()` since this only requires the include of mardyn_assert.
The `Simulation::exit()` method is also deleted.

During the replacement, I paid attention to no include the `Simulation.h` in any header file (~exception: `Planar.cpp` since it requires `Simulation` as one argument of its methods~ solved by `class Simulation;` instead if `#include`). Therefore, I had to move `Domain::setComponentThermostat` from the header to the cpp file.

What became apparent during the replacement:
A lot of files use `global_simulation` or `_simulation`, e.g. to get the ensemble.