### PR TITLE
Use proper exit codes

### DIFF
--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -553,7 +553,7 @@ void Domain::writeCheckpointHeader(std::string filename,
 						}
 					} else {
 						Log::global_log->error() << "Only LB mixing rule supported" << std::endl;
-						mardyn_exit(123);
+						MARDYN_EXIT(123);
 					}
 				}
 			}
@@ -711,7 +711,7 @@ void Domain::enableComponentwiseThermostat()
 void Domain::setComponentThermostat(int cid, int thermostat) {
 	if ((0 > cid) || (0 >= thermostat)) {
 		Log::global_log->error() << "Domain::setComponentThermostat: cid or thermostat id too low" << std::endl;
-		mardyn_exit(787);
+		MARDYN_EXIT(787);
 	}
 	this->_componentToThermostatIdMap[cid] = thermostat;
 	this->_universalThermostatN[thermostat] = 0;

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -96,7 +96,7 @@ void Domain::readXML(XMLfileUnits& xmlconfig) {
 		else {
 			std::ostringstream error_message;
 			error_message << "Unsupported volume type " << type << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		xmlconfig.changecurrentnode("..");
 	}
@@ -557,7 +557,7 @@ void Domain::writeCheckpointHeader(std::string filename,
 					} else {
 						std::ostringstream error_message;
 						error_message << "Only LB mixing rule supported" << std::endl;
-						MARDYN_EXIT(error_message);
+						MARDYN_EXIT(error_message.str());
 					}
 				}
 			}
@@ -716,7 +716,7 @@ void Domain::setComponentThermostat(int cid, int thermostat) {
 	if ((0 > cid) || (0 >= thermostat)) {
 		std::ostringstream error_message;
 		error_message << "Domain::setComponentThermostat: cid or thermostat id too low" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	this->_componentToThermostatIdMap[cid] = thermostat;
 	this->_universalThermostatN[thermostat] = 0;

--- a/src/Domain.cpp
+++ b/src/Domain.cpp
@@ -1,6 +1,7 @@
 
 #include <iostream>
 #include <string>
+#include <sstream>
 #include <cmath>
 #include <cstdint>
 
@@ -93,7 +94,9 @@ void Domain::readXML(XMLfileUnits& xmlconfig) {
 				<< _globalLength[2] << std::endl;
 		}
 		else {
-			Log::global_log->error() << "Unsupported volume type " << type << std::endl;
+			std::ostringstream error_message;
+			error_message << "Unsupported volume type " << type << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		xmlconfig.changecurrentnode("..");
 	}
@@ -552,8 +555,9 @@ void Domain::writeCheckpointHeader(std::string filename,
 							mixingss << "\t";
 						}
 					} else {
-						Log::global_log->error() << "Only LB mixing rule supported" << std::endl;
-						MARDYN_EXIT(123);
+						std::ostringstream error_message;
+						error_message << "Only LB mixing rule supported" << std::endl;
+						MARDYN_EXIT(error_message);
 					}
 				}
 			}
@@ -710,8 +714,9 @@ void Domain::enableComponentwiseThermostat()
 
 void Domain::setComponentThermostat(int cid, int thermostat) {
 	if ((0 > cid) || (0 >= thermostat)) {
-		Log::global_log->error() << "Domain::setComponentThermostat: cid or thermostat id too low" << std::endl;
-		MARDYN_EXIT(787);
+		std::ostringstream error_message;
+		error_message << "Domain::setComponentThermostat: cid or thermostat id too low" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	this->_componentToThermostatIdMap[cid] = thermostat;
 	this->_universalThermostatN[thermostat] = 0;

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -192,9 +192,10 @@ int main(int argc, char** argv) {
 
 	auto numArgs = args.size();
 	if(numArgs != 1) {
-		Log::global_log->error() << "Incorrect number of arguments provided." << std::endl;
 		op.print_usage();
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "Incorrect number of arguments provided." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	/* First read the given config file if it exists, then overwrite parameters with command line arguments. */
 	std::string configFileName(args[0]);
@@ -202,8 +203,9 @@ int main(int argc, char** argv) {
 		Log::global_log->info() << "Config file: " << configFileName << std::endl;
 		simulation.readConfigFile(configFileName);
 	} else {
-		Log::global_log->error() << "Cannot open config file '" << configFileName << "'" << std::endl;
-		MARDYN_EXIT(-2);
+		std::ostringstream error_message;
+		error_message << "Cannot open config file '" << configFileName << "'" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	/* processing command line arguments */

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -194,7 +194,7 @@ int main(int argc, char** argv) {
 	if(numArgs != 1) {
 		Log::global_log->error() << "Incorrect number of arguments provided." << std::endl;
 		op.print_usage();
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	/* First read the given config file if it exists, then overwrite parameters with command line arguments. */
 	std::string configFileName(args[0]);
@@ -203,7 +203,7 @@ int main(int argc, char** argv) {
 		simulation.readConfigFile(configFileName);
 	} else {
 		Log::global_log->error() << "Cannot open config file '" << configFileName << "'" << std::endl;
-		mardyn_exit(-2);
+		MARDYN_EXIT(-2);
 	}
 
 	/* processing command line arguments */

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -183,7 +183,7 @@ int main(int argc, char** argv) {
 		#ifdef ENABLE_MPI
 		MPI_Finalize();
 		#endif
-		exit(testresult); // using exit here should be OK
+		std::exit(testresult); // using exit here should be OK
 	}
 
 

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -195,7 +195,7 @@ int main(int argc, char** argv) {
 		op.print_usage();
 		std::ostringstream error_message;
 		error_message << "Incorrect number of arguments provided." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	/* First read the given config file if it exists, then overwrite parameters with command line arguments. */
 	std::string configFileName(args[0]);
@@ -205,7 +205,7 @@ int main(int argc, char** argv) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "Cannot open config file '" << configFileName << "'" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	/* processing command line arguments */

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -72,6 +72,7 @@
 
 #include "utils/FileUtils.h"
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
 
 #include "longRange/LongRangeCorrection.h"
 #include "longRange/Homogeneous.h"
@@ -171,21 +172,25 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->info() << "Integrator type: " << integratorType << std::endl;
 		if(integratorType == "Leapfrog") {
 #ifdef ENABLE_REDUCED_MEMORY_MODE
-			Log::global_log->error() << "The reduced memory mode (RMM) requires the LeapfrogRMM integrator." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "The reduced memory mode (RMM) requires the LeapfrogRMM integrator." << std::endl;
+			MARDYN_EXIT(error_message);
 #endif
 			_integrator = new Leapfrog();
 		} else if (integratorType == "LeapfrogRMM") {
 			_integrator = new LeapfrogRMM();
 		} else {
-			Log::global_log-> error() << "Unknown integrator " << integratorType << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Unknown integrator " << integratorType << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		_integrator->readXML(xmlconfig);
 		_integrator->init();
 		xmlconfig.changecurrentnode("..");
 	} else {
-		Log::global_log->error() << "Integrator section missing." << std::endl;
+		std::ostringstream error_message;
+		error_message << "Integrator section missing." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	/* run section */
@@ -205,7 +210,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		}
 		xmlconfig.changecurrentnode("..");
 	} else {
-		Log::global_log->error() << "Run section missing." << std::endl;
+		std::ostringstream error_message;
+		error_message << "Run section missing." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	/* ensemble */
@@ -221,8 +228,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			/* TODO: GrandCanonical terminates as readXML is not implemented and it is not tested yet. */
 			_ensemble = new GrandCanonicalEnsemble();
 		} else {
-			Log::global_log->error() << "Unknown ensemble type: " << ensembletype << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Unknown ensemble type: " << ensembletype << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		_ensemble->readXML(xmlconfig);
 		/** @todo Here we store data in the _domain member as long as we do not use the ensemble everywhere */
@@ -234,8 +242,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		xmlconfig.changecurrentnode("..");
 	}
 	else {
-		Log::global_log->error() << "Ensemble section missing." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Ensemble section missing." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	/* algorithm */
@@ -255,14 +264,16 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			 *        maybe use map/list to store cutoffs for different potentials? */
 			_cutoffRadius = std::max(_cutoffRadius, _LJCutoffRadius);
 			if(_cutoffRadius <= 0) {
-				Log::global_log->error() << "cutoff radius <= 0." << std::endl;
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;
+				error_message << "cutoff radius <= 0." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			Log::global_log->info() << "dimensionless cutoff radius:\t" << _cutoffRadius << std::endl;
 			xmlconfig.changecurrentnode("..");
 		} else {
-			Log::global_log->error() << "Cutoff section missing." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Cutoff section missing." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		/* electrostatics */
@@ -274,16 +285,17 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			_domain->setepsilonRF(epsilonRF);
 			xmlconfig.changecurrentnode("..");
 		} else {
-			Log::global_log->error() << "Electrostatics section for reaction field setup missing." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Electrostatics section for reaction field setup missing." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		if (xmlconfig.changecurrentnode("electrostatic[@type='FastMultipoleMethod']")) {
 #ifdef MARDYN_AUTOPAS
-			Log::global_log->fatal()
-				<< "The fast multipole method is not compatible with AutoPas. Please disable the AutoPas mode (ENABLE_AUTOPAS)!"
-				<< std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "The fast multipole method is not compatible with AutoPas. "
+							<< "Please disable the AutoPas mode (ENABLE_AUTOPAS)!" << std::endl;
+			MARDYN_EXIT(error_message);
 #endif
 			_FMM = new bhfmm::FastMultipoleMethod();
 			_FMM->readXML(xmlconfig);
@@ -337,12 +349,13 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 					if (datastructuretype == "AutoPas" or datastructuretype == "AutoPasContainer") {
 						// check if skin is specified
 						if (xmlconfig.getNodeValue("skin", skin) == 0) {
-							Log::global_log->error() << "Skin not set in datastructure/AutoPas. "
+							std::ostringstream error_message;
+							error_message << "Skin not set in datastructure/AutoPas. "
 												   "This will lead to a different interaction length in the container "
 												   "vs the GeneralDomainDecomposition which can lead ALL to shrink the "
 												   "domain too small."
 												  << std::endl;
-							MARDYN_EXIT(512435340);
+							MARDYN_EXIT(error_message);
 						}
 					} else {
 						Log::global_log->warning() << "Using the GeneralDomainDecomposition without AutoPas is not "
@@ -357,18 +370,21 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 					}
 					Log::global_log->info() << "Using skin = " << skin << " for the GeneralDomainDecomposition." << std::endl;
 				} else {
-					Log::global_log->error() << "Datastructure section missing" << std::endl;
-					MARDYN_EXIT(1);
+					std::ostringstream error_message;
+					error_message << "Datastructure section missing" << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 				if(not xmlconfig.changecurrentnode("../parallelisation")){
-					Log::global_log->error() << "Could not go back to parallelisation path. Aborting." << std::endl;
-					MARDYN_EXIT(1);
+					std::ostringstream error_message;
+					error_message << "Could not go back to parallelisation path. Aborting." << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 				delete _domainDecomposition;
 				_domainDecomposition = new GeneralDomainDecomposition(getcutoffRadius() + skin, _domain, forceLatchingToLinkedCellsGrid);
 			} else {
-				Log::global_log->error() << "Unknown parallelisation type: " << parallelisationtype << std::endl;
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;
+				error_message << "Unknown parallelisation type: " << parallelisationtype << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 		#else /* serial */
 			if(parallelisationtype != "DummyDecomposition") {
@@ -376,7 +392,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 						<< "Executable was compiled without support for parallel execution: "
 						<< parallelisationtype
 						<< " not available. Using serial mode." << std::endl;
-				//MARDYN_EXIT(1);
+				//MARDYN_EXIT(error_message);
 			}
 			//_domainDecomposition = new DomainDecompBase();  // already set in initialize()
 		#endif
@@ -392,9 +408,10 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			Log::global_log->info() << "Using timer " << loadTimerStr << " for the load calculation." << std::endl;
 			_timerForLoad = timers()->getTimer(loadTimerStr);
 			if (not _timerForLoad) {
-				Log::global_log->error() << "'timerForLoad' set to a timer that does not exist('" << loadTimerStr
+				std::ostringstream error_message;
+				error_message << "'timerForLoad' set to a timer that does not exist('" << loadTimerStr
 									<< "')! Aborting!" << std::endl;
-				exit(1);
+				MARDYN_EXIT(error_message);
 			}
 
 			std::size_t timerForLoadAveragingLength{1ul};
@@ -402,8 +419,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			Log::global_log->info() << "Averaging over " << timerForLoadAveragingLength
 							   << "time steps for the load calculation." << std::endl;
 			if(timerForLoadAveragingLength < 1ul) {
-				Log::global_log->fatal() << "timerForLoadAveragingLength has to be at least 1" << std::endl;
-				MARDYN_EXIT(15843);
+				std::ostringstream error_message;
+				error_message << "timerForLoadAveragingLength has to be at least 1" << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			_lastTraversalTimeHistory.setCapacity(timerForLoadAveragingLength);
 
@@ -411,8 +429,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		}
 		else {
 		#ifdef ENABLE_MPI
-			Log::global_log->error() << "Parallelisation section missing." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Parallelisation section missing." << std::endl;
+			MARDYN_EXIT(error_message);
 		#else /* serial */
 			// set _timerForLoad, s.t. it always exists.
 			_timerForLoad = timers()->getTimer("SIMULATION_COMPUTATION");
@@ -427,10 +446,11 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			Log::global_log->info() << "Datastructure type: " << datastructuretype << std::endl;
 			if(datastructuretype == "LinkedCells") {
 #ifdef MARDYN_AUTOPAS
-				Log::global_log->fatal()
+				std::ostringstream error_message;
+				error_message
 					<< "LinkedCells not compiled (use AutoPas instead, or compile with disabled autopas mode)!"
 					<< std::endl;
-				MARDYN_EXIT(33);
+				MARDYN_EXIT(error_message);
 #else
 				_moleculeContainer = new LinkedCells();
 				/** @todo Review if we need to know the max cutoff radius usable with any datastructure. */
@@ -438,21 +458,24 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 				_moleculeContainer->setCutoff(_cutoffRadius);
 #endif
 			} else if(datastructuretype == "AdaptiveSubCells") {
-				Log::global_log->warning() << "AdaptiveSubCells no longer supported." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "AdaptiveSubCells no longer supported." << std::endl;
+				MARDYN_EXIT(error_message);
 			} else if(datastructuretype == "AutoPas" || datastructuretype == "AutoPasContainer") {
 #ifdef MARDYN_AUTOPAS
 				Log::global_log->info() << "Using AutoPas container." << std::endl;
 				_moleculeContainer = new AutoPasContainer(_cutoffRadius);
 				Log::global_log->info() << "Setting cell cutoff radius for AutoPas container to " << _cutoffRadius << std::endl;
 #else
-				Log::global_log->fatal() << "AutoPas not compiled (use LinkedCells instead, or compile with enabled autopas mode)!" << std::endl;
-				MARDYN_EXIT(33);
+				std::ostringstream error_message;
+				error_message << "AutoPas not compiled (use LinkedCells instead, or compile with enabled autopas mode)!" << std::endl;
+				MARDYN_EXIT(error_message);
 #endif
 			}
 			else {
-				Log::global_log->error() << "Unknown data structure type: " << datastructuretype << std::endl;
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;
+				error_message << "Unknown data structure type: " << datastructuretype << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			_moleculeContainer->readXML(xmlconfig);
 
@@ -463,8 +486,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			_domainDecomposition->updateSendLeavingWithCopies(sendTogether);
 			xmlconfig.changecurrentnode("..");
 		} else {
-			Log::global_log->error() << "Datastructure section missing" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Datastructure section missing" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		// TODO: move parts to readXML in TemperatureControl?
@@ -506,9 +530,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
                         _temperatureControl = new TemperatureControl();
                         _temperatureControl->readXML(xmlconfig);
                     } else {
-                        Log::global_log->error() << "Instance of TemperatureControl allready exist! Programm exit ..."
-                                            << std::endl;
-                        MARDYN_EXIT(-1);
+                        std::ostringstream error_message;
+						error_message << "Instance of TemperatureControl already exist!" << std::endl;
+						MARDYN_EXIT(error_message);
                     }
                 }
 				else
@@ -530,8 +554,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			std::string type;
 			if( !xmlconfig.getNodeValue("@type", type) )
 			{
-				Log::global_log->error() << "LongRangeCorrection: Missing type specification. Program exit ..." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "LongRangeCorrection: Missing type specification. Program exit ..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			if("planar" == type)
 			{
@@ -554,8 +579,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			}
 			else
 			{
-				Log::global_log->error() << "LongRangeCorrection: Wrong type. Expected type == homogeneous|planar|none. Program exit ..." << std::endl;
-                MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "LongRangeCorrection: Wrong type. Expected type == homogeneous|planar|none. Program exit ..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			xmlconfig.changecurrentnode("..");
 		} else {
@@ -567,7 +593,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		xmlconfig.changecurrentnode(".."); /* algorithm section */
 	}
 	else {
-		Log::global_log->error() << "Algorithm section missing." << std::endl;
+		std::ostringstream error_message;
+		error_message << "Algorithm section missing." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	Log::global_log -> info() << "Registering default plugins..." << std::endl;
@@ -620,8 +648,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		}
 #endif
 		else {
-			Log::global_log->error() << "Unknown phase space file type" << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "Unknown phase space file type" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 	xmlconfig.changecurrentnode(oldpath);
@@ -650,8 +679,9 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			_inputReader = new PerCellGenerator();
 		}
 		else {
-			Log::global_log->error() << "Unknown generator: " << generatorName << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Unknown generator: " << generatorName << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		_inputReader->readXML(xmlconfig);
 	}
@@ -685,8 +715,9 @@ void Simulation::readConfigFile(std::string filename) {
 		initConfigXML(filename);
 	}
 	else {
-		Log::global_log->error() << "Unknown config file extension '" << extension << "'." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Unknown config file extension '" << extension << "'." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -699,9 +730,10 @@ void Simulation::initConfigXML(const std::string& inputfilename) {
 		Log::global_log->debug() << "Input XML:" << std::endl << std::string(inp) << std::endl;
 
 		if(inp.changecurrentnode("/mardyn") < 0) {
-			Log::global_log->error() << "Cound not find root node /mardyn in XML input file." << std::endl;
-			Log::global_log->fatal() << "Not a valid MarDyn XML input file." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Cound not find root node /mardyn in XML input file." << std::endl;
+			error_message << "Not a valid MarDyn XML input file." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		std::string version("unknown");
@@ -715,8 +747,9 @@ void Simulation::initConfigXML(const std::string& inputfilename) {
 			inp.changecurrentnode("..");
 		} // simulation-section
 		else {
-			Log::global_log->error() << "Simulation section missing" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Simulation section missing" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		parseMiscOptions(inp);
@@ -727,9 +760,10 @@ void Simulation::initConfigXML(const std::string& inputfilename) {
 		}
 
 	} catch (const std::exception& e) {
-		Log::global_log->error() << "Error in XML config. Please check your input file!" << std::endl;
-		Log::global_log->error() << "Exception: " << e.what() << std::endl;
-		MARDYN_EXIT(7);
+		std::ostringstream error_message;
+		error_message << "Error in XML config. Please check your input file!" << std::endl;
+		error_message << "Exception: " << e.what() << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 #ifdef ENABLE_MPI
@@ -854,8 +888,9 @@ void Simulation::prepare_start() {
 		Log::global_log->info() << "Initializing LongRangeCorrection" << std::endl;
 		_longRangeCorrection->init();
 	} else {
-		Log::global_log->fatal() << "No _longRangeCorrection set!" << std::endl;
-		MARDYN_EXIT(93742);
+		std::ostringstream error_message;
+		error_message << "No _longRangeCorrection set!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	// longRangeCorrection is a site-wise force plugin, so we have to call it before updateForces()
 	_longRangeCorrection->calculateLongRange();
@@ -948,9 +983,12 @@ void Simulation::preSimLoopSteps()
 	//sanity checks
 	if(preSimLoopStepsDone || simulationDone || postSimLoopStepsDone)
 	{
-		Log::global_log->error() << "Unexpected call to preSimLoopSteps()! Status: (pre sim loop steps done:" << preSimLoopStepsDone << ", simulation done: " << simulationDone << 
-					", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Unexpected call to preSimLoopSteps()! "
+					<< "Status: (pre sim loop steps done:" << preSimLoopStepsDone
+					<< ", simulation done: " << simulationDone
+					<< ", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 
@@ -1010,9 +1048,12 @@ void Simulation::simulateOneTimestep()
 	//sanity checks
 	if(!preSimLoopStepsDone || simulationDone || postSimLoopStepsDone)
 	{
-		Log::global_log->error() << "Unexpected call to simulateOneTimeStep()! Status: (pre sim loop steps done:" << preSimLoopStepsDone << ", simulation done: " << simulationDone << 
-					", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Unexpected call to simulateOneTimeStep()! "
+					<< "Status: (pre sim loop steps done:" << preSimLoopStepsDone
+					<< ", simulation done: " << simulationDone
+					<< ", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	#ifdef MAMICO_COUPLING
@@ -1241,9 +1282,12 @@ void Simulation::postSimLoopSteps()
 	//sanity checks
 	if(!preSimLoopStepsDone || !simulationDone || postSimLoopStepsDone)
 	{
-		Log::global_log->error() << "Unexpected call to postSimLoopSteps()! Status: (pre sim loop steps done:" << preSimLoopStepsDone << ", simulation done: " << simulationDone << 
-					", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Unexpected call to postSimLoopSteps()! "
+					<< "Status: (pre sim loop steps done:" << preSimLoopStepsDone
+					<< ", simulation done: " << simulationDone
+					<< ", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 
@@ -1307,8 +1351,9 @@ void Simulation::pluginEndStepCall(unsigned long simstep) {
 					   << _domain->getGlobalUpot() << "\tp = "
 					   << _domain->getGlobalPressure() << std::endl;
 	if (std::isnan(_domain->getGlobalCurrentTemperature()) || std::isnan(_domain->getGlobalUpot()) || std::isnan(_domain->getGlobalPressure())) {
-		Log::global_log->error() << "NaN detected, exiting." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "NaN detected, exiting." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -1377,8 +1422,9 @@ void Simulation::performOverlappingDecompositionAndCellTraversalStep(double etim
 #ifdef ENABLE_MPI
 	auto* dd = dynamic_cast<DomainDecompMPIBase*>(_domainDecomposition);
 	if (not dd) {
-		Log::global_log->fatal() << "DomainDecompMPIBase* required for overlapping comm, but dynamic_cast failed." << std::endl;
-		MARDYN_EXIT(873456);
+		std::ostringstream error_message;
+		error_message << "DomainDecompMPIBase* required for overlapping comm, but dynamic_cast failed." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	NonBlockingMPIMultiStepHandler nonBlockingMPIHandler {dd, _moleculeContainer, _domain, _cellProcessor};
 
@@ -1386,8 +1432,9 @@ void Simulation::performOverlappingDecompositionAndCellTraversalStep(double etim
 
 	nonBlockingMPIHandler.performOverlappingTasks(forceRebalancing, etime);
 #else
-	Log::global_log->fatal() << "performOverlappingDecompositionAndCellTraversalStep() called with disabled MPI." << std::endl;
-	MARDYN_EXIT(873457);
+	std::ostringstream error_message;
+	error_message << "performOverlappingDecompositionAndCellTraversalStep() called with disabled MPI." << std::endl;
+	MARDYN_EXIT(error_message);
 #endif
 }
 

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -174,7 +174,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 #ifdef ENABLE_REDUCED_MEMORY_MODE
 			std::ostringstream error_message;
 			error_message << "The reduced memory mode (RMM) requires the LeapfrogRMM integrator." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 #endif
 			_integrator = new Leapfrog();
 		} else if (integratorType == "LeapfrogRMM") {
@@ -182,7 +182,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			std::ostringstream error_message;
 			error_message << "Unknown integrator " << integratorType << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		_integrator->readXML(xmlconfig);
 		_integrator->init();
@@ -190,7 +190,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "Integrator section missing." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	/* run section */
@@ -212,7 +212,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "Run section missing." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	/* ensemble */
@@ -230,7 +230,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			std::ostringstream error_message;
 			error_message << "Unknown ensemble type: " << ensembletype << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		_ensemble->readXML(xmlconfig);
 		/** @todo Here we store data in the _domain member as long as we do not use the ensemble everywhere */
@@ -244,7 +244,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 	else {
 		std::ostringstream error_message;
 		error_message << "Ensemble section missing." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	/* algorithm */
@@ -266,14 +266,14 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			if(_cutoffRadius <= 0) {
 				std::ostringstream error_message;
 				error_message << "cutoff radius <= 0." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			Log::global_log->info() << "dimensionless cutoff radius:\t" << _cutoffRadius << std::endl;
 			xmlconfig.changecurrentnode("..");
 		} else {
 			std::ostringstream error_message;
 			error_message << "Cutoff section missing." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		/* electrostatics */
@@ -287,7 +287,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			std::ostringstream error_message;
 			error_message << "Electrostatics section for reaction field setup missing." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		if (xmlconfig.changecurrentnode("electrostatic[@type='FastMultipoleMethod']")) {
@@ -295,7 +295,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			std::ostringstream error_message;
 			error_message << "The fast multipole method is not compatible with AutoPas. "
 							<< "Please disable the AutoPas mode (ENABLE_AUTOPAS)!" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 #endif
 			_FMM = new bhfmm::FastMultipoleMethod();
 			_FMM->readXML(xmlconfig);
@@ -355,7 +355,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 												   "vs the GeneralDomainDecomposition which can lead ALL to shrink the "
 												   "domain too small."
 												  << std::endl;
-							MARDYN_EXIT(error_message);
+							MARDYN_EXIT(error_message.str());
 						}
 					} else {
 						Log::global_log->warning() << "Using the GeneralDomainDecomposition without AutoPas is not "
@@ -372,19 +372,19 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 				} else {
 					std::ostringstream error_message;
 					error_message << "Datastructure section missing" << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 				if(not xmlconfig.changecurrentnode("../parallelisation")){
 					std::ostringstream error_message;
 					error_message << "Could not go back to parallelisation path. Aborting." << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 				delete _domainDecomposition;
 				_domainDecomposition = new GeneralDomainDecomposition(getcutoffRadius() + skin, _domain, forceLatchingToLinkedCellsGrid);
 			} else {
 				std::ostringstream error_message;
 				error_message << "Unknown parallelisation type: " << parallelisationtype << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		#else /* serial */
 			if(parallelisationtype != "DummyDecomposition") {
@@ -392,7 +392,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 						<< "Executable was compiled without support for parallel execution: "
 						<< parallelisationtype
 						<< " not available. Using serial mode." << std::endl;
-				//MARDYN_EXIT(error_message);
+				//MARDYN_EXIT(error_message.str());
 			}
 			//_domainDecomposition = new DomainDecompBase();  // already set in initialize()
 		#endif
@@ -411,7 +411,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 				std::ostringstream error_message;
 				error_message << "'timerForLoad' set to a timer that does not exist('" << loadTimerStr
 									<< "')! Aborting!" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 
 			std::size_t timerForLoadAveragingLength{1ul};
@@ -421,7 +421,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			if(timerForLoadAveragingLength < 1ul) {
 				std::ostringstream error_message;
 				error_message << "timerForLoadAveragingLength has to be at least 1" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			_lastTraversalTimeHistory.setCapacity(timerForLoadAveragingLength);
 
@@ -431,7 +431,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		#ifdef ENABLE_MPI
 			std::ostringstream error_message;
 			error_message << "Parallelisation section missing." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		#else /* serial */
 			// set _timerForLoad, s.t. it always exists.
 			_timerForLoad = timers()->getTimer("SIMULATION_COMPUTATION");
@@ -450,7 +450,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 				error_message
 					<< "LinkedCells not compiled (use AutoPas instead, or compile with disabled autopas mode)!"
 					<< std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 #else
 				_moleculeContainer = new LinkedCells();
 				/** @todo Review if we need to know the max cutoff radius usable with any datastructure. */
@@ -460,7 +460,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			} else if(datastructuretype == "AdaptiveSubCells") {
 				std::ostringstream error_message;
 				error_message << "AdaptiveSubCells no longer supported." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			} else if(datastructuretype == "AutoPas" || datastructuretype == "AutoPasContainer") {
 #ifdef MARDYN_AUTOPAS
 				Log::global_log->info() << "Using AutoPas container." << std::endl;
@@ -469,13 +469,13 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 #else
 				std::ostringstream error_message;
 				error_message << "AutoPas not compiled (use LinkedCells instead, or compile with enabled autopas mode)!" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 #endif
 			}
 			else {
 				std::ostringstream error_message;
 				error_message << "Unknown data structure type: " << datastructuretype << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			_moleculeContainer->readXML(xmlconfig);
 
@@ -488,7 +488,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			std::ostringstream error_message;
 			error_message << "Datastructure section missing" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		// TODO: move parts to readXML in TemperatureControl?
@@ -532,7 +532,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
                     } else {
                         std::ostringstream error_message;
 						error_message << "Instance of TemperatureControl already exist!" << std::endl;
-						MARDYN_EXIT(error_message);
+						MARDYN_EXIT(error_message.str());
                     }
                 }
 				else
@@ -556,7 +556,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			{
 				std::ostringstream error_message;
 				error_message << "LongRangeCorrection: Missing type specification. Program exit ..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			if("planar" == type)
 			{
@@ -581,7 +581,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			{
 				std::ostringstream error_message;
 				error_message << "LongRangeCorrection: Wrong type. Expected type == homogeneous|planar|none. Program exit ..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			xmlconfig.changecurrentnode("..");
 		} else {
@@ -595,7 +595,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 	else {
 		std::ostringstream error_message;
 		error_message << "Algorithm section missing." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	Log::global_log -> info() << "Registering default plugins..." << std::endl;
@@ -650,7 +650,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		else {
 			std::ostringstream error_message;
 			error_message << "Unknown phase space file type" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 	xmlconfig.changecurrentnode(oldpath);
@@ -681,7 +681,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		else {
 			std::ostringstream error_message;
 			error_message << "Unknown generator: " << generatorName << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		_inputReader->readXML(xmlconfig);
 	}
@@ -717,7 +717,7 @@ void Simulation::readConfigFile(std::string filename) {
 	else {
 		std::ostringstream error_message;
 		error_message << "Unknown config file extension '" << extension << "'." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -733,7 +733,7 @@ void Simulation::initConfigXML(const std::string& inputfilename) {
 			std::ostringstream error_message;
 			error_message << "Cound not find root node /mardyn in XML input file." << std::endl;
 			error_message << "Not a valid MarDyn XML input file." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		std::string version("unknown");
@@ -749,7 +749,7 @@ void Simulation::initConfigXML(const std::string& inputfilename) {
 		else {
 			std::ostringstream error_message;
 			error_message << "Simulation section missing" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		parseMiscOptions(inp);
@@ -763,7 +763,7 @@ void Simulation::initConfigXML(const std::string& inputfilename) {
 		std::ostringstream error_message;
 		error_message << "Error in XML config. Please check your input file!" << std::endl;
 		error_message << "Exception: " << e.what() << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 #ifdef ENABLE_MPI
@@ -890,7 +890,7 @@ void Simulation::prepare_start() {
 	} else {
 		std::ostringstream error_message;
 		error_message << "No _longRangeCorrection set!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	// longRangeCorrection is a site-wise force plugin, so we have to call it before updateForces()
 	_longRangeCorrection->calculateLongRange();
@@ -988,7 +988,7 @@ void Simulation::preSimLoopSteps()
 					<< "Status: (pre sim loop steps done:" << preSimLoopStepsDone
 					<< ", simulation done: " << simulationDone
 					<< ", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 
@@ -1053,7 +1053,7 @@ void Simulation::simulateOneTimestep()
 					<< "Status: (pre sim loop steps done:" << preSimLoopStepsDone
 					<< ", simulation done: " << simulationDone
 					<< ", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	#ifdef MAMICO_COUPLING
@@ -1287,7 +1287,7 @@ void Simulation::postSimLoopSteps()
 					<< "Status: (pre sim loop steps done:" << preSimLoopStepsDone
 					<< ", simulation done: " << simulationDone
 					<< ", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 
@@ -1353,7 +1353,7 @@ void Simulation::pluginEndStepCall(unsigned long simstep) {
 	if (std::isnan(_domain->getGlobalCurrentTemperature()) || std::isnan(_domain->getGlobalUpot()) || std::isnan(_domain->getGlobalPressure())) {
 		std::ostringstream error_message;
 		error_message << "NaN detected, exiting." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -1424,7 +1424,7 @@ void Simulation::performOverlappingDecompositionAndCellTraversalStep(double etim
 	if (not dd) {
 		std::ostringstream error_message;
 		error_message << "DomainDecompMPIBase* required for overlapping comm, but dynamic_cast failed." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	NonBlockingMPIMultiStepHandler nonBlockingMPIHandler {dd, _moleculeContainer, _domain, _cellProcessor};
 
@@ -1434,7 +1434,7 @@ void Simulation::performOverlappingDecompositionAndCellTraversalStep(double etim
 #else
 	std::ostringstream error_message;
 	error_message << "performOverlappingDecompositionAndCellTraversalStep() called with disabled MPI." << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 #endif
 }
 

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -392,7 +392,6 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 						<< "Executable was compiled without support for parallel execution: "
 						<< parallelisationtype
 						<< " not available. Using serial mode." << std::endl;
-				//MARDYN_EXIT(error_message.str());
 			}
 			//_domainDecomposition = new DomainDecompBase();  // already set in initialize()
 		#endif

--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -172,14 +172,14 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		if(integratorType == "Leapfrog") {
 #ifdef ENABLE_REDUCED_MEMORY_MODE
 			Log::global_log->error() << "The reduced memory mode (RMM) requires the LeapfrogRMM integrator." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 #endif
 			_integrator = new Leapfrog();
 		} else if (integratorType == "LeapfrogRMM") {
 			_integrator = new LeapfrogRMM();
 		} else {
 			Log::global_log-> error() << "Unknown integrator " << integratorType << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		_integrator->readXML(xmlconfig);
 		_integrator->init();
@@ -222,7 +222,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			_ensemble = new GrandCanonicalEnsemble();
 		} else {
 			Log::global_log->error() << "Unknown ensemble type: " << ensembletype << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		_ensemble->readXML(xmlconfig);
 		/** @todo Here we store data in the _domain member as long as we do not use the ensemble everywhere */
@@ -235,7 +235,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 	}
 	else {
 		Log::global_log->error() << "Ensemble section missing." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	/* algorithm */
@@ -256,13 +256,13 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			_cutoffRadius = std::max(_cutoffRadius, _LJCutoffRadius);
 			if(_cutoffRadius <= 0) {
 				Log::global_log->error() << "cutoff radius <= 0." << std::endl;
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 			}
 			Log::global_log->info() << "dimensionless cutoff radius:\t" << _cutoffRadius << std::endl;
 			xmlconfig.changecurrentnode("..");
 		} else {
 			Log::global_log->error() << "Cutoff section missing." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 
 		/* electrostatics */
@@ -275,7 +275,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			xmlconfig.changecurrentnode("..");
 		} else {
 			Log::global_log->error() << "Electrostatics section for reaction field setup missing." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 
 		if (xmlconfig.changecurrentnode("electrostatic[@type='FastMultipoleMethod']")) {
@@ -283,7 +283,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			Log::global_log->fatal()
 				<< "The fast multipole method is not compatible with AutoPas. Please disable the AutoPas mode (ENABLE_AUTOPAS)!"
 				<< std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 #endif
 			_FMM = new bhfmm::FastMultipoleMethod();
 			_FMM->readXML(xmlconfig);
@@ -342,7 +342,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 												   "vs the GeneralDomainDecomposition which can lead ALL to shrink the "
 												   "domain too small."
 												  << std::endl;
-							mardyn_exit(512435340);
+							MARDYN_EXIT(512435340);
 						}
 					} else {
 						Log::global_log->warning() << "Using the GeneralDomainDecomposition without AutoPas is not "
@@ -358,17 +358,17 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 					Log::global_log->info() << "Using skin = " << skin << " for the GeneralDomainDecomposition." << std::endl;
 				} else {
 					Log::global_log->error() << "Datastructure section missing" << std::endl;
-					mardyn_exit(1);
+					MARDYN_EXIT(1);
 				}
 				if(not xmlconfig.changecurrentnode("../parallelisation")){
 					Log::global_log->error() << "Could not go back to parallelisation path. Aborting." << std::endl;
-					mardyn_exit(1);
+					MARDYN_EXIT(1);
 				}
 				delete _domainDecomposition;
 				_domainDecomposition = new GeneralDomainDecomposition(getcutoffRadius() + skin, _domain, forceLatchingToLinkedCellsGrid);
 			} else {
 				Log::global_log->error() << "Unknown parallelisation type: " << parallelisationtype << std::endl;
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 			}
 		#else /* serial */
 			if(parallelisationtype != "DummyDecomposition") {
@@ -376,7 +376,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 						<< "Executable was compiled without support for parallel execution: "
 						<< parallelisationtype
 						<< " not available. Using serial mode." << std::endl;
-				//mardyn_exit(1);
+				//MARDYN_EXIT(1);
 			}
 			//_domainDecomposition = new DomainDecompBase();  // already set in initialize()
 		#endif
@@ -403,7 +403,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 							   << "time steps for the load calculation." << std::endl;
 			if(timerForLoadAveragingLength < 1ul) {
 				Log::global_log->fatal() << "timerForLoadAveragingLength has to be at least 1" << std::endl;
-				mardyn_exit(15843);
+				MARDYN_EXIT(15843);
 			}
 			_lastTraversalTimeHistory.setCapacity(timerForLoadAveragingLength);
 
@@ -412,7 +412,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		else {
 		#ifdef ENABLE_MPI
 			Log::global_log->error() << "Parallelisation section missing." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		#else /* serial */
 			// set _timerForLoad, s.t. it always exists.
 			_timerForLoad = timers()->getTimer("SIMULATION_COMPUTATION");
@@ -430,7 +430,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 				Log::global_log->fatal()
 					<< "LinkedCells not compiled (use AutoPas instead, or compile with disabled autopas mode)!"
 					<< std::endl;
-				mardyn_exit(33);
+				MARDYN_EXIT(33);
 #else
 				_moleculeContainer = new LinkedCells();
 				/** @todo Review if we need to know the max cutoff radius usable with any datastructure. */
@@ -439,7 +439,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 #endif
 			} else if(datastructuretype == "AdaptiveSubCells") {
 				Log::global_log->warning() << "AdaptiveSubCells no longer supported." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			} else if(datastructuretype == "AutoPas" || datastructuretype == "AutoPasContainer") {
 #ifdef MARDYN_AUTOPAS
 				Log::global_log->info() << "Using AutoPas container." << std::endl;
@@ -447,12 +447,12 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 				Log::global_log->info() << "Setting cell cutoff radius for AutoPas container to " << _cutoffRadius << std::endl;
 #else
 				Log::global_log->fatal() << "AutoPas not compiled (use LinkedCells instead, or compile with enabled autopas mode)!" << std::endl;
-				mardyn_exit(33);
+				MARDYN_EXIT(33);
 #endif
 			}
 			else {
 				Log::global_log->error() << "Unknown data structure type: " << datastructuretype << std::endl;
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 			}
 			_moleculeContainer->readXML(xmlconfig);
 
@@ -464,7 +464,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			xmlconfig.changecurrentnode("..");
 		} else {
 			Log::global_log->error() << "Datastructure section missing" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 
 		// TODO: move parts to readXML in TemperatureControl?
@@ -508,7 +508,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
                     } else {
                         Log::global_log->error() << "Instance of TemperatureControl allready exist! Programm exit ..."
                                             << std::endl;
-                        mardyn_exit(-1);
+                        MARDYN_EXIT(-1);
                     }
                 }
 				else
@@ -531,7 +531,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			if( !xmlconfig.getNodeValue("@type", type) )
 			{
 				Log::global_log->error() << "LongRangeCorrection: Missing type specification. Program exit ..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 			if("planar" == type)
 			{
@@ -555,7 +555,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 			else
 			{
 				Log::global_log->error() << "LongRangeCorrection: Wrong type. Expected type == homogeneous|planar|none. Program exit ..." << std::endl;
-                mardyn_exit(-1);
+                MARDYN_EXIT(-1);
 			}
 			xmlconfig.changecurrentnode("..");
 		} else {
@@ -621,7 +621,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 #endif
 		else {
 			Log::global_log->error() << "Unknown phase space file type" << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 	}
 	xmlconfig.changecurrentnode(oldpath);
@@ -651,7 +651,7 @@ void Simulation::readXML(XMLfileUnits& xmlconfig) {
 		}
 		else {
 			Log::global_log->error() << "Unknown generator: " << generatorName << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		_inputReader->readXML(xmlconfig);
 	}
@@ -686,7 +686,7 @@ void Simulation::readConfigFile(std::string filename) {
 	}
 	else {
 		Log::global_log->error() << "Unknown config file extension '" << extension << "'." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 }
 
@@ -701,7 +701,7 @@ void Simulation::initConfigXML(const std::string& inputfilename) {
 		if(inp.changecurrentnode("/mardyn") < 0) {
 			Log::global_log->error() << "Cound not find root node /mardyn in XML input file." << std::endl;
 			Log::global_log->fatal() << "Not a valid MarDyn XML input file." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 
 		std::string version("unknown");
@@ -716,7 +716,7 @@ void Simulation::initConfigXML(const std::string& inputfilename) {
 		} // simulation-section
 		else {
 			Log::global_log->error() << "Simulation section missing" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 
 		parseMiscOptions(inp);
@@ -729,7 +729,7 @@ void Simulation::initConfigXML(const std::string& inputfilename) {
 	} catch (const std::exception& e) {
 		Log::global_log->error() << "Error in XML config. Please check your input file!" << std::endl;
 		Log::global_log->error() << "Exception: " << e.what() << std::endl;
-		mardyn_exit(7);
+		MARDYN_EXIT(7);
 	}
 
 #ifdef ENABLE_MPI
@@ -855,7 +855,7 @@ void Simulation::prepare_start() {
 		_longRangeCorrection->init();
 	} else {
 		Log::global_log->fatal() << "No _longRangeCorrection set!" << std::endl;
-		mardyn_exit(93742);
+		MARDYN_EXIT(93742);
 	}
 	// longRangeCorrection is a site-wise force plugin, so we have to call it before updateForces()
 	_longRangeCorrection->calculateLongRange();
@@ -950,7 +950,7 @@ void Simulation::preSimLoopSteps()
 	{
 		Log::global_log->error() << "Unexpected call to preSimLoopSteps()! Status: (pre sim loop steps done:" << preSimLoopStepsDone << ", simulation done: " << simulationDone << 
 					", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 
@@ -1012,7 +1012,7 @@ void Simulation::simulateOneTimestep()
 	{
 		Log::global_log->error() << "Unexpected call to simulateOneTimeStep()! Status: (pre sim loop steps done:" << preSimLoopStepsDone << ", simulation done: " << simulationDone << 
 					", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	#ifdef MAMICO_COUPLING
@@ -1243,7 +1243,7 @@ void Simulation::postSimLoopSteps()
 	{
 		Log::global_log->error() << "Unexpected call to postSimLoopSteps()! Status: (pre sim loop steps done:" << preSimLoopStepsDone << ", simulation done: " << simulationDone << 
 					", post sim loop steps done: " << postSimLoopStepsDone << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 
@@ -1308,7 +1308,7 @@ void Simulation::pluginEndStepCall(unsigned long simstep) {
 					   << _domain->getGlobalPressure() << std::endl;
 	if (std::isnan(_domain->getGlobalCurrentTemperature()) || std::isnan(_domain->getGlobalUpot()) || std::isnan(_domain->getGlobalPressure())) {
 		Log::global_log->error() << "NaN detected, exiting." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 }
 
@@ -1378,7 +1378,7 @@ void Simulation::performOverlappingDecompositionAndCellTraversalStep(double etim
 	auto* dd = dynamic_cast<DomainDecompMPIBase*>(_domainDecomposition);
 	if (not dd) {
 		Log::global_log->fatal() << "DomainDecompMPIBase* required for overlapping comm, but dynamic_cast failed." << std::endl;
-		mardyn_exit(873456);
+		MARDYN_EXIT(873456);
 	}
 	NonBlockingMPIMultiStepHandler nonBlockingMPIHandler {dd, _moleculeContainer, _domain, _cellProcessor};
 
@@ -1387,7 +1387,7 @@ void Simulation::performOverlappingDecompositionAndCellTraversalStep(double etim
 	nonBlockingMPIHandler.performOverlappingTasks(forceRebalancing, etime);
 #else
 	Log::global_log->fatal() << "performOverlappingDecompositionAndCellTraversalStep() called with disabled MPI." << std::endl;
-	mardyn_exit(873457);
+	MARDYN_EXIT(873457);
 #endif
 }
 

--- a/src/bhfmm/FastMultipoleMethod.cpp
+++ b/src/bhfmm/FastMultipoleMethod.cpp
@@ -67,10 +67,11 @@ void FastMultipoleMethod::init(double globalDomainLength[3], double bBoxMin[3],
 			and _LJCellSubdivisionFactor != 2
 			and _LJCellSubdivisionFactor != 4
 			and _LJCellSubdivisionFactor != 8) {
-		Log::global_log->error() << "Fast Multipole Method: bad subdivision factor:"
+		std::ostringstream error_message;
+		error_message << "Fast Multipole Method: bad subdivision factor:"
 				<< _LJCellSubdivisionFactor << std::endl;
-		Log::global_log->error() << "expected 1,2,4 or 8" << std::endl;
-		MARDYN_EXIT(5);
+		error_message << "expected 1,2,4 or 8" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info()
 			<< "Fast Multipole Method: each LJ cell will be subdivided in "
@@ -107,8 +108,9 @@ void FastMultipoleMethod::init(double globalDomainLength[3], double bBoxMin[3],
 	} else {
 		// TODO: Debugging in Progress!
 #if defined(ENABLE_MPI)
-		Log::global_log->error() << "MPI in combination with adaptive is not supported yet" << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "MPI in combination with adaptive is not supported yet" << std::endl;
+		MARDYN_EXIT(error_message);
 #endif
 		//int threshold = 100;
 		_pseudoParticleContainer = new AdaptivePseudoParticleContainer(
@@ -313,8 +315,9 @@ void FastMultipoleMethod::runner(int type, void *data) {
 #else
 #pragma omp critical
 	{
-	Log::global_log->error() << "Quicksched runner without FMM_FFT not implemented!" << std::endl;
-	MARDYN_EXIT(1);
+	std::ostringstream error_message;
+	error_message << "Quicksched runner without FMM_FFT not implemented!" << std::endl;
+	MARDYN_EXIT(error_message);
 	}
 #endif /* FMM_FFT */
 }

--- a/src/bhfmm/FastMultipoleMethod.cpp
+++ b/src/bhfmm/FastMultipoleMethod.cpp
@@ -71,7 +71,7 @@ void FastMultipoleMethod::init(double globalDomainLength[3], double bBoxMin[3],
 		error_message << "Fast Multipole Method: bad subdivision factor:"
 				<< _LJCellSubdivisionFactor << std::endl;
 		error_message << "expected 1,2,4 or 8" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	Log::global_log->info()
 			<< "Fast Multipole Method: each LJ cell will be subdivided in "
@@ -110,7 +110,7 @@ void FastMultipoleMethod::init(double globalDomainLength[3], double bBoxMin[3],
 #if defined(ENABLE_MPI)
 		std::ostringstream error_message;
 		error_message << "MPI in combination with adaptive is not supported yet" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 #endif
 		//int threshold = 100;
 		_pseudoParticleContainer = new AdaptivePseudoParticleContainer(
@@ -317,7 +317,7 @@ void FastMultipoleMethod::runner(int type, void *data) {
 	{
 	std::ostringstream error_message;
 	error_message << "Quicksched runner without FMM_FFT not implemented!" << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 	}
 #endif /* FMM_FFT */
 }

--- a/src/bhfmm/FastMultipoleMethod.cpp
+++ b/src/bhfmm/FastMultipoleMethod.cpp
@@ -70,7 +70,7 @@ void FastMultipoleMethod::init(double globalDomainLength[3], double bBoxMin[3],
 		Log::global_log->error() << "Fast Multipole Method: bad subdivision factor:"
 				<< _LJCellSubdivisionFactor << std::endl;
 		Log::global_log->error() << "expected 1,2,4 or 8" << std::endl;
-		mardyn_exit(5);
+		MARDYN_EXIT(5);
 	}
 	Log::global_log->info()
 			<< "Fast Multipole Method: each LJ cell will be subdivided in "
@@ -108,7 +108,7 @@ void FastMultipoleMethod::init(double globalDomainLength[3], double bBoxMin[3],
 		// TODO: Debugging in Progress!
 #if defined(ENABLE_MPI)
 		Log::global_log->error() << "MPI in combination with adaptive is not supported yet" << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 #endif
 		//int threshold = 100;
 		_pseudoParticleContainer = new AdaptivePseudoParticleContainer(
@@ -314,7 +314,7 @@ void FastMultipoleMethod::runner(int type, void *data) {
 #pragma omp critical
 	{
 	Log::global_log->error() << "Quicksched runner without FMM_FFT not implemented!" << std::endl;
-	mardyn_exit(1);
+	MARDYN_EXIT(1);
 	}
 #endif /* FMM_FFT */
 }

--- a/src/bhfmm/containers/UniformPseudoParticleContainer.cpp
+++ b/src/bhfmm/containers/UniformPseudoParticleContainer.cpp
@@ -114,7 +114,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 #if WIGNER == 1
 	std::ostringstream error_message;
 	error_message << "WIGNER not supported yet" << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 #endif
 #ifdef ENABLE_MPI
 	/*
@@ -179,7 +179,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 	if(_globalLevel > _maxLevel){
 		std::ostringstream error_message;
 		error_message << "Too many MPI ranks" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	//numProcessers has to be a power of 2
 	mardyn_assert(pow(2,log2(numProcessors)) == numProcessors);
@@ -383,7 +383,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 		if(size2 > 8){ //neighbourhood comms need to have size 8
 			std::ostringstream error_message;
 			error_message << "Error wrong communicator" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 #endif

--- a/src/bhfmm/containers/UniformPseudoParticleContainer.cpp
+++ b/src/bhfmm/containers/UniformPseudoParticleContainer.cpp
@@ -14,6 +14,7 @@
 #include "bhfmm/HaloBufferNoOverlap.h"
 #include "bhfmm/HaloBufferOverlap.h"
 #include <string>
+#include <sstream>
 #include <algorithm>
 #include <array>
 #ifdef _OPENMP
@@ -111,8 +112,9 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 	_comm = domainDecomp.getCommunicator();
 #endif
 #if WIGNER == 1
-	//global_log->error() << "not supported yet" << std::endl;
-	MARDYN_EXIT(-1);
+	std::ostringstream error_message;
+	error_message << "WIGNER not supported yet" << std::endl;
+	MARDYN_EXIT(error_message);
 #endif
 #ifdef ENABLE_MPI
 	/*
@@ -175,8 +177,9 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 	MPI_Comm_size(_comm,&numProcessors);
 	_globalLevel = ceil(log2(numProcessors)/3.0);
 	if(_globalLevel > _maxLevel){
-		std::cout << "too many MPI ranks \n";
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "Too many MPI ranks" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	//numProcessers has to be a power of 2
 	mardyn_assert(pow(2,log2(numProcessors)) == numProcessors);
@@ -378,8 +381,9 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 		int size2;
 		MPI_Comm_size(_neighbourhoodComms[i], &size2);
 		if(size2 > 8){ //neighbourhood comms need to have size 8
-			std::cout << "Error wrong communicator \n";
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Error wrong communicator" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 #endif

--- a/src/bhfmm/containers/UniformPseudoParticleContainer.cpp
+++ b/src/bhfmm/containers/UniformPseudoParticleContainer.cpp
@@ -112,7 +112,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 #endif
 #if WIGNER == 1
 	//global_log->error() << "not supported yet" << std::endl;
-	mardyn_exit(-1);
+	MARDYN_EXIT(-1);
 #endif
 #ifdef ENABLE_MPI
 	/*
@@ -176,7 +176,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 	_globalLevel = ceil(log2(numProcessors)/3.0);
 	if(_globalLevel > _maxLevel){
 		std::cout << "too many MPI ranks \n";
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	//numProcessers has to be a power of 2
 	mardyn_assert(pow(2,log2(numProcessors)) == numProcessors);
@@ -379,7 +379,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 		MPI_Comm_size(_neighbourhoodComms[i], &size2);
 		if(size2 > 8){ //neighbourhood comms need to have size 8
 			std::cout << "Error wrong communicator \n";
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 	}
 #endif

--- a/src/bhfmm/containers/UniformPseudoParticleContainer_old_Wigner_cpp.txt
+++ b/src/bhfmm/containers/UniformPseudoParticleContainer_old_Wigner_cpp.txt
@@ -45,7 +45,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 #endif
 #if WIGNER == 1
 	//global_log->error() << "not supported yet" << std::endl;
-	mardyn_exit(-1);
+	MARDYN_EXIT(-1);
 #endif
 #ifdef ENABLE_MPI
 	_timerProcessCells.set_sync(false);
@@ -81,7 +81,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 	_globalLevel = log2(numProcessors)/3;
 	if(_globalLevel > _maxLevel){
 		std::cout << "too many MPI ranks \n";
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	//numProcessers has to be a power of 8
 	mardyn_assert(log2(numProcessors) == _globalLevel * 3);
@@ -778,7 +778,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 				for (m2z = LoLim(2) + 2; m2z <= HiLim(2) + 2; m2z++) {
 					if (m2z < 0 or m2z >= localMpCells) {
 						std::cout << "Error \n";
-						mardyn_exit(-1);
+						MARDYN_EXIT(-1);
 					}
 
 
@@ -786,7 +786,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 					for (m2y = LoLim(1) + 2; m2y <= HiLim(1) + 2; m2y++) {
 						if (m2y < 0 or m2y >= localMpCells) {
 							std::cout << "Error \n";
-							mardyn_exit(-1);
+							MARDYN_EXIT(-1);
 						}
 
 
@@ -794,7 +794,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 						for (m2x = LoLim(0) + 2; m2x <= HiLim(0) + 2; m2x++) {
 							if (m2x < 0 or m2x >= localMpCells) {
 								std::cout << "Error \n";
-								mardyn_exit(-1);
+								MARDYN_EXIT(-1);
 							}
 
 							m2v[0] = m2x;

--- a/src/bhfmm/containers/UniformPseudoParticleContainer_old_Wigner_cpp.txt
+++ b/src/bhfmm/containers/UniformPseudoParticleContainer_old_Wigner_cpp.txt
@@ -45,7 +45,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 #endif
 #if WIGNER == 1
 	//global_log->error() << "not supported yet" << std::endl;
-	MARDYN_EXIT(-1);
+	MARDYN_EXIT(error_message);
 #endif
 #ifdef ENABLE_MPI
 	_timerProcessCells.set_sync(false);
@@ -81,7 +81,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 	_globalLevel = log2(numProcessors)/3;
 	if(_globalLevel > _maxLevel){
 		std::cout << "too many MPI ranks \n";
-		MARDYN_EXIT(-1);
+		MARDYN_EXIT(error_message);
 	}
 	//numProcessers has to be a power of 8
 	mardyn_assert(log2(numProcessors) == _globalLevel * 3);
@@ -778,7 +778,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 				for (m2z = LoLim(2) + 2; m2z <= HiLim(2) + 2; m2z++) {
 					if (m2z < 0 or m2z >= localMpCells) {
 						std::cout << "Error \n";
-						MARDYN_EXIT(-1);
+						MARDYN_EXIT(error_message);
 					}
 
 
@@ -786,7 +786,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 					for (m2y = LoLim(1) + 2; m2y <= HiLim(1) + 2; m2y++) {
 						if (m2y < 0 or m2y >= localMpCells) {
 							std::cout << "Error \n";
-							MARDYN_EXIT(-1);
+							MARDYN_EXIT(error_message);
 						}
 
 
@@ -794,7 +794,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 						for (m2x = LoLim(0) + 2; m2x <= HiLim(0) + 2; m2x++) {
 							if (m2x < 0 or m2x >= localMpCells) {
 								std::cout << "Error \n";
-								MARDYN_EXIT(-1);
+								MARDYN_EXIT(error_message);
 							}
 
 							m2v[0] = m2x;

--- a/src/bhfmm/containers/UniformPseudoParticleContainer_old_Wigner_cpp.txt
+++ b/src/bhfmm/containers/UniformPseudoParticleContainer_old_Wigner_cpp.txt
@@ -45,7 +45,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 #endif
 #if WIGNER == 1
 	//global_log->error() << "not supported yet" << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 #endif
 #ifdef ENABLE_MPI
 	_timerProcessCells.set_sync(false);
@@ -81,7 +81,7 @@ UniformPseudoParticleContainer::UniformPseudoParticleContainer(
 	_globalLevel = log2(numProcessors)/3;
 	if(_globalLevel > _maxLevel){
 		std::cout << "too many MPI ranks \n";
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	//numProcessers has to be a power of 8
 	mardyn_assert(log2(numProcessors) == _globalLevel * 3);
@@ -778,7 +778,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 				for (m2z = LoLim(2) + 2; m2z <= HiLim(2) + 2; m2z++) {
 					if (m2z < 0 or m2z >= localMpCells) {
 						std::cout << "Error \n";
-						MARDYN_EXIT(error_message);
+						MARDYN_EXIT(error_message.str());
 					}
 
 
@@ -786,7 +786,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 					for (m2y = LoLim(1) + 2; m2y <= HiLim(1) + 2; m2y++) {
 						if (m2y < 0 or m2y >= localMpCells) {
 							std::cout << "Error \n";
-							MARDYN_EXIT(error_message);
+							MARDYN_EXIT(error_message.str());
 						}
 
 
@@ -794,7 +794,7 @@ void UniformPseudoParticleContainer::GatherWellSepLo_MPI(double *cellWid, int lo
 						for (m2x = LoLim(0) + 2; m2x <= HiLim(0) + 2; m2x++) {
 							if (m2x < 0 or m2x >= localMpCells) {
 								std::cout << "Error \n";
-								MARDYN_EXIT(error_message);
+								MARDYN_EXIT(error_message.str());
 							}
 
 							m2v[0] = m2x;

--- a/src/ensemble/CanonicalEnsemble.cpp
+++ b/src/ensemble/CanonicalEnsemble.cpp
@@ -197,7 +197,7 @@ void CanonicalEnsemble::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "Volume type not supported." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	xmlconfig.changecurrentnode("domain");
 	_domain->readXML(xmlconfig);

--- a/src/ensemble/CanonicalEnsemble.cpp
+++ b/src/ensemble/CanonicalEnsemble.cpp
@@ -196,7 +196,7 @@ void CanonicalEnsemble::readXML(XMLfileUnits& xmlconfig) {
 		_domain = new BoxDomain();
 	} else {
 		Log::global_log->error() << "Volume type not supported." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	xmlconfig.changecurrentnode("domain");
 	_domain->readXML(xmlconfig);

--- a/src/ensemble/CanonicalEnsemble.cpp
+++ b/src/ensemble/CanonicalEnsemble.cpp
@@ -195,8 +195,9 @@ void CanonicalEnsemble::readXML(XMLfileUnits& xmlconfig) {
 	if("box" == domaintype) {
 		_domain = new BoxDomain();
 	} else {
-		Log::global_log->error() << "Volume type not supported." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Volume type not supported." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	xmlconfig.changecurrentnode("domain");
 	_domain->readXML(xmlconfig);

--- a/src/ensemble/CavityEnsemble.cpp
+++ b/src/ensemble/CavityEnsemble.cpp
@@ -96,7 +96,7 @@ void CavityEnsemble::setControlVolume(double x0, double y0, double z0, double x1
         Log::global_log->error() << "\nInvalid control volume (" << x0 << " / " << y0
                             << " / " << z0 << ") to (" << x1 << " / " << y1 << " / "
                             << z1 << ")." << std::endl;
-        mardyn_exit(711);
+        MARDYN_EXIT(711);
     }
 
     this->restrictedControlVolume = true;
@@ -112,19 +112,19 @@ void CavityEnsemble::setControlVolume(double x0, double y0, double z0, double x1
 void CavityEnsemble::init(Component *component, unsigned Nx, unsigned Ny, unsigned Nz) {
     if (this->ownrank < 0) {
         Log::global_log->error() << "\nInvalid rank " << ownrank << ".\n";
-        mardyn_exit(712);
+        MARDYN_EXIT(712);
     }
     if (this->initialized) {
         Log::global_log->error() << "\nCavity ensemble initialized twice.\n";
-        mardyn_exit(713);
+        MARDYN_EXIT(713);
     }
     if (0.0 >= this->T) {
         Log::global_log->error() << "\nInvalid temperature T = " << T << ".\n";
-        mardyn_exit(714);
+        MARDYN_EXIT(714);
     }
     if (0.0 >= this->globalV) {
         Log::global_log->error() << "\nInvalid control volume V_ctrl = " << globalV << ".\n";
-        mardyn_exit(715);
+        MARDYN_EXIT(715);
     }
 
     this->componentid = component->ID();

--- a/src/ensemble/CavityEnsemble.cpp
+++ b/src/ensemble/CavityEnsemble.cpp
@@ -97,7 +97,7 @@ void CavityEnsemble::setControlVolume(double x0, double y0, double z0, double x1
         error_message << "\nInvalid control volume (" << x0 << " / " << y0
                             << " / " << z0 << ") to (" << x1 << " / " << y1 << " / "
                             << z1 << ")." << std::endl;
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
 
     this->restrictedControlVolume = true;
@@ -114,22 +114,22 @@ void CavityEnsemble::init(Component *component, unsigned Nx, unsigned Ny, unsign
     if (this->ownrank < 0) {
         std::ostringstream error_message;
         error_message << "\nInvalid rank " << ownrank << ".\n";
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
     if (this->initialized) {
         std::ostringstream error_message;
         error_message << "\nCavity ensemble initialized twice.\n";
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
     if (0.0 >= this->T) {
         std::ostringstream error_message;
         error_message << "\nInvalid temperature T = " << T << ".\n";
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
     if (0.0 >= this->globalV) {
         std::ostringstream error_message;
         error_message << "\nInvalid control volume V_ctrl = " << globalV << ".\n";
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
 
     this->componentid = component->ID();

--- a/src/ensemble/CavityEnsemble.cpp
+++ b/src/ensemble/CavityEnsemble.cpp
@@ -93,9 +93,11 @@ void CavityEnsemble::setSubdomain(int rank, double x0, double x1, double y0, dou
 
 void CavityEnsemble::setControlVolume(double x0, double y0, double z0, double x1, double y1, double z1) {
     if ((x0 >= x1) || (y0 >= y1) || (z0 >= z1)) {
-        std::ostringstream error_message;        error_message << "\nInvalid control volume (" << x0 << " / " << y0
+        std::ostringstream error_message;
+        error_message << "\nInvalid control volume (" << x0 << " / " << y0
                             << " / " << z0 << ") to (" << x1 << " / " << y1 << " / "
-                            << z1 << ")." << std::endl;        MARDYN_EXIT(error_message);
+                            << z1 << ")." << std::endl;
+        MARDYN_EXIT(error_message);
     }
 
     this->restrictedControlVolume = true;

--- a/src/ensemble/CavityEnsemble.cpp
+++ b/src/ensemble/CavityEnsemble.cpp
@@ -93,10 +93,9 @@ void CavityEnsemble::setSubdomain(int rank, double x0, double x1, double y0, dou
 
 void CavityEnsemble::setControlVolume(double x0, double y0, double z0, double x1, double y1, double z1) {
     if ((x0 >= x1) || (y0 >= y1) || (z0 >= z1)) {
-        Log::global_log->error() << "\nInvalid control volume (" << x0 << " / " << y0
+        std::ostringstream error_message;        error_message << "\nInvalid control volume (" << x0 << " / " << y0
                             << " / " << z0 << ") to (" << x1 << " / " << y1 << " / "
-                            << z1 << ")." << std::endl;
-        MARDYN_EXIT(711);
+                            << z1 << ")." << std::endl;        MARDYN_EXIT(error_message);
     }
 
     this->restrictedControlVolume = true;
@@ -111,20 +110,24 @@ void CavityEnsemble::setControlVolume(double x0, double y0, double z0, double x1
 
 void CavityEnsemble::init(Component *component, unsigned Nx, unsigned Ny, unsigned Nz) {
     if (this->ownrank < 0) {
-        Log::global_log->error() << "\nInvalid rank " << ownrank << ".\n";
-        MARDYN_EXIT(712);
+        std::ostringstream error_message;
+        error_message << "\nInvalid rank " << ownrank << ".\n";
+        MARDYN_EXIT(error_message);
     }
     if (this->initialized) {
-        Log::global_log->error() << "\nCavity ensemble initialized twice.\n";
-        MARDYN_EXIT(713);
+        std::ostringstream error_message;
+        error_message << "\nCavity ensemble initialized twice.\n";
+        MARDYN_EXIT(error_message);
     }
     if (0.0 >= this->T) {
-        Log::global_log->error() << "\nInvalid temperature T = " << T << ".\n";
-        MARDYN_EXIT(714);
+        std::ostringstream error_message;
+        error_message << "\nInvalid temperature T = " << T << ".\n";
+        MARDYN_EXIT(error_message);
     }
     if (0.0 >= this->globalV) {
-        Log::global_log->error() << "\nInvalid control volume V_ctrl = " << globalV << ".\n";
-        MARDYN_EXIT(715);
+        std::ostringstream error_message;
+        error_message << "\nInvalid control volume V_ctrl = " << globalV << ".\n";
+        MARDYN_EXIT(error_message);
     }
 
     this->componentid = component->ID();

--- a/src/ensemble/ChemicalPotential.cpp
+++ b/src/ensemble/ChemicalPotential.cpp
@@ -284,8 +284,9 @@ bool ChemicalPotential::decideDeletion(double deltaUTilde)
 					<< "SEVERE WARNING: The Widom method is (erroneously) trying to carry out test deletions.\n";
 			return false;
 		}
-		Log::global_log->error() << "No decision is possible." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "No decision is possible." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	float dec = *_remainingDecisions.begin();
 	_remainingDecisions.erase(_remainingDecisions.begin());
@@ -317,8 +318,9 @@ bool ChemicalPotential::decideInsertion(double deltaUTilde)
 					<< ": no decision is possible !!!\n";
 			return false;
 		}
-		Log::global_log->error() << "No decision is possible." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "No decision is possible." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	double acc = _globalReducedVolume * exp(_muTilde - deltaUTilde)
 			/ (1.0 + (double) (_globalN));
@@ -373,10 +375,9 @@ void ChemicalPotential::setControlVolume(double x0, double y0, double z0,
 		double x1, double y1, double z1)
 {
 	if ((x0 >= x1) || (y0 >= y1) || (z0 >= z1)) {
-		Log::global_log->error() << "\nInvalid control volume (" << x0 << " / " << y0
+		std::ostringstream error_message;		error_message << "\nInvalid control volume (" << x0 << " / " << y0
 				<< " / " << z0 << ") to (" << x1 << " / " << y1 << " / " << z1
-				<< ")." << std::endl;
-		MARDYN_EXIT(611);
+				<< ")." << std::endl;		MARDYN_EXIT(error_message);
 	}
 	_restrictedControlVolume = true;
 	_globalV = (x1 - x0) * (y1 - y0) * (z1 - z0);

--- a/src/ensemble/ChemicalPotential.cpp
+++ b/src/ensemble/ChemicalPotential.cpp
@@ -375,9 +375,11 @@ void ChemicalPotential::setControlVolume(double x0, double y0, double z0,
 		double x1, double y1, double z1)
 {
 	if ((x0 >= x1) || (y0 >= y1) || (z0 >= z1)) {
-		std::ostringstream error_message;		error_message << "\nInvalid control volume (" << x0 << " / " << y0
+		std::ostringstream error_message;
+		error_message << "\nInvalid control volume (" << x0 << " / " << y0
 				<< " / " << z0 << ") to (" << x1 << " / " << y1 << " / " << z1
-				<< ")." << std::endl;		MARDYN_EXIT(error_message);
+				<< ")." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	_restrictedControlVolume = true;
 	_globalV = (x1 - x0) * (y1 - y0) * (z1 - z0);

--- a/src/ensemble/ChemicalPotential.cpp
+++ b/src/ensemble/ChemicalPotential.cpp
@@ -286,7 +286,7 @@ bool ChemicalPotential::decideDeletion(double deltaUTilde)
 		}
 		std::ostringstream error_message;
 		error_message << "No decision is possible." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	float dec = *_remainingDecisions.begin();
 	_remainingDecisions.erase(_remainingDecisions.begin());
@@ -320,7 +320,7 @@ bool ChemicalPotential::decideInsertion(double deltaUTilde)
 		}
 		std::ostringstream error_message;
 		error_message << "No decision is possible." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	double acc = _globalReducedVolume * exp(_muTilde - deltaUTilde)
 			/ (1.0 + (double) (_globalN));
@@ -379,7 +379,7 @@ void ChemicalPotential::setControlVolume(double x0, double y0, double z0,
 		error_message << "\nInvalid control volume (" << x0 << " / " << y0
 				<< " / " << z0 << ") to (" << x1 << " / " << y1 << " / " << z1
 				<< ")." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	_restrictedControlVolume = true;
 	_globalV = (x1 - x0) * (y1 - y0) * (z1 - z0);

--- a/src/ensemble/ChemicalPotential.cpp
+++ b/src/ensemble/ChemicalPotential.cpp
@@ -285,7 +285,7 @@ bool ChemicalPotential::decideDeletion(double deltaUTilde)
 			return false;
 		}
 		Log::global_log->error() << "No decision is possible." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	float dec = *_remainingDecisions.begin();
 	_remainingDecisions.erase(_remainingDecisions.begin());
@@ -318,7 +318,7 @@ bool ChemicalPotential::decideInsertion(double deltaUTilde)
 			return false;
 		}
 		Log::global_log->error() << "No decision is possible." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	double acc = _globalReducedVolume * exp(_muTilde - deltaUTilde)
 			/ (1.0 + (double) (_globalN));
@@ -376,7 +376,7 @@ void ChemicalPotential::setControlVolume(double x0, double y0, double z0,
 		Log::global_log->error() << "\nInvalid control volume (" << x0 << " / " << y0
 				<< " / " << z0 << ") to (" << x1 << " / " << y1 << " / " << z1
 				<< ")." << std::endl;
-		mardyn_exit(611);
+		MARDYN_EXIT(611);
 	}
 	_restrictedControlVolume = true;
 	_globalV = (x1 - x0) * (y1 - y0) * (z1 - z0);

--- a/src/ensemble/EnsembleBase.cpp
+++ b/src/ensemble/EnsembleBase.cpp
@@ -25,7 +25,7 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 	if (numComponents == 0) {
 		std::ostringstream error_message;
 		error_message << "No components found. Please verify that you have input them correctly." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	_components.resize(numComponents);
 	XMLfile::Query::const_iterator componentIter;
@@ -60,7 +60,7 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			std::ostringstream error_message;
 			error_message << "Unknown mixing rule " << mixingruletype << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		mixingrule->readXML(xmlconfig);
 
@@ -72,7 +72,7 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 			std::ostringstream error_message;
 			error_message << "Mixing: cid=" << cid2+1 << " is larger than number of components ("
 							<< numComponents << ")" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		_mixingrules[cid1][cid2] = mixingrule;
 	}
@@ -120,18 +120,18 @@ void Ensemble::setMixingrule(std::shared_ptr<MixingRuleBase> mixingrule) {
 	if (cid1 == cid2) {
 		std::ostringstream error_message;
 		error_message << "Mixing setMixingrule: cids must not be the same" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	if (std::min(cid1, cid2) < 0) {
 		std::ostringstream error_message;
 		error_message << "Mixing setMixingrule: cids must not be negative" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	if (std::max(cid1, cid2) >= _components.size()) {
 		std::ostringstream error_message;
 		error_message << "Mixing setMixingrule: cids must not exceed number of components ("
 						<< _components.size() << ")" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	
 	_mixingrules[cid1][cid2] = mixingrule;

--- a/src/ensemble/EnsembleBase.cpp
+++ b/src/ensemble/EnsembleBase.cpp
@@ -24,7 +24,7 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "Number of components: " << numComponents << std::endl;
 	if (numComponents == 0) {
 		Log::global_log->fatal() << "No components found. Please verify that you have input them correctly." << std::endl;
-		mardyn_exit(96123);
+		MARDYN_EXIT(96123);
 	}
 	_components.resize(numComponents);
 	XMLfile::Query::const_iterator componentIter;
@@ -58,7 +58,7 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 
 		} else {
 			Log::global_log->error() << "Unknown mixing rule " << mixingruletype << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		mixingrule->readXML(xmlconfig);
 
@@ -69,7 +69,7 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 		if (cid2 >= numComponents) {
 			Log::global_log->error() << "Mixing: cid=" << cid2+1 << " is larger than number of components ("
 									 << numComponents << ")" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		_mixingrules[cid1][cid2] = mixingrule;
 	}
@@ -116,16 +116,16 @@ void Ensemble::setMixingrule(std::shared_ptr<MixingRuleBase> mixingrule) {
 	// Check if cids are valid
 	if (cid1 == cid2) {
 		Log::global_log->error() << "Mixing setMixingrule: cids must not be the same" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	if (std::min(cid1, cid2) < 0) {
 		Log::global_log->error() << "Mixing setMixingrule: cids must not be negative" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	if (std::max(cid1, cid2) >= _components.size()) {
 		Log::global_log->error() << "Mixing setMixingrule: cids must not exceed number of components ("
 								 << _components.size() << ")" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	
 	_mixingrules[cid1][cid2] = mixingrule;

--- a/src/ensemble/EnsembleBase.cpp
+++ b/src/ensemble/EnsembleBase.cpp
@@ -23,8 +23,9 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 	numComponents = query.card();
 	Log::global_log->info() << "Number of components: " << numComponents << std::endl;
 	if (numComponents == 0) {
-		Log::global_log->fatal() << "No components found. Please verify that you have input them correctly." << std::endl;
-		MARDYN_EXIT(96123);
+		std::ostringstream error_message;
+		error_message << "No components found. Please verify that you have input them correctly." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	_components.resize(numComponents);
 	XMLfile::Query::const_iterator componentIter;
@@ -57,8 +58,9 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 			mixingrule = std::make_shared<LorentzBerthelotMixingRule>();
 
 		} else {
-			Log::global_log->error() << "Unknown mixing rule " << mixingruletype << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Unknown mixing rule " << mixingruletype << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		mixingrule->readXML(xmlconfig);
 
@@ -67,9 +69,10 @@ void Ensemble::readXML(XMLfileUnits& xmlconfig) {
 		// Check if cid is larger than number of components
 		// cid starts with 0 and cid2 is always larger than cid1
 		if (cid2 >= numComponents) {
-			Log::global_log->error() << "Mixing: cid=" << cid2+1 << " is larger than number of components ("
-									 << numComponents << ")" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Mixing: cid=" << cid2+1 << " is larger than number of components ("
+							<< numComponents << ")" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		_mixingrules[cid1][cid2] = mixingrule;
 	}
@@ -115,17 +118,20 @@ void Ensemble::setMixingrule(std::shared_ptr<MixingRuleBase> mixingrule) {
 
 	// Check if cids are valid
 	if (cid1 == cid2) {
-		Log::global_log->error() << "Mixing setMixingrule: cids must not be the same" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Mixing setMixingrule: cids must not be the same" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	if (std::min(cid1, cid2) < 0) {
-		Log::global_log->error() << "Mixing setMixingrule: cids must not be negative" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Mixing setMixingrule: cids must not be negative" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	if (std::max(cid1, cid2) >= _components.size()) {
-		Log::global_log->error() << "Mixing setMixingrule: cids must not exceed number of components ("
-								 << _components.size() << ")" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Mixing setMixingrule: cids must not exceed number of components ("
+						<< _components.size() << ")" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	
 	_mixingrules[cid1][cid2] = mixingrule;

--- a/src/ensemble/GrandCanonicalEnsemble.h
+++ b/src/ensemble/GrandCanonicalEnsemble.h
@@ -40,8 +40,9 @@ public:
 
 	// TODO: Implement STUB
 	void readXML(XMLfileUnits& xmlconfig) override {
-		Log::global_log->info() << "[GrandCanonicalEnsemble] readXML not implemented!" << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[GrandCanonicalEnsemble] readXML not implemented!" << std::endl;
+		MARDYN_EXIT(error_message);
 	};
 
 	unsigned long N() override {
@@ -70,8 +71,9 @@ public:
 
 	// TODO: Implement
 	void updateGlobalVariable(ParticleContainer* particleContainer, GlobalVariable variable) override {
-		Log::global_log->info() << "[GrandCanonicalEnsemble] updateGlobalVariable not implemented!" << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[GrandCanonicalEnsemble] updateGlobalVariable not implemented!" << std::endl;
+		MARDYN_EXIT(error_message);
 	};
 
 	/*! Runs steps formerly in initConfigXML in simulation.cpp */

--- a/src/ensemble/GrandCanonicalEnsemble.h
+++ b/src/ensemble/GrandCanonicalEnsemble.h
@@ -41,7 +41,7 @@ public:
 	// TODO: Implement STUB
 	void readXML(XMLfileUnits& xmlconfig) override {
 		Log::global_log->info() << "[GrandCanonicalEnsemble] readXML not implemented!" << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	};
 
 	unsigned long N() override {
@@ -71,7 +71,7 @@ public:
 	// TODO: Implement
 	void updateGlobalVariable(ParticleContainer* particleContainer, GlobalVariable variable) override {
 		Log::global_log->info() << "[GrandCanonicalEnsemble] updateGlobalVariable not implemented!" << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	};
 
 	/*! Runs steps formerly in initConfigXML in simulation.cpp */

--- a/src/ensemble/GrandCanonicalEnsemble.h
+++ b/src/ensemble/GrandCanonicalEnsemble.h
@@ -42,7 +42,7 @@ public:
 	void readXML(XMLfileUnits& xmlconfig) override {
 		std::ostringstream error_message;
 		error_message << "[GrandCanonicalEnsemble] readXML not implemented!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	};
 
 	unsigned long N() override {
@@ -73,7 +73,7 @@ public:
 	void updateGlobalVariable(ParticleContainer* particleContainer, GlobalVariable variable) override {
 		std::ostringstream error_message;
 		error_message << "[GrandCanonicalEnsemble] updateGlobalVariable not implemented!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	};
 
 	/*! Runs steps formerly in initConfigXML in simulation.cpp */

--- a/src/ensemble/PressureGradient.cpp
+++ b/src/ensemble/PressureGradient.cpp
@@ -219,8 +219,9 @@ void PressureGradient::specifyTauPrime(double tauPrime, double dt)
 	if(this->_localRank != 0) return;
 	if(this->_universalConstantAccelerationTimesteps == 0)
 	{
-		Log::global_log->error() << "SEVERE ERROR: unknown UCAT!\n";
-		MARDYN_EXIT(78);
+		std::ostringstream error_message;
+		error_message << "SEVERE ERROR: unknown UCAT!\n";
+		MARDYN_EXIT(error_message);
 	}
 	unsigned int vql = (unsigned int)ceil(tauPrime / (dt*this->_universalConstantAccelerationTimesteps));
 	std::map<unsigned int, unsigned int>::iterator vqlit;

--- a/src/ensemble/PressureGradient.cpp
+++ b/src/ensemble/PressureGradient.cpp
@@ -220,7 +220,7 @@ void PressureGradient::specifyTauPrime(double tauPrime, double dt)
 	if(this->_universalConstantAccelerationTimesteps == 0)
 	{
 		Log::global_log->error() << "SEVERE ERROR: unknown UCAT!\n";
-		mardyn_exit(78);
+		MARDYN_EXIT(78);
 	}
 	unsigned int vql = (unsigned int)ceil(tauPrime / (dt*this->_universalConstantAccelerationTimesteps));
 	std::map<unsigned int, unsigned int>::iterator vqlit;

--- a/src/ensemble/PressureGradient.cpp
+++ b/src/ensemble/PressureGradient.cpp
@@ -221,7 +221,7 @@ void PressureGradient::specifyTauPrime(double tauPrime, double dt)
 	{
 		std::ostringstream error_message;
 		error_message << "SEVERE ERROR: unknown UCAT!\n";
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	unsigned int vql = (unsigned int)ceil(tauPrime / (dt*this->_universalConstantAccelerationTimesteps));
 	std::map<unsigned int, unsigned int>::iterator vqlit;

--- a/src/io/ASCIIReader.cpp
+++ b/src/io/ASCIIReader.cpp
@@ -166,8 +166,9 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 				_phaseSpaceHeaderFileStream >> numljcenters >> numcharges >> numdipoles
 											>> numquadrupoles >> numtersoff;
 				if(numtersoff != 0) {
-					std::ostringstream error_message;					error_message << "tersoff no longer supported."
-										<< std::endl;					MARDYN_EXIT(error_message);
+					std::ostringstream error_message;
+					error_message << "tersoff no longer supported." << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 				double x, y, z, m;
 				for(unsigned int j = 0; j < numljcenters; j++) {
@@ -404,11 +405,11 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 		}
 
 		if(componentid > numcomponents) {
-			std::ostringstream error_message;			error_message << "Molecule id " << id
+			std::ostringstream error_message;
+			error_message << "Molecule id " << id
 								<< " has a component ID greater than the existing number of components: "
-								<< componentid
-								<< ">"
-								<< numcomponents << std::endl;			MARDYN_EXIT(error_message);
+								<< componentid << ">" << numcomponents << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.

--- a/src/io/ASCIIReader.cpp
+++ b/src/io/ASCIIReader.cpp
@@ -57,7 +57,7 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	_phaseSpaceHeaderFileStream >> token;
 	if(token != "mardyn") {
 		Log::global_log->error() << _phaseSpaceHeaderFile << " not a valid mardyn input file." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	std::string inputversion;
@@ -65,12 +65,12 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	// FIXME: remove tag trunk from file specification?
 	if(token != "trunk") {
 		Log::global_log->error() << "Wrong input file specifier (\'" << token << "\' instead of \'trunk\')." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	if(std::stoi(inputversion) < 20080701) {
 		Log::global_log->error() << "Input version too old (" << inputversion << ")" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	Log::global_log->info() << "Reading phase space header from file " << _phaseSpaceHeaderFile << std::endl;
@@ -165,7 +165,7 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 				if(numtersoff != 0) {
 					Log::global_log->error() << "tersoff no longer supported."
 										<< std::endl;
-					mardyn_exit(-1);
+					MARDYN_EXIT(-1);
 				}
 				double x, y, z, m;
 				for(unsigned int j = 0; j < numljcenters; j++) {
@@ -275,7 +275,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 	_phaseSpaceFileStream.open(_phaseSpaceFile.c_str());
 	if(!_phaseSpaceFileStream.is_open()) {
 		Log::global_log->error() << "Could not open phaseSpaceFile " << _phaseSpaceFile << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	Log::global_log->info() << "Reading phase space file " << _phaseSpaceFile << std::endl;
 #ifdef ENABLE_MPI
@@ -301,7 +301,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 	}
 	if((token != "NumberOfMolecules") && (token != "N")) {
 		Log::global_log->error() << "Expected the token 'NumberOfMolecules (N)' instead of '" << token << "'" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	_phaseSpaceFileStream >> nummolecules;
 #ifdef ENABLE_MPI
@@ -328,7 +328,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 		else if(ntypestring == "IRV") ntype = Ndatatype::IRV;
 		else {
 			Log::global_log->error() << "Unknown molecule format '" << ntypestring << "'" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 	} else {
 		_phaseSpaceFileStream.seekg(spos);
@@ -389,7 +389,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 				break;
 			default:
 				Log::global_log->error() << "[ASCIIReader.cpp] Unknown ntype" << std::endl;
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 		}
 		if((x < 0.0 || x >= domain->getGlobalLength(0))
 		   || (y < 0.0 || y >= domain->getGlobalLength(1))
@@ -403,7 +403,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 								<< componentid
 								<< ">"
 								<< numcomponents << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.

--- a/src/io/ASCIIReader.cpp
+++ b/src/io/ASCIIReader.cpp
@@ -56,21 +56,24 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	_phaseSpaceHeaderFileStream.open(_phaseSpaceHeaderFile.c_str());
 	_phaseSpaceHeaderFileStream >> token;
 	if(token != "mardyn") {
-		Log::global_log->error() << _phaseSpaceHeaderFile << " not a valid mardyn input file." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << _phaseSpaceHeaderFile << " not a valid mardyn input file." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	std::string inputversion;
 	_phaseSpaceHeaderFileStream >> token >> inputversion;
 	// FIXME: remove tag trunk from file specification?
 	if(token != "trunk") {
-		Log::global_log->error() << "Wrong input file specifier (\'" << token << "\' instead of \'trunk\')." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Wrong input file specifier (\'" << token << "\' instead of \'trunk\')." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	if(std::stoi(inputversion) < 20080701) {
-		Log::global_log->error() << "Input version too old (" << inputversion << ")" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Input version too old (" << inputversion << ")" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	Log::global_log->info() << "Reading phase space header from file " << _phaseSpaceHeaderFile << std::endl;
@@ -163,9 +166,8 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 				_phaseSpaceHeaderFileStream >> numljcenters >> numcharges >> numdipoles
 											>> numquadrupoles >> numtersoff;
 				if(numtersoff != 0) {
-					Log::global_log->error() << "tersoff no longer supported."
-										<< std::endl;
-					MARDYN_EXIT(-1);
+					std::ostringstream error_message;					error_message << "tersoff no longer supported."
+										<< std::endl;					MARDYN_EXIT(error_message);
 				}
 				double x, y, z, m;
 				for(unsigned int j = 0; j < numljcenters; j++) {
@@ -274,8 +276,9 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 	Log::global_log->info() << "Opening phase space file " << _phaseSpaceFile << std::endl;
 	_phaseSpaceFileStream.open(_phaseSpaceFile.c_str());
 	if(!_phaseSpaceFileStream.is_open()) {
-		Log::global_log->error() << "Could not open phaseSpaceFile " << _phaseSpaceFile << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Could not open phaseSpaceFile " << _phaseSpaceFile << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info() << "Reading phase space file " << _phaseSpaceFile << std::endl;
 #ifdef ENABLE_MPI
@@ -300,8 +303,9 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 		_phaseSpaceFileStream >> token;
 	}
 	if((token != "NumberOfMolecules") && (token != "N")) {
-		Log::global_log->error() << "Expected the token 'NumberOfMolecules (N)' instead of '" << token << "'" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Expected the token 'NumberOfMolecules (N)' instead of '" << token << "'" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	_phaseSpaceFileStream >> nummolecules;
 #ifdef ENABLE_MPI
@@ -327,8 +331,9 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 		else if(ntypestring == "ICRV") ntype = Ndatatype::ICRV;
 		else if(ntypestring == "IRV") ntype = Ndatatype::IRV;
 		else {
-			Log::global_log->error() << "Unknown molecule format '" << ntypestring << "'" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Unknown molecule format '" << ntypestring << "'" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	} else {
 		_phaseSpaceFileStream.seekg(spos);
@@ -388,8 +393,9 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 				componentid = 1;
 				break;
 			default:
-				Log::global_log->error() << "[ASCIIReader.cpp] Unknown ntype" << std::endl;
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;
+				error_message << "[ASCIIReader.cpp] Unknown ntype" << std::endl;
+				MARDYN_EXIT(error_message);
 		}
 		if((x < 0.0 || x >= domain->getGlobalLength(0))
 		   || (y < 0.0 || y >= domain->getGlobalLength(1))
@@ -398,12 +404,11 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 		}
 
 		if(componentid > numcomponents) {
-			Log::global_log->error() << "Molecule id " << id
+			std::ostringstream error_message;			error_message << "Molecule id " << id
 								<< " has a component ID greater than the existing number of components: "
 								<< componentid
 								<< ">"
-								<< numcomponents << std::endl;
-			MARDYN_EXIT(1);
+								<< numcomponents << std::endl;			MARDYN_EXIT(error_message);
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.

--- a/src/io/ASCIIReader.cpp
+++ b/src/io/ASCIIReader.cpp
@@ -58,7 +58,7 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	if(token != "mardyn") {
 		std::ostringstream error_message;
 		error_message << _phaseSpaceHeaderFile << " not a valid mardyn input file." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	std::string inputversion;
@@ -67,13 +67,13 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	if(token != "trunk") {
 		std::ostringstream error_message;
 		error_message << "Wrong input file specifier (\'" << token << "\' instead of \'trunk\')." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if(std::stoi(inputversion) < 20080701) {
 		std::ostringstream error_message;
 		error_message << "Input version too old (" << inputversion << ")" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	Log::global_log->info() << "Reading phase space header from file " << _phaseSpaceHeaderFile << std::endl;
@@ -168,7 +168,7 @@ void ASCIIReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 				if(numtersoff != 0) {
 					std::ostringstream error_message;
 					error_message << "tersoff no longer supported." << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 				double x, y, z, m;
 				for(unsigned int j = 0; j < numljcenters; j++) {
@@ -279,7 +279,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 	if(!_phaseSpaceFileStream.is_open()) {
 		std::ostringstream error_message;
 		error_message << "Could not open phaseSpaceFile " << _phaseSpaceFile << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	Log::global_log->info() << "Reading phase space file " << _phaseSpaceFile << std::endl;
 #ifdef ENABLE_MPI
@@ -306,7 +306,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 	if((token != "NumberOfMolecules") && (token != "N")) {
 		std::ostringstream error_message;
 		error_message << "Expected the token 'NumberOfMolecules (N)' instead of '" << token << "'" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	_phaseSpaceFileStream >> nummolecules;
 #ifdef ENABLE_MPI
@@ -334,7 +334,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 		else {
 			std::ostringstream error_message;
 			error_message << "Unknown molecule format '" << ntypestring << "'" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	} else {
 		_phaseSpaceFileStream.seekg(spos);
@@ -396,7 +396,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 			default:
 				std::ostringstream error_message;
 				error_message << "[ASCIIReader.cpp] Unknown ntype" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 		}
 		if((x < 0.0 || x >= domain->getGlobalLength(0))
 		   || (y < 0.0 || y >= domain->getGlobalLength(1))
@@ -409,7 +409,7 @@ ASCIIReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domain
 			error_message << "Molecule id " << id
 								<< " has a component ID greater than the existing number of components: "
 								<< componentid << ">" << numcomponents << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.

--- a/src/io/Adios2Reader.cpp
+++ b/src/io/Adios2Reader.cpp
@@ -536,19 +536,19 @@ void Adios2Reader::initAdios2() {
                 << "[Adios2Reader] Invalid argument exception, STOPPING PROGRAM from rank"
                 << domainDecomp.getRank()
                 << ": " << e.what() << std::endl;
-	mardyn_exit(1);
+	MARDYN_EXIT(1);
     } catch (std::ios_base::failure& e) {
         Log::global_log->fatal()
                 << "[Adios2Reader] IO System base failure exception, STOPPING PROGRAM from rank "
                 << domainDecomp.getRank()
                 << ": " << e.what() << std::endl;
-	mardyn_exit(1);
+	MARDYN_EXIT(1);
     } catch (std::exception& e) {
         Log::global_log->fatal()
                 << "[Adios2Reader] Exception, STOPPING PROGRAM from rank"
                 << domainDecomp.getRank()
                 << ": " << e.what() << std::endl;
-	mardyn_exit(1);
+	MARDYN_EXIT(1);
     }
     Log::global_log->info() << "[Adios2Reader] Init complete." << std::endl;
 };

--- a/src/io/Adios2Reader.cpp
+++ b/src/io/Adios2Reader.cpp
@@ -90,7 +90,7 @@ unsigned long Adios2Reader::readPhaseSpace(ParticleContainer* particleContainer,
 	} else {
 		std::ostringstream error_message;
 		error_message << "[Adios2Reader] Unknown _mode '" << _mode << "'" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	_simulation.setSimulationTime(_simtime);
@@ -537,17 +537,17 @@ void Adios2Reader::initAdios2() {
 		std::ostringstream error_message;
         error_message << "[Adios2Reader] Invalid argument exception, STOPPING PROGRAM from rank"
                 << domainDecomp.getRank() << ": " << e.what() << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
     } catch (std::ios_base::failure& e) {
 		std::ostringstream error_message;
         error_message << "[Adios2Reader] IO System base failure exception, STOPPING PROGRAM from rank "
                 << domainDecomp.getRank() << ": " << e.what() << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
     } catch (std::exception& e) {
 		std::ostringstream error_message;
         error_message << "[Adios2Reader] Exception, STOPPING PROGRAM from rank"
                 << domainDecomp.getRank() << ": " << e.what() << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
     }
     Log::global_log->info() << "[Adios2Reader] Init complete." << std::endl;
 };

--- a/src/io/Adios2Reader.cpp
+++ b/src/io/Adios2Reader.cpp
@@ -88,7 +88,9 @@ unsigned long Adios2Reader::readPhaseSpace(ParticleContainer* particleContainer,
 	} else if (_mode == "parallelRead") {
 		parallelRead(particleContainer, domain, domainDecomp);
 	} else {
-		Log::global_log->error() << "[Adios2Reader] Unknown _mode '" << _mode << "'" << std::endl;
+		std::ostringstream error_message;
+		error_message << "[Adios2Reader] Unknown _mode '" << _mode << "'" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	_simulation.setSimulationTime(_simtime);
@@ -532,23 +534,20 @@ void Adios2Reader::initAdios2() {
         }
   }
     catch (std::invalid_argument& e) {
-        Log::global_log->fatal()
-                << "[Adios2Reader] Invalid argument exception, STOPPING PROGRAM from rank"
-                << domainDecomp.getRank()
-                << ": " << e.what() << std::endl;
-	MARDYN_EXIT(1);
+		std::ostringstream error_message;
+        error_message << "[Adios2Reader] Invalid argument exception, STOPPING PROGRAM from rank"
+                << domainDecomp.getRank() << ": " << e.what() << std::endl;
+		MARDYN_EXIT(error_message);
     } catch (std::ios_base::failure& e) {
-        Log::global_log->fatal()
-                << "[Adios2Reader] IO System base failure exception, STOPPING PROGRAM from rank "
-                << domainDecomp.getRank()
-                << ": " << e.what() << std::endl;
-	MARDYN_EXIT(1);
+		std::ostringstream error_message;
+        error_message << "[Adios2Reader] IO System base failure exception, STOPPING PROGRAM from rank "
+                << domainDecomp.getRank() << ": " << e.what() << std::endl;
+		MARDYN_EXIT(error_message);
     } catch (std::exception& e) {
-        Log::global_log->fatal()
-                << "[Adios2Reader] Exception, STOPPING PROGRAM from rank"
-                << domainDecomp.getRank()
-                << ": " << e.what() << std::endl;
-	MARDYN_EXIT(1);
+		std::ostringstream error_message;
+        error_message << "[Adios2Reader] Exception, STOPPING PROGRAM from rank"
+                << domainDecomp.getRank() << ": " << e.what() << std::endl;
+		MARDYN_EXIT(error_message);
     }
     Log::global_log->info() << "[Adios2Reader] Init complete." << std::endl;
 };

--- a/src/io/Adios2Writer.cpp
+++ b/src/io/Adios2Writer.cpp
@@ -267,17 +267,17 @@ void Adios2Writer::initAdios2() {
 		std::ostringstream error_message;
 		error_message << "Invalid argument exception:" << std::endl;
 		error_message << e.what() << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	} catch (std::ios_base::failure& e) {
 		std::ostringstream error_message;
 		error_message << "IO System base failure exception: " << std::endl;
 		error_message << e.what() << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	} catch (std::exception& e) {
 		std::ostringstream error_message;
 		error_message << "Exception: " << std::endl;
 		error_message << e.what() << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	Log::global_log->info() << "[Adios2Writer] Init complete." << std::endl;
 }
@@ -425,17 +425,17 @@ void Adios2Writer::endStep(ParticleContainer* particleContainer, DomainDecompBas
 		std::ostringstream error_message;
 		error_message << "[Adios2Writer] Invalid argument exception:" << std::endl;
 		error_message << e.what();
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	} catch (std::ios_base::failure& e) {
 		std::ostringstream error_message;
 		error_message << "[Adios2Writer] IO System base failure exception:" << std::endl;
 		error_message << e.what();
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	} catch (std::exception& e) {
 		std::ostringstream error_message;
 		error_message << "[Adios2Writer] Exception:" << std::endl;
 		error_message << e.what();
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	Log::global_log->info() << "[Adios2Writer] endStep." << std::endl;
 }

--- a/src/io/Adios2Writer.cpp
+++ b/src/io/Adios2Writer.cpp
@@ -265,14 +265,14 @@ void Adios2Writer::initAdios2() {
 		resetContainers();
 	} catch (std::invalid_argument& e) {
 		Log::global_log->fatal() << "Invalid argument exception, STOPPING PROGRAM from rank: " << e.what() << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	} catch (std::ios_base::failure& e) {
 		Log::global_log->fatal() << "IO System base failure exception, STOPPING PROGRAM from rank: " << e.what() << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	} catch (std::exception& e) {
 		Log::global_log->fatal() << "Exception, STOPPING PROGRAM from rank: " << e.what()
 							<< std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	Log::global_log->info() << "[Adios2Writer] Init complete." << std::endl;
 }

--- a/src/io/Adios2Writer.cpp
+++ b/src/io/Adios2Writer.cpp
@@ -264,15 +264,20 @@ void Adios2Writer::initAdios2() {
 		}
 		resetContainers();
 	} catch (std::invalid_argument& e) {
-		Log::global_log->fatal() << "Invalid argument exception, STOPPING PROGRAM from rank: " << e.what() << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Invalid argument exception:" << std::endl;
+		error_message << e.what() << std::endl;
+		MARDYN_EXIT(error_message);
 	} catch (std::ios_base::failure& e) {
-		Log::global_log->fatal() << "IO System base failure exception, STOPPING PROGRAM from rank: " << e.what() << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "IO System base failure exception: " << std::endl;
+		error_message << e.what() << std::endl;
+		MARDYN_EXIT(error_message);
 	} catch (std::exception& e) {
-		Log::global_log->fatal() << "Exception, STOPPING PROGRAM from rank: " << e.what()
-							<< std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Exception: " << std::endl;
+		error_message << e.what() << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info() << "[Adios2Writer] Init complete." << std::endl;
 }
@@ -417,14 +422,20 @@ void Adios2Writer::endStep(ParticleContainer* particleContainer, DomainDecompBas
 
 		clearContainers();
 	} catch (std::invalid_argument& e) {
-		Log::global_log->error() << "[Adios2Writer] Invalid argument exception, STOPPING PROGRAM";
-		Log::global_log->error() << e.what();
+		std::ostringstream error_message;
+		error_message << "[Adios2Writer] Invalid argument exception:" << std::endl;
+		error_message << e.what();
+		MARDYN_EXIT(error_message);
 	} catch (std::ios_base::failure& e) {
-		Log::global_log->error() << "[Adios2Writer] IO System base failure exception, STOPPING PROGRAM";
-		Log::global_log->error() << e.what();
+		std::ostringstream error_message;
+		error_message << "[Adios2Writer] IO System base failure exception:" << std::endl;
+		error_message << e.what();
+		MARDYN_EXIT(error_message);
 	} catch (std::exception& e) {
-		Log::global_log->error() << "[Adios2Writer] Exception, STOPPING PROGRAM";
-		Log::global_log->error() << e.what();
+		std::ostringstream error_message;
+		error_message << "[Adios2Writer] Exception:" << std::endl;
+		error_message << e.what();
+		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info() << "[Adios2Writer] endStep." << std::endl;
 }

--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -79,7 +79,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 		std::ostringstream error_message;
 		error_message << "Could not find root node /mardyn in XML input file." << std::endl;
 		error_message << "Not a valid MarDyn XML input file." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	bool bInputOk = true;
@@ -98,7 +98,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	if(not bInputOk) {
 		std::ostringstream error_message;
 		error_message << "Content of file: '" << _phaseSpaceHeaderFile << "' corrupted! Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -110,7 +110,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	else {
 		std::ostringstream error_message;
 		error_message << "Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	// Set parameters of Domain and Simulation class
@@ -138,7 +138,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 		std::ostringstream error_message;
 		error_message << "Could not open phaseSpaceFile "
 							<< _phaseSpaceFile << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	Log::global_log->info() << "Reading phase space file " << _phaseSpaceFile
 					   << std::endl;
@@ -183,7 +183,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 			std::ostringstream error_message;
 			error_message << "End of file was hit before all " << numMolecules << " expected molecules were read."
 				<< std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
         }
 		_phaseSpaceFileStream.read(reinterpret_cast<char*> (&id), 8);
 		switch (_nMoleculeFormat) {
@@ -227,7 +227,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 				std::ostringstream error_message;
 				error_message << "BinaryReader: Unknown phase space format: " << _nMoleculeFormat << std::endl
 									<< "Aborting simulation." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 		}
 		if ((x < 0.0 || x >= domain->getGlobalLength(0)) || (y < 0.0 || y >= domain->getGlobalLength(1)) ||
 			(z < 0.0 || z >= domain->getGlobalLength(2))) {
@@ -241,12 +241,12 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 								<< componentid
 								<< ">"
 								<< numcomponents << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		if(componentid == 0) {
 			std::ostringstream error_message;
 			error_message << "Molecule id " << id << " has componentID == 0." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.

--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -76,9 +76,10 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	XMLfileUnits inp(_phaseSpaceHeaderFile);
 
 	if(not inp.changecurrentnode("/mardyn")) {
-		Log::global_log->error() << "Could not find root node /mardyn in XML input file." << std::endl;
-		Log::global_log->fatal() << "Not a valid MarDyn XML input file." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Could not find root node /mardyn in XML input file." << std::endl;
+		error_message << "Not a valid MarDyn XML input file." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	bool bInputOk = true;
@@ -95,8 +96,9 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	bInputOk = bInputOk && inp.getNodeValue("format@type", strMoleculeFormat);
 
 	if(not bInputOk) {
-		Log::global_log->error() << "Content of file: '" << _phaseSpaceHeaderFile << "' corrupted! Program exit ..." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Content of file: '" << _phaseSpaceHeaderFile << "' corrupted! Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -106,8 +108,9 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	else if("ICRV" == strMoleculeFormat)
 		_nMoleculeFormat = ICRV;
 	else {
-		Log::global_log->error() << "Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	// Set parameters of Domain and Simulation class
@@ -132,9 +135,8 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 	_phaseSpaceFileStream.open(_phaseSpaceFile.c_str(),
 							   std::ios::binary | std::ios::in);
 	if(!_phaseSpaceFileStream.is_open()) {
-		Log::global_log->error() << "Could not open phaseSpaceFile "
-							<< _phaseSpaceFile << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;		error_message << "Could not open phaseSpaceFile "
+							<< _phaseSpaceFile << std::endl;		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info() << "Reading phase space file " << _phaseSpaceFile
 					   << std::endl;
@@ -176,9 +178,8 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 		if (domainDecomp->getRank() == 0) { // Rank 0 only
 #endif
 		if(_phaseSpaceFileStream.eof()) {
-			Log::global_log->error() << "End of file was hit before all " << numMolecules << " expected molecules were read."
-				<< std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;			error_message << "End of file was hit before all " << numMolecules << " expected molecules were read."
+				<< std::endl;			MARDYN_EXIT(error_message);
         }
 		_phaseSpaceFileStream.read(reinterpret_cast<char*> (&id), 8);
 		switch (_nMoleculeFormat) {
@@ -219,9 +220,10 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 				_phaseSpaceFileStream.read(reinterpret_cast<char*> (&vz), 8);
 				break;
 			default:
-				Log::global_log->error() << "BinaryReader: Unknown phase space format: " << _nMoleculeFormat << std::endl
+				std::ostringstream error_message;
+				error_message << "BinaryReader: Unknown phase space format: " << _nMoleculeFormat << std::endl
 									<< "Aborting simulation." << std::endl;
-				MARDYN_EXIT(12);
+				MARDYN_EXIT(error_message);
 		}
 		if ((x < 0.0 || x >= domain->getGlobalLength(0)) || (y < 0.0 || y >= domain->getGlobalLength(1)) ||
 			(z < 0.0 || z >= domain->getGlobalLength(2))) {
@@ -229,17 +231,18 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 		}
 
 		if(componentid > numcomponents) {
-			Log::global_log->error() << "Molecule id " << id
+			std::ostringstream error_message;
+			error_message << "Molecule id " << id
 								<< " has a component ID greater than the existing number of components: "
 								<< componentid
 								<< ">"
 								<< numcomponents << std::endl;
-			MARDYN_EXIT(1);
+			MARDYN_EXIT(error_message);
 		}
 		if(componentid == 0) {
-			Log::global_log->error() << "Molecule id " << id
-								<< " has componentID == 0." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Molecule id " << id << " has componentID == 0." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.

--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -78,7 +78,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	if(not inp.changecurrentnode("/mardyn")) {
 		Log::global_log->error() << "Could not find root node /mardyn in XML input file." << std::endl;
 		Log::global_log->fatal() << "Not a valid MarDyn XML input file." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	bool bInputOk = true;
@@ -96,7 +96,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 
 	if(not bInputOk) {
 		Log::global_log->error() << "Content of file: '" << _phaseSpaceHeaderFile << "' corrupted! Program exit ..." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -107,7 +107,7 @@ void BinaryReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 		_nMoleculeFormat = ICRV;
 	else {
 		Log::global_log->error() << "Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	// Set parameters of Domain and Simulation class
@@ -134,7 +134,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 	if(!_phaseSpaceFileStream.is_open()) {
 		Log::global_log->error() << "Could not open phaseSpaceFile "
 							<< _phaseSpaceFile << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	Log::global_log->info() << "Reading phase space file " << _phaseSpaceFile
 					   << std::endl;
@@ -178,7 +178,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 		if(_phaseSpaceFileStream.eof()) {
 			Log::global_log->error() << "End of file was hit before all " << numMolecules << " expected molecules were read."
 				<< std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
         }
 		_phaseSpaceFileStream.read(reinterpret_cast<char*> (&id), 8);
 		switch (_nMoleculeFormat) {
@@ -221,7 +221,7 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 			default:
 				Log::global_log->error() << "BinaryReader: Unknown phase space format: " << _nMoleculeFormat << std::endl
 									<< "Aborting simulation." << std::endl;
-				mardyn_exit(12);
+				MARDYN_EXIT(12);
 		}
 		if ((x < 0.0 || x >= domain->getGlobalLength(0)) || (y < 0.0 || y >= domain->getGlobalLength(1)) ||
 			(z < 0.0 || z >= domain->getGlobalLength(2))) {
@@ -234,12 +234,12 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 								<< componentid
 								<< ">"
 								<< numcomponents << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		if(componentid == 0) {
 			Log::global_log->error() << "Molecule id " << id
 								<< " has componentID == 0." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.

--- a/src/io/BinaryReader.cpp
+++ b/src/io/BinaryReader.cpp
@@ -135,8 +135,10 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 	_phaseSpaceFileStream.open(_phaseSpaceFile.c_str(),
 							   std::ios::binary | std::ios::in);
 	if(!_phaseSpaceFileStream.is_open()) {
-		std::ostringstream error_message;		error_message << "Could not open phaseSpaceFile "
-							<< _phaseSpaceFile << std::endl;		MARDYN_EXIT(error_message);
+		std::ostringstream error_message;
+		error_message << "Could not open phaseSpaceFile "
+							<< _phaseSpaceFile << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info() << "Reading phase space file " << _phaseSpaceFile
 					   << std::endl;
@@ -178,8 +180,10 @@ BinaryReader::readPhaseSpace(ParticleContainer* particleContainer, Domain* domai
 		if (domainDecomp->getRank() == 0) { // Rank 0 only
 #endif
 		if(_phaseSpaceFileStream.eof()) {
-			std::ostringstream error_message;			error_message << "End of file was hit before all " << numMolecules << " expected molecules were read."
-				<< std::endl;			MARDYN_EXIT(error_message);
+			std::ostringstream error_message;
+			error_message << "End of file was hit before all " << numMolecules << " expected molecules were read."
+				<< std::endl;
+			MARDYN_EXIT(error_message);
         }
 		_phaseSpaceFileStream.read(reinterpret_cast<char*> (&id), 8);
 		switch (_nMoleculeFormat) {

--- a/src/io/CavityWriter.cpp
+++ b/src/io/CavityWriter.cpp
@@ -39,32 +39,32 @@ void CavityWriter::readXML(XMLfileUnits &xmlconfig) {
     if (_maxNeighbors <= 0) {
         std::ostringstream error_message;
         error_message << "[CavityWriter] Invalid number of maxNeighbors: " << _maxNeighbors << std::endl;
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
 
     xmlconfig.getNodeValue("radius", _radius);
     if (_radius <= 0.0f) {
         std::ostringstream error_message;
         error_message << "[CavityWriter] Invalid size of radius: " << _radius << std::endl;
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
     xmlconfig.getNodeValue("Nx", _Nx);
     if (_Nx <= 0) {
         std::ostringstream error_message;
         error_message << "[CavityWriter] Invalid number of cells Nx: " << _Nx << std::endl;
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
     xmlconfig.getNodeValue("Ny", _Ny);
     if (_Ny <= 0) {
         std::ostringstream error_message;
         error_message << "[CavityWriter] Invalid number of cells Ny: " << _Ny << std::endl;
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
     xmlconfig.getNodeValue("Nz", _Nz);
     if (_Nz <= 0) {
         std::ostringstream error_message;
         error_message << "[CavityWriter] Invalid number of cells Nz: " << _Nz << std::endl;
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
 
     // Default Control Volume is entire Domain
@@ -82,13 +82,13 @@ void CavityWriter::readXML(XMLfileUnits &xmlconfig) {
         if (_controlVolume[d * 2] > _controlVolume[d * 2 + 1]) {
             std::ostringstream error_message;
             error_message << "[CavityWriter] Lower Bound of Control Volume may not be larger than upper bound." << std::endl;
-            MARDYN_EXIT(error_message);
+            MARDYN_EXIT(error_message.str());
         }
         if (_controlVolume[d * 2] < 0 ||
             _controlVolume[d * 2 + 1] > global_simulation->getDomain()->getGlobalLength(d)) {
             std::ostringstream error_message;
             error_message << "[CavityWriter] Control volume bounds may not be outside of domain boundaries." << std::endl;
-            MARDYN_EXIT(error_message);
+            MARDYN_EXIT(error_message.str());
         }
     }
 

--- a/src/io/CavityWriter.cpp
+++ b/src/io/CavityWriter.cpp
@@ -38,28 +38,28 @@ void CavityWriter::readXML(XMLfileUnits &xmlconfig) {
     xmlconfig.getNodeValue("maxNeighbours", _maxNeighbors);
     if (_maxNeighbors <= 0) {
         Log::global_log->error() << "[CavityWriter] Invalid number of maxNeighbors: " << _maxNeighbors << std::endl;
-        mardyn_exit(999);
+        MARDYN_EXIT(999);
     }
 
     xmlconfig.getNodeValue("radius", _radius);
     if (_radius <= 0.0f) {
         Log::global_log->error() << "[CavityWriter] Invalid size of radius: " << _radius << std::endl;
-        mardyn_exit(999);
+        MARDYN_EXIT(999);
     }
     xmlconfig.getNodeValue("Nx", _Nx);
     if (_Nx <= 0) {
         Log::global_log->error() << "[CavityWriter] Invalid number of cells Nx: " << _Nx << std::endl;
-        mardyn_exit(999);
+        MARDYN_EXIT(999);
     }
     xmlconfig.getNodeValue("Ny", _Ny);
     if (_Ny <= 0) {
         Log::global_log->error() << "[CavityWriter] Invalid number of cells Ny: " << _Ny << std::endl;
-        mardyn_exit(999);
+        MARDYN_EXIT(999);
     }
     xmlconfig.getNodeValue("Nz", _Nz);
     if (_Nz <= 0) {
         Log::global_log->error() << "[CavityWriter] Invalid number of cells Nz: " << _Nz << std::endl;
-        mardyn_exit(999);
+        MARDYN_EXIT(999);
     }
 
     // Default Control Volume is entire Domain
@@ -77,13 +77,13 @@ void CavityWriter::readXML(XMLfileUnits &xmlconfig) {
         if (_controlVolume[d * 2] > _controlVolume[d * 2 + 1]) {
             Log::global_log->error() << "[CavityWriter] Lower Bound of Control Volume may not be larger than upper bound. "
                                 << std::endl;
-            mardyn_exit(999);
+            MARDYN_EXIT(999);
         }
         if (_controlVolume[d * 2] < 0 ||
             _controlVolume[d * 2 + 1] > global_simulation->getDomain()->getGlobalLength(d)) {
             Log::global_log->error() << "[CavityWriter] Control volume bounds may not be outside of domain boundaries. "
                                 << std::endl;
-            mardyn_exit(999);
+            MARDYN_EXIT(999);
         }
     }
 

--- a/src/io/CavityWriter.cpp
+++ b/src/io/CavityWriter.cpp
@@ -80,13 +80,15 @@ void CavityWriter::readXML(XMLfileUnits &xmlconfig) {
     xmlconfig.getNodeValue("ControlVolume/z1", _controlVolume[5]);
     for (int d = 0; d < 3; d++) {
         if (_controlVolume[d * 2] > _controlVolume[d * 2 + 1]) {
-            std::ostringstream error_message;            error_message << "[CavityWriter] Lower Bound of Control Volume may not be larger than upper bound. "
-                                << std::endl;            MARDYN_EXIT(error_message);
+            std::ostringstream error_message;
+            error_message << "[CavityWriter] Lower Bound of Control Volume may not be larger than upper bound." << std::endl;
+            MARDYN_EXIT(error_message);
         }
         if (_controlVolume[d * 2] < 0 ||
             _controlVolume[d * 2 + 1] > global_simulation->getDomain()->getGlobalLength(d)) {
-            std::ostringstream error_message;            error_message << "[CavityWriter] Control volume bounds may not be outside of domain boundaries. "
-                                << std::endl;            MARDYN_EXIT(error_message);
+            std::ostringstream error_message;
+            error_message << "[CavityWriter] Control volume bounds may not be outside of domain boundaries." << std::endl;
+            MARDYN_EXIT(error_message);
         }
     }
 

--- a/src/io/CavityWriter.cpp
+++ b/src/io/CavityWriter.cpp
@@ -37,29 +37,34 @@ void CavityWriter::readXML(XMLfileUnits &xmlconfig) {
 
     xmlconfig.getNodeValue("maxNeighbours", _maxNeighbors);
     if (_maxNeighbors <= 0) {
-        Log::global_log->error() << "[CavityWriter] Invalid number of maxNeighbors: " << _maxNeighbors << std::endl;
-        MARDYN_EXIT(999);
+        std::ostringstream error_message;
+        error_message << "[CavityWriter] Invalid number of maxNeighbors: " << _maxNeighbors << std::endl;
+        MARDYN_EXIT(error_message);
     }
 
     xmlconfig.getNodeValue("radius", _radius);
     if (_radius <= 0.0f) {
-        Log::global_log->error() << "[CavityWriter] Invalid size of radius: " << _radius << std::endl;
-        MARDYN_EXIT(999);
+        std::ostringstream error_message;
+        error_message << "[CavityWriter] Invalid size of radius: " << _radius << std::endl;
+        MARDYN_EXIT(error_message);
     }
     xmlconfig.getNodeValue("Nx", _Nx);
     if (_Nx <= 0) {
-        Log::global_log->error() << "[CavityWriter] Invalid number of cells Nx: " << _Nx << std::endl;
-        MARDYN_EXIT(999);
+        std::ostringstream error_message;
+        error_message << "[CavityWriter] Invalid number of cells Nx: " << _Nx << std::endl;
+        MARDYN_EXIT(error_message);
     }
     xmlconfig.getNodeValue("Ny", _Ny);
     if (_Ny <= 0) {
-        Log::global_log->error() << "[CavityWriter] Invalid number of cells Ny: " << _Ny << std::endl;
-        MARDYN_EXIT(999);
+        std::ostringstream error_message;
+        error_message << "[CavityWriter] Invalid number of cells Ny: " << _Ny << std::endl;
+        MARDYN_EXIT(error_message);
     }
     xmlconfig.getNodeValue("Nz", _Nz);
     if (_Nz <= 0) {
-        Log::global_log->error() << "[CavityWriter] Invalid number of cells Nz: " << _Nz << std::endl;
-        MARDYN_EXIT(999);
+        std::ostringstream error_message;
+        error_message << "[CavityWriter] Invalid number of cells Nz: " << _Nz << std::endl;
+        MARDYN_EXIT(error_message);
     }
 
     // Default Control Volume is entire Domain
@@ -75,15 +80,13 @@ void CavityWriter::readXML(XMLfileUnits &xmlconfig) {
     xmlconfig.getNodeValue("ControlVolume/z1", _controlVolume[5]);
     for (int d = 0; d < 3; d++) {
         if (_controlVolume[d * 2] > _controlVolume[d * 2 + 1]) {
-            Log::global_log->error() << "[CavityWriter] Lower Bound of Control Volume may not be larger than upper bound. "
-                                << std::endl;
-            MARDYN_EXIT(999);
+            std::ostringstream error_message;            error_message << "[CavityWriter] Lower Bound of Control Volume may not be larger than upper bound. "
+                                << std::endl;            MARDYN_EXIT(error_message);
         }
         if (_controlVolume[d * 2] < 0 ||
             _controlVolume[d * 2 + 1] > global_simulation->getDomain()->getGlobalLength(d)) {
-            Log::global_log->error() << "[CavityWriter] Control volume bounds may not be outside of domain boundaries. "
-                                << std::endl;
-            MARDYN_EXIT(999);
+            std::ostringstream error_message;            error_message << "[CavityWriter] Control volume bounds may not be outside of domain boundaries. "
+                                << std::endl;            MARDYN_EXIT(error_message);
         }
     }
 

--- a/src/io/CheckpointWriter.cpp
+++ b/src/io/CheckpointWriter.cpp
@@ -19,8 +19,9 @@ void CheckpointWriter::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "Write frequency: " << _writeFrequency << std::endl;
 
 	if(_writeFrequency == 0) {
-		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	std::string checkpointType = "unknown";
@@ -32,8 +33,9 @@ void CheckpointWriter::readXML(XMLfileUnits& xmlconfig) {
 		_useBinaryFormat = true;
 	}
 	else {
-		Log::global_log->error() << "Unknown CheckpointWriter type '" << checkpointType << "', expected: ASCII|binary." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "Unknown CheckpointWriter type '" << checkpointType << "', expected: ASCII|binary." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	_outputPrefix = "mardyn";

--- a/src/io/CheckpointWriter.cpp
+++ b/src/io/CheckpointWriter.cpp
@@ -20,7 +20,7 @@ void CheckpointWriter::readXML(XMLfileUnits& xmlconfig) {
 
 	if(_writeFrequency == 0) {
 		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	std::string checkpointType = "unknown";
@@ -33,7 +33,7 @@ void CheckpointWriter::readXML(XMLfileUnits& xmlconfig) {
 	}
 	else {
 		Log::global_log->error() << "Unknown CheckpointWriter type '" << checkpointType << "', expected: ASCII|binary." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	_outputPrefix = "mardyn";

--- a/src/io/CheckpointWriter.cpp
+++ b/src/io/CheckpointWriter.cpp
@@ -21,7 +21,7 @@ void CheckpointWriter::readXML(XMLfileUnits& xmlconfig) {
 	if(_writeFrequency == 0) {
 		std::ostringstream error_message;
 		error_message << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	std::string checkpointType = "unknown";
@@ -35,7 +35,7 @@ void CheckpointWriter::readXML(XMLfileUnits& xmlconfig) {
 	else {
 		std::ostringstream error_message;
 		error_message << "Unknown CheckpointWriter type '" << checkpointType << "', expected: ASCII|binary." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	_outputPrefix = "mardyn";

--- a/src/io/CommunicationPartnerWriter.cpp
+++ b/src/io/CommunicationPartnerWriter.cpp
@@ -18,7 +18,7 @@ void CommunicationPartnerWriter::readXML(XMLfileUnits& xmlconfig) {
 
 	if(_writeFrequency == 0) {
 		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	std::string HaloParticleType = "unknown";

--- a/src/io/CommunicationPartnerWriter.cpp
+++ b/src/io/CommunicationPartnerWriter.cpp
@@ -17,8 +17,9 @@ void CommunicationPartnerWriter::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "Write frequency: " << _writeFrequency << std::endl;
 
 	if(_writeFrequency == 0) {
-		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	std::string HaloParticleType = "unknown";

--- a/src/io/CommunicationPartnerWriter.cpp
+++ b/src/io/CommunicationPartnerWriter.cpp
@@ -19,7 +19,7 @@ void CommunicationPartnerWriter::readXML(XMLfileUnits& xmlconfig) {
 	if(_writeFrequency == 0) {
 		std::ostringstream error_message;
 		error_message << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	std::string HaloParticleType = "unknown";

--- a/src/io/CubicGridGeneratorInternal.cpp
+++ b/src/io/CubicGridGeneratorInternal.cpp
@@ -41,7 +41,7 @@ void CubicGridGeneratorInternal::readXML(XMLfileUnits& xmlconfig) {
 	// setting both or none is not allowed!
 	if((_numMolecules == 0 && density == -1.) || (_numMolecules != 0 && density != -1.) ){
 		Log::global_log->error() << "Error in CubicGridGeneratorInternal: You have to set either density or numMolecules!" << std::endl;
-		mardyn_exit(2341);
+		MARDYN_EXIT(2341);
 	}
 
 	if(density != -1.){
@@ -50,7 +50,7 @@ void CubicGridGeneratorInternal::readXML(XMLfileUnits& xmlconfig) {
 			Log::global_log->error()
 					<< "Error in CubicGridGeneratorInternal: Density has to be positive and non-zero!"
 					<< std::endl;
-			mardyn_exit(2342);
+			MARDYN_EXIT(2342);
 		}
 		double vol = 1.0;
 		for (int d = 0; d < 3; ++d)
@@ -67,7 +67,7 @@ unsigned long CubicGridGeneratorInternal::readPhaseSpace(ParticleContainer *part
 	if(_numMolecules == 0){
 		Log::global_log->error() << "Error in CubicGridGeneratorInternal: numMolecules is not set!"
 				<< std::endl << "Please make sure to run readXML()!" << std::endl;
-		mardyn_exit(2341);
+		MARDYN_EXIT(2341);
 	}
 
 	// create a body centered cubic layout, by creating by placing the molecules on the
@@ -147,7 +147,7 @@ std::array<unsigned long, 3> CubicGridGeneratorInternal::determineMolsPerDimensi
 		if (answer < 1) {
 			Log::global_log->error() << "computed num Molecules along dimension " << d << ": " << answer << std::endl;
 			Log::global_log->error() << "Should be larger than 1. Exiting." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 
 		ret[d] = answer;

--- a/src/io/CubicGridGeneratorInternal.cpp
+++ b/src/io/CubicGridGeneratorInternal.cpp
@@ -42,7 +42,7 @@ void CubicGridGeneratorInternal::readXML(XMLfileUnits& xmlconfig) {
 	if((_numMolecules == 0 && density == -1.) || (_numMolecules != 0 && density != -1.) ){
 		std::ostringstream error_message;
 		error_message << "Error in CubicGridGeneratorInternal: You have to set either density or numMolecules!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if(density != -1.){
@@ -50,7 +50,7 @@ void CubicGridGeneratorInternal::readXML(XMLfileUnits& xmlconfig) {
 		if(density <= 0){
 			std::ostringstream error_message;
 			error_message << "Error in CubicGridGeneratorInternal: Density has to be positive and non-zero!" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		double vol = 1.0;
 		for (int d = 0; d < 3; ++d)
@@ -68,7 +68,7 @@ unsigned long CubicGridGeneratorInternal::readPhaseSpace(ParticleContainer *part
 		std::ostringstream error_message;
 		error_message << "Error in CubicGridGeneratorInternal: numMolecules is not set!"
 				<< std::endl << "Please make sure to run readXML()!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	// create a body centered cubic layout, by creating by placing the molecules on the
@@ -149,7 +149,7 @@ std::array<unsigned long, 3> CubicGridGeneratorInternal::determineMolsPerDimensi
 			std::ostringstream error_message;
 			error_message << "computed num Molecules along dimension " << d << ": " << answer << std::endl;
 			error_message << "Should be larger than 1. Exiting." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		ret[d] = answer;

--- a/src/io/CubicGridGeneratorInternal.cpp
+++ b/src/io/CubicGridGeneratorInternal.cpp
@@ -40,17 +40,17 @@ void CubicGridGeneratorInternal::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "binaryMixture: " << _binaryMixture << std::endl;
 	// setting both or none is not allowed!
 	if((_numMolecules == 0 && density == -1.) || (_numMolecules != 0 && density != -1.) ){
-		Log::global_log->error() << "Error in CubicGridGeneratorInternal: You have to set either density or numMolecules!" << std::endl;
-		MARDYN_EXIT(2341);
+		std::ostringstream error_message;
+		error_message << "Error in CubicGridGeneratorInternal: You have to set either density or numMolecules!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	if(density != -1.){
 		// density has been set
 		if(density <= 0){
-			Log::global_log->error()
+			std::ostringstream error_message;			error_message
 					<< "Error in CubicGridGeneratorInternal: Density has to be positive and non-zero!"
-					<< std::endl;
-			MARDYN_EXIT(2342);
+					<< std::endl;			MARDYN_EXIT(error_message);
 		}
 		double vol = 1.0;
 		for (int d = 0; d < 3; ++d)
@@ -65,9 +65,8 @@ unsigned long CubicGridGeneratorInternal::readPhaseSpace(ParticleContainer *part
 	Log::global_log->info() << "Reading phase space file (CubicGridGenerator)." << std::endl;
 
 	if(_numMolecules == 0){
-		Log::global_log->error() << "Error in CubicGridGeneratorInternal: numMolecules is not set!"
-				<< std::endl << "Please make sure to run readXML()!" << std::endl;
-		MARDYN_EXIT(2341);
+		std::ostringstream error_message;		error_message << "Error in CubicGridGeneratorInternal: numMolecules is not set!"
+				<< std::endl << "Please make sure to run readXML()!" << std::endl;		MARDYN_EXIT(error_message);
 	}
 
 	// create a body centered cubic layout, by creating by placing the molecules on the
@@ -145,9 +144,10 @@ std::array<unsigned long, 3> CubicGridGeneratorInternal::determineMolsPerDimensi
 		mardyn_assert(answer >= 1);
 
 		if (answer < 1) {
-			Log::global_log->error() << "computed num Molecules along dimension " << d << ": " << answer << std::endl;
-			Log::global_log->error() << "Should be larger than 1. Exiting." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "computed num Molecules along dimension " << d << ": " << answer << std::endl;
+			error_message << "Should be larger than 1. Exiting." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		ret[d] = answer;

--- a/src/io/CubicGridGeneratorInternal.cpp
+++ b/src/io/CubicGridGeneratorInternal.cpp
@@ -48,9 +48,9 @@ void CubicGridGeneratorInternal::readXML(XMLfileUnits& xmlconfig) {
 	if(density != -1.){
 		// density has been set
 		if(density <= 0){
-			std::ostringstream error_message;			error_message
-					<< "Error in CubicGridGeneratorInternal: Density has to be positive and non-zero!"
-					<< std::endl;			MARDYN_EXIT(error_message);
+			std::ostringstream error_message;
+			error_message << "Error in CubicGridGeneratorInternal: Density has to be positive and non-zero!" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		double vol = 1.0;
 		for (int d = 0; d < 3; ++d)
@@ -65,8 +65,10 @@ unsigned long CubicGridGeneratorInternal::readPhaseSpace(ParticleContainer *part
 	Log::global_log->info() << "Reading phase space file (CubicGridGenerator)." << std::endl;
 
 	if(_numMolecules == 0){
-		std::ostringstream error_message;		error_message << "Error in CubicGridGeneratorInternal: numMolecules is not set!"
-				<< std::endl << "Please make sure to run readXML()!" << std::endl;		MARDYN_EXIT(error_message);
+		std::ostringstream error_message;
+		error_message << "Error in CubicGridGeneratorInternal: numMolecules is not set!"
+				<< std::endl << "Please make sure to run readXML()!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	// create a body centered cubic layout, by creating by placing the molecules on the

--- a/src/io/FlopRateWriter.cpp
+++ b/src/io/FlopRateWriter.cpp
@@ -36,7 +36,7 @@ void FlopRateWriter::readXML(XMLfileUnits& xmlconfig) {
 	// TODO:
 	if(_writeToFile) {
 		Log::global_log->error() << "TODO: file output not yet supported." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	if(_writeToFile) {

--- a/src/io/FlopRateWriter.cpp
+++ b/src/io/FlopRateWriter.cpp
@@ -28,7 +28,7 @@ void FlopRateWriter::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "Unknown FlopRateOutputPlugin::mode. Choose \"stdout\", \"file\" or \"both\"." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	_writeFrequency = 1;
@@ -39,7 +39,7 @@ void FlopRateWriter::readXML(XMLfileUnits& xmlconfig) {
 	if(_writeToFile) {
 		std::ostringstream error_message;
 		error_message << "TODO: file output not yet supported." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if(_writeToFile) {

--- a/src/io/FlopRateWriter.cpp
+++ b/src/io/FlopRateWriter.cpp
@@ -26,7 +26,9 @@ void FlopRateWriter::readXML(XMLfileUnits& xmlconfig) {
 		_writeToStdout = true;
 		_writeToFile = true;
 	} else {
-		Log::global_log->error() << "Unknown FlopRateOutputPlugin::mode. Choose \"stdout\", \"file\" or \"both\"." << std::endl;
+		std::ostringstream error_message;
+		error_message << "Unknown FlopRateOutputPlugin::mode. Choose \"stdout\", \"file\" or \"both\"." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	_writeFrequency = 1;
@@ -35,8 +37,9 @@ void FlopRateWriter::readXML(XMLfileUnits& xmlconfig) {
 
 	// TODO:
 	if(_writeToFile) {
-		Log::global_log->error() << "TODO: file output not yet supported." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "TODO: file output not yet supported." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	if(_writeToFile) {

--- a/src/io/FlopRateWriter.h
+++ b/src/io/FlopRateWriter.h
@@ -11,6 +11,7 @@
 #include "plugins/PluginBase.h"
 
 #include <fstream>
+#include <sstream>
 
 class FlopCounter;
 

--- a/src/io/HaloParticleWriter.cpp
+++ b/src/io/HaloParticleWriter.cpp
@@ -18,7 +18,7 @@ void HaloParticleWriter::readXML(XMLfileUnits& xmlconfig) {
 
 	if(_writeFrequency == 0) {
 		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	std::string HaloParticleType = "unknown";

--- a/src/io/HaloParticleWriter.cpp
+++ b/src/io/HaloParticleWriter.cpp
@@ -19,7 +19,7 @@ void HaloParticleWriter::readXML(XMLfileUnits& xmlconfig) {
 	if(_writeFrequency == 0) {
 		std::ostringstream error_message;
 		error_message << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	std::string HaloParticleType = "unknown";

--- a/src/io/HaloParticleWriter.cpp
+++ b/src/io/HaloParticleWriter.cpp
@@ -17,8 +17,9 @@ void HaloParticleWriter::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "Write frequency: " << _writeFrequency << std::endl;
 
 	if(_writeFrequency == 0) {
-		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	std::string HaloParticleType = "unknown";

--- a/src/io/KDTreePrinter.cpp
+++ b/src/io/KDTreePrinter.cpp
@@ -19,7 +19,7 @@ void KDTreePrinter::readXML(XMLfileUnits &xmlconfig) {
 
 	if (_writeFrequency == 0) {
 		std::ostringstream error_message;error_message << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	_outputPrefix = "mardyn";

--- a/src/io/KDTreePrinter.cpp
+++ b/src/io/KDTreePrinter.cpp
@@ -18,9 +18,8 @@ void KDTreePrinter::readXML(XMLfileUnits &xmlconfig) {
 	Log::global_log->info() << "Write frequency: " << _writeFrequency << std::endl;
 
 	if (_writeFrequency == 0) {
-		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency
-								 << std::endl;
-		MARDYN_EXIT(948947);
+		std::ostringstream error_message;		error_message << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency
+								 << std::endl;		MARDYN_EXIT(error_message);
 	}
 
 	_outputPrefix = "mardyn";

--- a/src/io/KDTreePrinter.cpp
+++ b/src/io/KDTreePrinter.cpp
@@ -18,8 +18,8 @@ void KDTreePrinter::readXML(XMLfileUnits &xmlconfig) {
 	Log::global_log->info() << "Write frequency: " << _writeFrequency << std::endl;
 
 	if (_writeFrequency == 0) {
-		std::ostringstream error_message;		error_message << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency
-								 << std::endl;		MARDYN_EXIT(error_message);
+		std::ostringstream error_message;error_message << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	_outputPrefix = "mardyn";

--- a/src/io/KDTreePrinter.cpp
+++ b/src/io/KDTreePrinter.cpp
@@ -20,7 +20,7 @@ void KDTreePrinter::readXML(XMLfileUnits &xmlconfig) {
 	if (_writeFrequency == 0) {
 		Log::global_log->error() << "Write frequency must be a positive nonzero integer, but is " << _writeFrequency
 								 << std::endl;
-		mardyn_exit(948947);
+		MARDYN_EXIT(948947);
 	}
 
 	_outputPrefix = "mardyn";

--- a/src/io/MPI_IOCheckpointWriter.cpp
+++ b/src/io/MPI_IOCheckpointWriter.cpp
@@ -437,6 +437,6 @@ void MPI_IOCheckpointWriter::handle_error(int i) {
 	std::ostringstream error_message;
 	error_message << "Writing of file was not successfull " << " , " << i
 			<< " , " << error_string << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 #endif
 }

--- a/src/io/MPI_IOCheckpointWriter.cpp
+++ b/src/io/MPI_IOCheckpointWriter.cpp
@@ -434,7 +434,9 @@ void MPI_IOCheckpointWriter::handle_error(int i) {
 
 	MPI_Error_string(i, error_string, &length_of_error_string);
 
-	std::ostringstream error_message;	error_message << "Writing of file was not successfull " << " , " << i
-			<< " , " << error_string << std::endl;	MARDYN_EXIT(error_message);
+	std::ostringstream error_message;
+	error_message << "Writing of file was not successfull " << " , " << i
+			<< " , " << error_string << std::endl;
+	MARDYN_EXIT(error_message);
 #endif
 }

--- a/src/io/MPI_IOCheckpointWriter.cpp
+++ b/src/io/MPI_IOCheckpointWriter.cpp
@@ -434,8 +434,7 @@ void MPI_IOCheckpointWriter::handle_error(int i) {
 
 	MPI_Error_string(i, error_string, &length_of_error_string);
 
-	Log::global_log->error() << "Writing of file was not successfull " << " , " << i
-			<< " , " << error_string << std::endl;
-	MARDYN_EXIT(1);
+	std::ostringstream error_message;	error_message << "Writing of file was not successfull " << " , " << i
+			<< " , " << error_string << std::endl;	MARDYN_EXIT(error_message);
 #endif
 }

--- a/src/io/MPI_IOCheckpointWriter.cpp
+++ b/src/io/MPI_IOCheckpointWriter.cpp
@@ -436,6 +436,6 @@ void MPI_IOCheckpointWriter::handle_error(int i) {
 
 	Log::global_log->error() << "Writing of file was not successfull " << " , " << i
 			<< " , " << error_string << std::endl;
-	mardyn_exit(1);
+	MARDYN_EXIT(1);
 #endif
 }

--- a/src/io/MPI_IOReader.cpp
+++ b/src/io/MPI_IOReader.cpp
@@ -60,7 +60,7 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	if(token != "mardyn") {
 		std::ostringstream error_message;
 		error_message << _phaseSpaceHeaderFile << " not a valid mardyn input file." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	std::string inputversion;
@@ -69,13 +69,13 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	if(token != "trunk") {
 		std::ostringstream error_message;
 		error_message << "Wrong input file specifier (\'" << token << "\' instead of \'trunk\')." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if(strtoul(inputversion.c_str(), NULL, 0) < 20080701) {
 		std::ostringstream error_message;
 		error_message << "Input version tool old (" << inputversion << ")" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	Log::global_log->info() << "Reading phase space header from file " << _phaseSpaceHeaderFile << std::endl;
@@ -121,7 +121,7 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 				std::ostringstream error_message;
 				error_message << "Unknown molecule format: '"
 									<< ntypestring << "'" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			_moleculeFormat = ntypestring;
 			Log::global_log->info() << " molecule format: " << ntypestring << std::endl;
@@ -188,7 +188,7 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 				if(numtersoff != 0) {
 					std::ostringstream error_message;
 					error_message << "tersoff no longer supported." << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 				double x, y, z, m;
 				for(unsigned int j = 0; j < numljcenters; j++) {
@@ -662,6 +662,6 @@ void MPI_IOReader::handle_error(int i) {
 	std::ostringstream error_message;
 	error_message << "Writing of file was not successfull " << " , " << i
 			<< " , " << error_string << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 #endif
 }

--- a/src/io/MPI_IOReader.cpp
+++ b/src/io/MPI_IOReader.cpp
@@ -118,8 +118,10 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 
 			if(!(ntypestring == "ICRVQD" || ntypestring == "ICRV"
 				 || ntypestring == "IRV")) {
-				std::ostringstream error_message;				error_message << "Unknown molecule format: '"
-									<< ntypestring << "'" << std::endl;				MARDYN_EXIT(error_message);
+				std::ostringstream error_message;
+				error_message << "Unknown molecule format: '"
+									<< ntypestring << "'" << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			_moleculeFormat = ntypestring;
 			Log::global_log->info() << " molecule format: " << ntypestring << std::endl;
@@ -657,7 +659,9 @@ void MPI_IOReader::handle_error(int i) {
 
 	MPI_Error_string(i, error_string, &length_of_error_string);
 
-	std::ostringstream error_message;	error_message << "Writing of file was not successfull " << " , " << i
-			<< " , " << error_string << std::endl;	MARDYN_EXIT(error_message);
+	std::ostringstream error_message;
+	error_message << "Writing of file was not successfull " << " , " << i
+			<< " , " << error_string << std::endl;
+	MARDYN_EXIT(error_message);
 #endif
 }

--- a/src/io/MPI_IOReader.cpp
+++ b/src/io/MPI_IOReader.cpp
@@ -59,7 +59,7 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	_phaseSpaceHeaderFileStream >> token;
 	if(token != "mardyn") {
 		Log::global_log->error() << _phaseSpaceHeaderFile << " not a valid mardyn input file." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	std::string inputversion;
@@ -67,12 +67,12 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	// FIXME: remove tag trunk from file specification?
 	if(token != "trunk") {
 		Log::global_log->error() << "Wrong input file specifier (\'" << token << "\' instead of \'trunk\')." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	if(strtoul(inputversion.c_str(), NULL, 0) < 20080701) {
 		Log::global_log->error() << "Input version tool old (" << inputversion << ")" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	Log::global_log->info() << "Reading phase space header from file " << _phaseSpaceHeaderFile << std::endl;
@@ -117,7 +117,7 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 				 || ntypestring == "IRV")) {
 				Log::global_log->error() << "Unknown molecule format: '"
 									<< ntypestring << "'" << std::endl;
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 			}
 			_moleculeFormat = ntypestring;
 			Log::global_log->info() << " molecule format: " << ntypestring << std::endl;
@@ -183,7 +183,7 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 											>> numquadrupoles >> numtersoff;
 				if(numtersoff != 0) {
 					Log::global_log->error() << "tersoff no longer supported." << std::endl;
-					mardyn_exit(-1);
+					MARDYN_EXIT(-1);
 				}
 				double x, y, z, m;
 				for(unsigned int j = 0; j < numljcenters; j++) {
@@ -656,6 +656,6 @@ void MPI_IOReader::handle_error(int i) {
 
 	Log::global_log->error() << "Writing of file was not successfull " << " , " << i
 			<< " , " << error_string << std::endl;
-	mardyn_exit(1);
+	MARDYN_EXIT(1);
 #endif
 }

--- a/src/io/MPI_IOReader.cpp
+++ b/src/io/MPI_IOReader.cpp
@@ -58,21 +58,24 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 	_phaseSpaceHeaderFileStream.open(_phaseSpaceHeaderFile.c_str());
 	_phaseSpaceHeaderFileStream >> token;
 	if(token != "mardyn") {
-		Log::global_log->error() << _phaseSpaceHeaderFile << " not a valid mardyn input file." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << _phaseSpaceHeaderFile << " not a valid mardyn input file." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	std::string inputversion;
 	_phaseSpaceHeaderFileStream >> token >> inputversion;
 	// FIXME: remove tag trunk from file specification?
 	if(token != "trunk") {
-		Log::global_log->error() << "Wrong input file specifier (\'" << token << "\' instead of \'trunk\')." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Wrong input file specifier (\'" << token << "\' instead of \'trunk\')." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	if(strtoul(inputversion.c_str(), NULL, 0) < 20080701) {
-		Log::global_log->error() << "Input version tool old (" << inputversion << ")" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Input version tool old (" << inputversion << ")" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	Log::global_log->info() << "Reading phase space header from file " << _phaseSpaceHeaderFile << std::endl;
@@ -115,9 +118,8 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 
 			if(!(ntypestring == "ICRVQD" || ntypestring == "ICRV"
 				 || ntypestring == "IRV")) {
-				Log::global_log->error() << "Unknown molecule format: '"
-									<< ntypestring << "'" << std::endl;
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;				error_message << "Unknown molecule format: '"
+									<< ntypestring << "'" << std::endl;				MARDYN_EXIT(error_message);
 			}
 			_moleculeFormat = ntypestring;
 			Log::global_log->info() << " molecule format: " << ntypestring << std::endl;
@@ -182,8 +184,9 @@ void MPI_IOReader::readPhaseSpaceHeader(Domain* domain, double timestep) {
 				_phaseSpaceHeaderFileStream >> numljcenters >> numcharges >> numdipoles
 											>> numquadrupoles >> numtersoff;
 				if(numtersoff != 0) {
-					Log::global_log->error() << "tersoff no longer supported." << std::endl;
-					MARDYN_EXIT(-1);
+					std::ostringstream error_message;
+					error_message << "tersoff no longer supported." << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 				double x, y, z, m;
 				for(unsigned int j = 0; j < numljcenters; j++) {
@@ -654,8 +657,7 @@ void MPI_IOReader::handle_error(int i) {
 
 	MPI_Error_string(i, error_string, &length_of_error_string);
 
-	Log::global_log->error() << "Writing of file was not successfull " << " , " << i
-			<< " , " << error_string << std::endl;
-	MARDYN_EXIT(1);
+	std::ostringstream error_message;	error_message << "Writing of file was not successfull " << " , " << i
+			<< " , " << error_string << std::endl;	MARDYN_EXIT(error_message);
 #endif
 }

--- a/src/io/Mkesfera.cpp
+++ b/src/io/Mkesfera.cpp
@@ -177,7 +177,7 @@ MkesferaGenerator::readPhaseSpace(ParticleContainer* particleContainer, Domain* 
 					   startx[2] > idx[2]) {
 						std::ostringstream error_message;
 						error_message << "Error in calculation of start and end values! \n";
-						MARDYN_EXIT(error_message);
+						MARDYN_EXIT(error_message.str());
 					}
 					fill[idx[0] - startx[0]][idx[1] - startx[1]][idx[2] - startx[2]][p] = tfill;
 					if(tfill) {

--- a/src/io/Mkesfera.cpp
+++ b/src/io/Mkesfera.cpp
@@ -175,8 +175,9 @@ MkesferaGenerator::readPhaseSpace(ParticleContainer* particleContainer, Domain* 
 					if(idx[0] - startx[0] >= fl_units_local[0] or idx[1] - startx[1] >= fl_units_local[1] or
 					   idx[2] - startx[2] >= fl_units_local[2] or startx[0] > idx[0] or startx[1] > idx[1] or
 					   startx[2] > idx[2]) {
-						Log::global_log->error() << "Error in calculation of start and end values! \n";
-						MARDYN_EXIT(0);
+						std::ostringstream error_message;
+						error_message << "Error in calculation of start and end values! \n";
+						MARDYN_EXIT(error_message);
 					}
 					fill[idx[0] - startx[0]][idx[1] - startx[1]][idx[2] - startx[2]][p] = tfill;
 					if(tfill) {

--- a/src/io/Mkesfera.cpp
+++ b/src/io/Mkesfera.cpp
@@ -176,7 +176,7 @@ MkesferaGenerator::readPhaseSpace(ParticleContainer* particleContainer, Domain* 
 					   idx[2] - startx[2] >= fl_units_local[2] or startx[0] > idx[0] or startx[1] > idx[1] or
 					   startx[2] > idx[2]) {
 						Log::global_log->error() << "Error in calculation of start and end values! \n";
-						mardyn_exit(0);
+						MARDYN_EXIT(0);
 					}
 					fill[idx[0] - startx[0]][idx[1] - startx[1]][idx[2] - startx[2]][p] = tfill;
 					if(tfill) {

--- a/src/io/MmpldWriter.cpp
+++ b/src/io/MmpldWriter.cpp
@@ -56,7 +56,7 @@ MmpldWriter::MmpldWriter(uint64_t startTimestep, uint64_t writeFrequency, uint64
 		_color_type(MMPLD_COLOR_NONE)
 {
 	if (0 == _writeFrequency) {
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 }
 
@@ -89,7 +89,7 @@ void MmpldWriter::readXML(XMLfileUnits& xmlconfig)
 			break;
 		default:
 			Log::global_log->error() << "Unsupported MMPLD version:" << _mmpldversion << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 			break;
 	}
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
@@ -102,7 +102,7 @@ void MmpldWriter::readXML(XMLfileUnits& xmlconfig)
 	Log::global_log->info() << "[MMPLD Writer] Number of sites: " << numSites << std::endl;
 	if(numSites < 1) {
 		Log::global_log->fatal() << "[MMPLD Writer] No site parameters specified." << std::endl;
-		mardyn_exit(48973);
+		MARDYN_EXIT(48973);
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator outputSiteIter;
@@ -144,7 +144,7 @@ void MmpldWriter::init(ParticleContainer *particleContainer,
 {
 	if ( (htole32(1) != 1) || (htole64(1.0) != 1.0) ) {
 		Log::global_log->error() << "[MMPLD Writer] The MMPLD Writer currently only supports running on little endian systems." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	// only executed once
@@ -392,7 +392,7 @@ long MmpldWriter::get_data_frame_header_size() {
 			break;
 		default:
 			Log::global_log->error() << "[MMPLD Writer] Unsupported MMPLD version: " << _mmpldversion << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 			break;
 	}
 	return data_frame_header_size;

--- a/src/io/MmpldWriter.cpp
+++ b/src/io/MmpldWriter.cpp
@@ -56,7 +56,9 @@ MmpldWriter::MmpldWriter(uint64_t startTimestep, uint64_t writeFrequency, uint64
 		_color_type(MMPLD_COLOR_NONE)
 {
 	if (0 == _writeFrequency) {
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[MMPLD Writer] writefrequency must not be 0" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -88,8 +90,9 @@ void MmpldWriter::readXML(XMLfileUnits& xmlconfig)
 		case 102:
 			break;
 		default:
-			Log::global_log->error() << "Unsupported MMPLD version:" << _mmpldversion << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Unsupported MMPLD version:" << _mmpldversion << std::endl;
+			MARDYN_EXIT(error_message);
 			break;
 	}
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
@@ -101,8 +104,9 @@ void MmpldWriter::readXML(XMLfileUnits& xmlconfig)
 	numSites = query.card();
 	Log::global_log->info() << "[MMPLD Writer] Number of sites: " << numSites << std::endl;
 	if(numSites < 1) {
-		Log::global_log->fatal() << "[MMPLD Writer] No site parameters specified." << std::endl;
-		MARDYN_EXIT(48973);
+		std::ostringstream error_message;
+		error_message << "[MMPLD Writer] No site parameters specified." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator outputSiteIter;
@@ -143,8 +147,9 @@ void MmpldWriter::init(ParticleContainer *particleContainer,
 						DomainDecompBase *domainDecomp, Domain *domain)
 {
 	if ( (htole32(1) != 1) || (htole64(1.0) != 1.0) ) {
-		Log::global_log->error() << "[MMPLD Writer] The MMPLD Writer currently only supports running on little endian systems." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "[MMPLD Writer] The MMPLD Writer currently only supports running on little endian systems." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	// only executed once
@@ -391,8 +396,9 @@ long MmpldWriter::get_data_frame_header_size() {
 			data_frame_header_size = sizeof(float) + sizeof(uint32_t);
 			break;
 		default:
-			Log::global_log->error() << "[MMPLD Writer] Unsupported MMPLD version: " << _mmpldversion << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "[MMPLD Writer] Unsupported MMPLD version: " << _mmpldversion << std::endl;
+			MARDYN_EXIT(error_message);
 			break;
 	}
 	return data_frame_header_size;

--- a/src/io/MmpldWriter.cpp
+++ b/src/io/MmpldWriter.cpp
@@ -58,7 +58,7 @@ MmpldWriter::MmpldWriter(uint64_t startTimestep, uint64_t writeFrequency, uint64
 	if (0 == _writeFrequency) {
 		std::ostringstream error_message;
 		error_message << "[MMPLD Writer] writefrequency must not be 0" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -92,7 +92,7 @@ void MmpldWriter::readXML(XMLfileUnits& xmlconfig)
 		default:
 			std::ostringstream error_message;
 			error_message << "Unsupported MMPLD version:" << _mmpldversion << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 			break;
 	}
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
@@ -106,7 +106,7 @@ void MmpldWriter::readXML(XMLfileUnits& xmlconfig)
 	if(numSites < 1) {
 		std::ostringstream error_message;
 		error_message << "[MMPLD Writer] No site parameters specified." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator outputSiteIter;
@@ -149,7 +149,7 @@ void MmpldWriter::init(ParticleContainer *particleContainer,
 	if ( (htole32(1) != 1) || (htole64(1.0) != 1.0) ) {
 		std::ostringstream error_message;
 		error_message << "[MMPLD Writer] The MMPLD Writer currently only supports running on little endian systems." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	// only executed once
@@ -398,7 +398,7 @@ long MmpldWriter::get_data_frame_header_size() {
 		default:
 			std::ostringstream error_message;
 			error_message << "[MMPLD Writer] Unsupported MMPLD version: " << _mmpldversion << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 			break;
 	}
 	return data_frame_header_size;

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -25,14 +25,14 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		_filler = std::shared_ptr<ObjectFillerBase>(objectFillerFactory.create(fillerType));
 		if(!_filler) {
 			Log::global_log->error() << "Object filler could not be created" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		Log::global_log->debug() << "Using object filler of type: " << _filler->getPluginName() << std::endl;
 		_filler->readXML(xmlconfig);
 		xmlconfig.changecurrentnode("..");
 	} else {
 		Log::global_log->error() << "No filler specified." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	if(xmlconfig.changecurrentnode("object")) {
@@ -49,7 +49,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		xmlconfig.changecurrentnode("..");
 	} else {
 		Log::global_log->error() << "No object specified." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	if(xmlconfig.changecurrentnode("velocityAssigner")) {
@@ -79,7 +79,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 			_velocityAssigner = std::make_shared<MaxwellVelocityAssigner>(0, seed);
 		} else {
 			Log::global_log->error() << "Unknown velocity assigner specified." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		Ensemble* ensemble = _simulation.getEnsemble();
 		Log::global_log->info() << "Setting temperature for velocity assigner to " << ensemble->T() << std::endl;

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -27,7 +27,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		if(!_filler) {
 			std::ostringstream error_message;
 			error_message << "Object filler could not be created" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		Log::global_log->debug() << "Using object filler of type: " << _filler->getPluginName() << std::endl;
 		_filler->readXML(xmlconfig);
@@ -35,7 +35,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "No filler specified." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if(xmlconfig.changecurrentnode("object")) {
@@ -47,7 +47,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		if(!_object) {
 			std::ostringstream error_message;
 			error_message << "Unknown object type: " << objectType << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		Log::global_log->debug() << "Created object of type: " << _object->getPluginName() << std::endl;
 		_object->readXML(xmlconfig);
@@ -55,7 +55,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "No object specified." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if(xmlconfig.changecurrentnode("velocityAssigner")) {
@@ -86,7 +86,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			std::ostringstream error_message;
 			error_message << "Unknown velocity assigner specified." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		Ensemble* ensemble = _simulation.getEnsemble();
 		Log::global_log->info() << "Setting temperature for velocity assigner to " << ensemble->T() << std::endl;

--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -2,6 +2,7 @@
 
 #include <limits>
 #include <chrono>
+#include <sstream>
 
 #include "utils/mardyn_assert.h"
 #include "ensemble/EnsembleBase.h"
@@ -24,15 +25,17 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		ObjectFillerFactory objectFillerFactory;
 		_filler = std::shared_ptr<ObjectFillerBase>(objectFillerFactory.create(fillerType));
 		if(!_filler) {
-			Log::global_log->error() << "Object filler could not be created" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Object filler could not be created" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		Log::global_log->debug() << "Using object filler of type: " << _filler->getPluginName() << std::endl;
 		_filler->readXML(xmlconfig);
 		xmlconfig.changecurrentnode("..");
 	} else {
-		Log::global_log->error() << "No filler specified." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "No filler specified." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	if(xmlconfig.changecurrentnode("object")) {
@@ -42,14 +45,17 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		ObjectFactory objectFactory;
 		_object = std::shared_ptr<Object>(objectFactory.create(objectType));
 		if(!_object) {
-			Log::global_log->error() << "Unknown object type: " << objectType << std::endl;
+			std::ostringstream error_message;
+			error_message << "Unknown object type: " << objectType << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		Log::global_log->debug() << "Created object of type: " << _object->getPluginName() << std::endl;
 		_object->readXML(xmlconfig);
 		xmlconfig.changecurrentnode("..");
 	} else {
-		Log::global_log->error() << "No object specified." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "No object specified." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	if(xmlconfig.changecurrentnode("velocityAssigner")) {
@@ -78,8 +84,9 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		} else if(velocityAssignerName == "MaxwellVelocityDistribution") {
 			_velocityAssigner = std::make_shared<MaxwellVelocityAssigner>(0, seed);
 		} else {
-			Log::global_log->error() << "Unknown velocity assigner specified." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Unknown velocity assigner specified." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		Ensemble* ensemble = _simulation.getEnsemble();
 		Log::global_log->info() << "Setting temperature for velocity assigner to " << ensemble->T() << std::endl;

--- a/src/io/PerCellGenerator.cpp
+++ b/src/io/PerCellGenerator.cpp
@@ -42,16 +42,18 @@ void PerCellGenerator::readXML(XMLfileUnits &xmlconfig) {
 	if (_numMoleculesPerCell != std::numeric_limits<unsigned int>::max()) {
 		Log::global_log->info() << "numMoleculesPerCell: " << _numMoleculesPerCell << std::endl;
 	} else {
-		Log::global_log->error() << "Missing required field numMoleculesPerCell. Aborting!" << std::endl;
-		MARDYN_EXIT(1949);
+		std::ostringstream error_message;
+		error_message << "Missing required field numMoleculesPerCell. Aborting!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	xmlconfig.getNodeValue("initTemperature", _initTemperature);
 	if (_initTemperature > 0.) {
 		Log::global_log->info() << "initTemperature: " << _initTemperature << std::endl;
 	} else {
-		Log::global_log->error() << "Missing required field initTemperature. Aborting!" << std::endl;
-		MARDYN_EXIT(1949);
+		std::ostringstream error_message;
+		error_message << "Missing required field initTemperature. Aborting!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	xmlconfig.getNodeValue("generateAtLeastTwoParticles", _generateAtLeastTwoParticles);

--- a/src/io/PerCellGenerator.cpp
+++ b/src/io/PerCellGenerator.cpp
@@ -43,7 +43,7 @@ void PerCellGenerator::readXML(XMLfileUnits &xmlconfig) {
 		Log::global_log->info() << "numMoleculesPerCell: " << _numMoleculesPerCell << std::endl;
 	} else {
 		Log::global_log->error() << "Missing required field numMoleculesPerCell. Aborting!" << std::endl;
-		mardyn_exit(1949);
+		MARDYN_EXIT(1949);
 	}
 
 	xmlconfig.getNodeValue("initTemperature", _initTemperature);
@@ -51,7 +51,7 @@ void PerCellGenerator::readXML(XMLfileUnits &xmlconfig) {
 		Log::global_log->info() << "initTemperature: " << _initTemperature << std::endl;
 	} else {
 		Log::global_log->error() << "Missing required field initTemperature. Aborting!" << std::endl;
-		mardyn_exit(1949);
+		MARDYN_EXIT(1949);
 	}
 
 	xmlconfig.getNodeValue("generateAtLeastTwoParticles", _generateAtLeastTwoParticles);

--- a/src/io/PerCellGenerator.cpp
+++ b/src/io/PerCellGenerator.cpp
@@ -44,7 +44,7 @@ void PerCellGenerator::readXML(XMLfileUnits &xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "Missing required field numMoleculesPerCell. Aborting!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	xmlconfig.getNodeValue("initTemperature", _initTemperature);
@@ -53,7 +53,7 @@ void PerCellGenerator::readXML(XMLfileUnits &xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "Missing required field initTemperature. Aborting!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	xmlconfig.getNodeValue("generateAtLeastTwoParticles", _generateAtLeastTwoParticles);

--- a/src/io/RDF.cpp
+++ b/src/io/RDF.cpp
@@ -33,8 +33,9 @@ RDF::RDF() :
 
 void RDF::init() {
 	if(!_readConfig){
-		Log::global_log->error() << "RDF initialized without reading the configuration, exiting" << std::endl;
-		MARDYN_EXIT(25);
+		std::ostringstream error_message;
+		error_message << "RDF initialized without reading the configuration, exiting" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	_cellProcessor = new RDFCellProcessor(global_simulation->getcutoffRadius(), this);
@@ -153,27 +154,27 @@ void RDF::init() {
 void RDF::readXML(XMLfileUnits& xmlconfig) {
 	_writeFrequency = 1;
 	xmlconfig.getNodeValue("writefrequency", _writeFrequency);
-	Log::global_log->info() << "Write frequency: " << _writeFrequency << std::endl;
+	Log::global_log->info() << "[RDF] Write frequency: " << _writeFrequency << std::endl;
 
 	_samplingFrequency = 1;
 	xmlconfig.getNodeValue("samplingfrequency", _samplingFrequency);
-	Log::global_log->info() << "Sampling frequency: " << _samplingFrequency << std::endl;
+	Log::global_log->info() << "[RDF] Sampling frequency: " << _samplingFrequency << std::endl;
 
 	_outputPrefix = "mardyn";
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
-	Log::global_log->info() << "Output prefix: " << _outputPrefix << std::endl;
+	Log::global_log->info() << "[RDF] Output prefix: " << _outputPrefix << std::endl;
 
 	_bins = 1;
 	xmlconfig.getNodeValue("bins", _bins);
-	Log::global_log->info() << "Number of bins: " << _bins << std::endl;
+	Log::global_log->info() << "[RDF] Number of bins: " << _bins << std::endl;
 
 	_angularBins = 1;
 	xmlconfig.getNodeValue("angularbins", _angularBins);
-	Log::global_log->info() << "Number of angular bins: " << _angularBins << std::endl;
+	Log::global_log->info() << "[RDF] Number of angular bins: " << _angularBins << std::endl;
 
 	_intervalLength = 1;
 	xmlconfig.getNodeValueReduced("intervallength", _intervalLength);
-	Log::global_log->info() << "Interval length: " << _intervalLength << std::endl;
+	Log::global_log->info() << "[RDF] Interval length: " << _intervalLength << std::endl;
 	_readConfig = true;
 }
 

--- a/src/io/RDF.cpp
+++ b/src/io/RDF.cpp
@@ -35,7 +35,7 @@ void RDF::init() {
 	if(!_readConfig){
 		std::ostringstream error_message;
 		error_message << "RDF initialized without reading the configuration, exiting" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	_cellProcessor = new RDFCellProcessor(global_simulation->getcutoffRadius(), this);

--- a/src/io/RDF.cpp
+++ b/src/io/RDF.cpp
@@ -34,7 +34,7 @@ RDF::RDF() :
 void RDF::init() {
 	if(!_readConfig){
 		Log::global_log->error() << "RDF initialized without reading the configuration, exiting" << std::endl;
-		mardyn_exit(25);
+		MARDYN_EXIT(25);
 	}
 
 	_cellProcessor = new RDFCellProcessor(global_simulation->getcutoffRadius(), this);

--- a/src/io/ReplicaGenerator.cpp
+++ b/src/io/ReplicaGenerator.cpp
@@ -56,9 +56,10 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	XMLfileUnits inp(subDomain.strFilePathHeader);
 
 	if(not inp.changecurrentnode("/mardyn")) {
-		Log::global_log->error() << "Could not find root node /mardyn in XML input file." << std::endl;
-		Log::global_log->fatal() << "Not a valid MarDyn XML input file." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Could not find root node /mardyn in XML input file." << std::endl;
+		error_message << "Not a valid MarDyn XML input file." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	bool bInputOk = true;
@@ -80,9 +81,8 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	subDomain.dDensity = subDomain.numParticles / subDomain.dVolume;
 
 	if(not bInputOk) {
-		Log::global_log->error() << "Content of file: '" << subDomain.strFilePathHeader << "' corrupted! Program exit ..."
-							<< std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;		error_message << "Content of file: '" << subDomain.strFilePathHeader << "' corrupted! Program exit ..."
+							<< std::endl;		MARDYN_EXIT(error_message);
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -92,8 +92,9 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	else if("ICRV" == strMoleculeFormat)
 		_nMoleculeFormat = ICRV;
 	else {
-		Log::global_log->error() << "Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -106,8 +107,9 @@ void ReplicaGenerator::readReplicaPhaseSpaceData(SubDomain& subDomain, DomainDec
 	std::ifstream ifs;
 	ifs.open(subDomain.strFilePathData.c_str(), std::ios::binary | std::ios::in);
 	if(!ifs.is_open()) {
-		Log::global_log->error() << "Could not open phaseSpaceFile " << subDomain.strFilePathData << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Could not open phaseSpaceFile " << subDomain.strFilePathData << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	Log::global_log->info() << "Reading phase space file " << subDomain.strFilePathData << std::endl;
@@ -188,9 +190,8 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 	} else if("heterogeneous_LV" == strType) {
 		_nSystemType = ST_HETEROGENEOUS_LIQUID_VAPOR;
 	} else {
-		Log::global_log->error() << "Specified wrong type at XML path: " << xmlconfig.getcurrentnodepath() << "/type"
-							<< std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;		error_message << "Specified wrong type at XML path: " << xmlconfig.getcurrentnodepath() << "/type"
+							<< std::endl;		MARDYN_EXIT(error_message);
 	}
 
 	SubDomain sd;
@@ -240,8 +241,9 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 			numChanges = query.card();
 			Log::global_log->info() << "Number of components to change: " << (uint32_t) numChanges << std::endl;
 			if(numChanges < 1) {
-				Log::global_log->error() << "No component change defined in XML-config file. Program exit ..." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "No component change defined in XML-config file. Program exit ..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			XMLfile::Query::const_iterator changeIter;
 			for(changeIter = query.begin(); changeIter; changeIter++) {
@@ -263,8 +265,9 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 			numChanges = query.card();
 			Log::global_log->info() << "Number of components to change: " << (uint32_t) numChanges << std::endl;
 			if(numChanges < 1) {
-				Log::global_log->error() << "No component change defined in XML-config file. Program exit ..." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "No component change defined in XML-config file. Program exit ..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			XMLfile::Query::const_iterator changeIter;
 			for(changeIter = query.begin(); changeIter; changeIter++) {
@@ -528,11 +531,10 @@ ReplicaGenerator::readPhaseSpace(ParticleContainer* particleContainer, Domain* d
 					   << std::endl;
 
 	if(domainDecomp->getRank() == 0 && numParticlesGlobal != _numParticlesTotal - numAddedParticlesFreespaceGlobal) {
-		Log::global_log->info() << "Number of particles: " << numParticlesGlobal << " (added)"
-																			   " != "
-						   << (_numParticlesTotal - numAddedParticlesFreespaceGlobal) << " (expected). Program exit ..."
-						   << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "Number of particles: " << numParticlesGlobal << " (added) != "
+						<< (_numParticlesTotal - numAddedParticlesFreespaceGlobal) << " (expected)." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	global_simulation->timers()->stop("REPLICA_GENERATOR_VLE_INPUT");

--- a/src/io/ReplicaGenerator.cpp
+++ b/src/io/ReplicaGenerator.cpp
@@ -58,7 +58,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	if(not inp.changecurrentnode("/mardyn")) {
 		Log::global_log->error() << "Could not find root node /mardyn in XML input file." << std::endl;
 		Log::global_log->fatal() << "Not a valid MarDyn XML input file." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	bool bInputOk = true;
@@ -82,7 +82,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	if(not bInputOk) {
 		Log::global_log->error() << "Content of file: '" << subDomain.strFilePathHeader << "' corrupted! Program exit ..."
 							<< std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -93,7 +93,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 		_nMoleculeFormat = ICRV;
 	else {
 		Log::global_log->error() << "Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 }
 
@@ -107,7 +107,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceData(SubDomain& subDomain, DomainDec
 	ifs.open(subDomain.strFilePathData.c_str(), std::ios::binary | std::ios::in);
 	if(!ifs.is_open()) {
 		Log::global_log->error() << "Could not open phaseSpaceFile " << subDomain.strFilePathData << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	Log::global_log->info() << "Reading phase space file " << subDomain.strFilePathData << std::endl;
@@ -190,7 +190,7 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		Log::global_log->error() << "Specified wrong type at XML path: " << xmlconfig.getcurrentnodepath() << "/type"
 							<< std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	SubDomain sd;
@@ -241,7 +241,7 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 			Log::global_log->info() << "Number of components to change: " << (uint32_t) numChanges << std::endl;
 			if(numChanges < 1) {
 				Log::global_log->error() << "No component change defined in XML-config file. Program exit ..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 			XMLfile::Query::const_iterator changeIter;
 			for(changeIter = query.begin(); changeIter; changeIter++) {
@@ -264,7 +264,7 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 			Log::global_log->info() << "Number of components to change: " << (uint32_t) numChanges << std::endl;
 			if(numChanges < 1) {
 				Log::global_log->error() << "No component change defined in XML-config file. Program exit ..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 			XMLfile::Query::const_iterator changeIter;
 			for(changeIter = query.begin(); changeIter; changeIter++) {
@@ -532,7 +532,7 @@ ReplicaGenerator::readPhaseSpace(ParticleContainer* particleContainer, Domain* d
 																			   " != "
 						   << (_numParticlesTotal - numAddedParticlesFreespaceGlobal) << " (expected). Program exit ..."
 						   << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	global_simulation->timers()->stop("REPLICA_GENERATOR_VLE_INPUT");

--- a/src/io/ReplicaGenerator.cpp
+++ b/src/io/ReplicaGenerator.cpp
@@ -59,7 +59,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 		std::ostringstream error_message;
 		error_message << "Could not find root node /mardyn in XML input file." << std::endl;
 		error_message << "Not a valid MarDyn XML input file." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	bool bInputOk = true;
@@ -83,7 +83,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	if(not bInputOk) {
 		std::ostringstream error_message;
 		error_message << "Content of file: '" << subDomain.strFilePathHeader << "' corrupted!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -95,7 +95,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	else {
 		std::ostringstream error_message;
 		error_message << "Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -110,7 +110,7 @@ void ReplicaGenerator::readReplicaPhaseSpaceData(SubDomain& subDomain, DomainDec
 	if(!ifs.is_open()) {
 		std::ostringstream error_message;
 		error_message << "Could not open phaseSpaceFile " << subDomain.strFilePathData << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	Log::global_log->info() << "Reading phase space file " << subDomain.strFilePathData << std::endl;
@@ -193,7 +193,7 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "Specified wrong type at XML path: " << xmlconfig.getcurrentnodepath() << "/type" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	SubDomain sd;
@@ -245,7 +245,7 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 			if(numChanges < 1) {
 				std::ostringstream error_message;
 				error_message << "No component change defined in XML-config file. Program exit ..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			XMLfile::Query::const_iterator changeIter;
 			for(changeIter = query.begin(); changeIter; changeIter++) {
@@ -269,7 +269,7 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 			if(numChanges < 1) {
 				std::ostringstream error_message;
 				error_message << "No component change defined in XML-config file. Program exit ..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			XMLfile::Query::const_iterator changeIter;
 			for(changeIter = query.begin(); changeIter; changeIter++) {
@@ -536,7 +536,7 @@ ReplicaGenerator::readPhaseSpace(ParticleContainer* particleContainer, Domain* d
 		std::ostringstream error_message;
 		error_message << "Number of particles: " << numParticlesGlobal << " (added) != "
 						<< (_numParticlesTotal - numAddedParticlesFreespaceGlobal) << " (expected)." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	global_simulation->timers()->stop("REPLICA_GENERATOR_VLE_INPUT");

--- a/src/io/ReplicaGenerator.cpp
+++ b/src/io/ReplicaGenerator.cpp
@@ -81,8 +81,9 @@ void ReplicaGenerator::readReplicaPhaseSpaceHeader(SubDomain& subDomain) {
 	subDomain.dDensity = subDomain.numParticles / subDomain.dVolume;
 
 	if(not bInputOk) {
-		std::ostringstream error_message;		error_message << "Content of file: '" << subDomain.strFilePathHeader << "' corrupted! Program exit ..."
-							<< std::endl;		MARDYN_EXIT(error_message);
+		std::ostringstream error_message;
+		error_message << "Content of file: '" << subDomain.strFilePathHeader << "' corrupted!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -190,8 +191,9 @@ void ReplicaGenerator::readXML(XMLfileUnits& xmlconfig) {
 	} else if("heterogeneous_LV" == strType) {
 		_nSystemType = ST_HETEROGENEOUS_LIQUID_VAPOR;
 	} else {
-		std::ostringstream error_message;		error_message << "Specified wrong type at XML path: " << xmlconfig.getcurrentnodepath() << "/type"
-							<< std::endl;		MARDYN_EXIT(error_message);
+		std::ostringstream error_message;
+		error_message << "Specified wrong type at XML path: " << xmlconfig.getcurrentnodepath() << "/type" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	SubDomain sd;

--- a/src/io/ResultWriter.cpp
+++ b/src/io/ResultWriter.cpp
@@ -15,7 +15,7 @@ void ResultWriter::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "[ResultWriter] Write frequency: " << _writeFrequency << std::endl;
 	if (_writeFrequency <= 0) {
 		Log::global_log->error() << "[ResultWriter] Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		mardyn_exit(123);
+		MARDYN_EXIT(123);
 	}
 
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);

--- a/src/io/ResultWriter.cpp
+++ b/src/io/ResultWriter.cpp
@@ -16,7 +16,7 @@ void ResultWriter::readXML(XMLfileUnits& xmlconfig) {
 	if (_writeFrequency <= 0) {
 		std::ostringstream error_message;
 		error_message << "[ResultWriter] Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);

--- a/src/io/ResultWriter.cpp
+++ b/src/io/ResultWriter.cpp
@@ -14,8 +14,9 @@ void ResultWriter::readXML(XMLfileUnits& xmlconfig) {
 	xmlconfig.getNodeValue("writefrequency", _writeFrequency);
 	Log::global_log->info() << "[ResultWriter] Write frequency: " << _writeFrequency << std::endl;
 	if (_writeFrequency <= 0) {
-		Log::global_log->error() << "[ResultWriter] Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
-		MARDYN_EXIT(123);
+		std::ostringstream error_message;
+		error_message << "[ResultWriter] Write frequency must be a positive nonzero integer, but is " << _writeFrequency << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);

--- a/src/io/TimerProfiler.cpp
+++ b/src/io/TimerProfiler.cpp
@@ -7,11 +7,13 @@
 
 #include <cmath>
 #include <tuple>
+#include <sstream>
 
 #include "TimerProfiler.h"
 #include "utils/Logger.h"
 #include "utils/String_utils.h"
 #include "utils/xmlfileUnits.h"
+#include "utils/mardyn_assert.h"
 
 
 
@@ -35,7 +37,9 @@ void TimerProfiler::readXML(XMLfileUnits& xmlconfig) {
 		} else if (displayMode == "none") {
 			setDisplayMode(Displaymode::NONE);
 		} else {
-			Log::global_log->error() << "Unknown display mode: " << displayMode << std::endl;
+			std::ostringstream error_message;
+			error_message << "Unknown display mode: " << displayMode << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 }

--- a/src/io/TimerProfiler.cpp
+++ b/src/io/TimerProfiler.cpp
@@ -39,7 +39,7 @@ void TimerProfiler::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			std::ostringstream error_message;
 			error_message << "Unknown display mode: " << displayMode << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 }

--- a/src/io/TimerWriter.cpp
+++ b/src/io/TimerWriter.cpp
@@ -34,8 +34,9 @@ void TimerWriter::readXML(XMLfileUnits& xmlconfig) {
 						   << std::endl;
 	}
 	if (_timerNames.empty()) {
-		Log::global_log->error() << "TimerWriter: no timers given. make sure you specify them correctly." << std::endl;
-		MARDYN_EXIT(242367);
+		std::ostringstream error_message;
+		error_message << "TimerWriter: no timers given. make sure you specify them correctly." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	xmlconfig.changecurrentnode(oldpath);
 }

--- a/src/io/TimerWriter.cpp
+++ b/src/io/TimerWriter.cpp
@@ -35,7 +35,7 @@ void TimerWriter::readXML(XMLfileUnits& xmlconfig) {
 	}
 	if (_timerNames.empty()) {
 		Log::global_log->error() << "TimerWriter: no timers given. make sure you specify them correctly." << std::endl;
-		mardyn_exit(242367);
+		MARDYN_EXIT(242367);
 	}
 	xmlconfig.changecurrentnode(oldpath);
 }

--- a/src/io/TimerWriter.cpp
+++ b/src/io/TimerWriter.cpp
@@ -36,7 +36,7 @@ void TimerWriter::readXML(XMLfileUnits& xmlconfig) {
 	if (_timerNames.empty()) {
 		std::ostringstream error_message;
 		error_message << "TimerWriter: no timers given. make sure you specify them correctly." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	xmlconfig.changecurrentnode(oldpath);
 }

--- a/src/io/vtk/VTKGridWriter.cpp
+++ b/src/io/vtk/VTKGridWriter.cpp
@@ -34,7 +34,9 @@ void VTKGridWriter::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "VTKMoleculeWriter: Output prefix: " << _fileName << std::endl;
 
 	if (_writeFrequency <= 0) {
-		Log::global_log->error() << "VTKMoleculeWriter: writeFrequency must be > 0!" << std::endl;
+		std::ostringstream error_message;
+		error_message << "VTKMoleculeWriter: writeFrequency must be > 0!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -47,8 +49,9 @@ void  VTKGridWriter::endStep(
 	LinkedCells* container = dynamic_cast<LinkedCells*>(particleContainer);
 #ifndef NDEBUG
 	if (container == NULL) {
-		Log::global_log->error() << "VTKGridWriter works only with plottable LinkedCells!" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "VTKGridWriter works only with plottable LinkedCells!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 #endif
 
@@ -113,8 +116,9 @@ void  VTKGridWriter::init(ParticleContainer *particleContainer,
                           DomainDecompBase * /*domainDecomposition*/, Domain * /*domain*/) {
 #ifndef NDEBUG
 	if (dynamic_cast<LinkedCells*>(particleContainer) == NULL) {
-		Log::global_log->error() << "VTKGridWriter works only with LinkCells!" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "VTKGridWriter works only with LinkCells!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 #endif
 }

--- a/src/io/vtk/VTKGridWriter.cpp
+++ b/src/io/vtk/VTKGridWriter.cpp
@@ -48,7 +48,7 @@ void  VTKGridWriter::endStep(
 #ifndef NDEBUG
 	if (container == NULL) {
 		Log::global_log->error() << "VTKGridWriter works only with plottable LinkedCells!" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 #endif
 
@@ -114,7 +114,7 @@ void  VTKGridWriter::init(ParticleContainer *particleContainer,
 #ifndef NDEBUG
 	if (dynamic_cast<LinkedCells*>(particleContainer) == NULL) {
 		Log::global_log->error() << "VTKGridWriter works only with LinkCells!" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 #endif
 }

--- a/src/io/vtk/VTKGridWriter.cpp
+++ b/src/io/vtk/VTKGridWriter.cpp
@@ -36,7 +36,7 @@ void VTKGridWriter::readXML(XMLfileUnits& xmlconfig) {
 	if (_writeFrequency <= 0) {
 		std::ostringstream error_message;
 		error_message << "VTKMoleculeWriter: writeFrequency must be > 0!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -51,7 +51,7 @@ void  VTKGridWriter::endStep(
 	if (container == NULL) {
 		std::ostringstream error_message;
 		error_message << "VTKGridWriter works only with plottable LinkedCells!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 #endif
 
@@ -118,7 +118,7 @@ void  VTKGridWriter::init(ParticleContainer *particleContainer,
 	if (dynamic_cast<LinkedCells*>(particleContainer) == NULL) {
 		std::ostringstream error_message;
 		error_message << "VTKGridWriter works only with LinkCells!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 #endif
 }

--- a/src/io/vtk/VTKMoleculeWriter.cpp
+++ b/src/io/vtk/VTKMoleculeWriter.cpp
@@ -38,7 +38,7 @@ void VTKMoleculeWriter::readXML(XMLfileUnits& xmlconfig) {
 	if (_writeFrequency <= 0) {
 		std::ostringstream error_message;
 		error_message << "VTKMoleculeWriter: writeFrequency must be > 0!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 

--- a/src/io/vtk/VTKMoleculeWriter.cpp
+++ b/src/io/vtk/VTKMoleculeWriter.cpp
@@ -36,7 +36,9 @@ void VTKMoleculeWriter::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "VTKMoleculeWriter: Output prefix: " << _fileName << std::endl;
 
 	if (_writeFrequency <= 0) {
-		Log::global_log->error() << "VTKMoleculeWriter: writeFrequency must be > 0!" << std::endl;
+		std::ostringstream error_message;
+		error_message << "VTKMoleculeWriter: writeFrequency must be > 0!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 

--- a/src/longRange/Homogeneous.cpp
+++ b/src/longRange/Homogeneous.cpp
@@ -83,7 +83,7 @@ void Homogeneous::init() {
 					if (tau1 + tau2 >= _cutoffLJ) {
 						std::ostringstream error_message;
 						error_message << "Error calculating cutoff corrections, rc too small" << std::endl;
-						MARDYN_EXIT(error_message);
+						MARDYN_EXIT(error_message.str());
 					}
 					double eps24;
 					params >> eps24;

--- a/src/longRange/Homogeneous.cpp
+++ b/src/longRange/Homogeneous.cpp
@@ -82,7 +82,7 @@ void Homogeneous::init() {
 					double tau2 = sqrt(xj * xj + yj * yj + zj * zj);
 					if (tau1 + tau2 >= _cutoffLJ) {
 						Log::global_log->error() << "Error calculating cutoff corrections, rc too small" << std::endl;
-						mardyn_exit(1);
+						MARDYN_EXIT(1);
 					}
 					double eps24;
 					params >> eps24;

--- a/src/longRange/Homogeneous.cpp
+++ b/src/longRange/Homogeneous.cpp
@@ -81,8 +81,9 @@ void Homogeneous::init() {
 					double zj = cj.ljcenter(sj).rz();
 					double tau2 = sqrt(xj * xj + yj * yj + zj * zj);
 					if (tau1 + tau2 >= _cutoffLJ) {
-						Log::global_log->error() << "Error calculating cutoff corrections, rc too small" << std::endl;
-						MARDYN_EXIT(1);
+						std::ostringstream error_message;
+						error_message << "Error calculating cutoff corrections, rc too small" << std::endl;
+						MARDYN_EXIT(error_message);
 					}
 					double eps24;
 					params >> eps24;

--- a/src/longRange/Planar.cpp
+++ b/src/longRange/Planar.cpp
@@ -151,7 +151,7 @@ void Planar::init()
 		} else {
 			std::ostringstream error_message;
 			error_message << "Long Range Correction: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 }
@@ -197,13 +197,13 @@ void Planar::readXML(XMLfileUnits& xmlconfig)
 	{
 		std::ostringstream error_message;
 		error_message << "Long Range Correction: Write frequency < 1! Programm exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	if(_nStopWritingProfiles <= _nStartWritingProfiles)
 	{
 		std::ostringstream error_message;
 		error_message << "Long Range Correction: Writing profiles 'stop' <= 'start'! Programm exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	bool bInputIsValid = (bRet1 && bRet2 && bRet3);
 	if(true == bInputIsValid)
@@ -216,7 +216,7 @@ void Planar::readXML(XMLfileUnits& xmlconfig)
 	{
 		std::ostringstream error_message;
 		error_message << "Long Range Correction: Write control parameters not valid! Programm exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 

--- a/src/longRange/Planar.cpp
+++ b/src/longRange/Planar.cpp
@@ -149,8 +149,9 @@ void Planar::init()
 			_subject->registerObserver(this);
 			Log::global_log->info() << "Long Range Correction: Subject registered" << std::endl;
 		} else {
-			Log::global_log->error() << "Long Range Correction: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "Long Range Correction: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 }
@@ -194,13 +195,15 @@ void Planar::readXML(XMLfileUnits& xmlconfig)
 	bool bRet3 = xmlconfig.getNodeValue("writecontrol/stop", _nStopWritingProfiles);
 	if(_nWriteFreqProfiles < 1)
 	{
-		Log::global_log->error() << "Long Range Correction: Write frequency < 1! Programm exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "Long Range Correction: Write frequency < 1! Programm exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	if(_nStopWritingProfiles <= _nStartWritingProfiles)
 	{
-		Log::global_log->error() << "Long Range Correction: Writing profiles 'stop' <= 'start'! Programm exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "Long Range Correction: Writing profiles 'stop' <= 'start'! Programm exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	bool bInputIsValid = (bRet1 && bRet2 && bRet3);
 	if(true == bInputIsValid)
@@ -211,8 +214,9 @@ void Planar::readXML(XMLfileUnits& xmlconfig)
 	}
 	else
 	{
-		Log::global_log->error() << "Long Range Correction: Write control parameters not valid! Programm exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "Long Range Correction: Write control parameters not valid! Programm exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 

--- a/src/longRange/Planar.cpp
+++ b/src/longRange/Planar.cpp
@@ -150,7 +150,7 @@ void Planar::init()
 			Log::global_log->info() << "Long Range Correction: Subject registered" << std::endl;
 		} else {
 			Log::global_log->error() << "Long Range Correction: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 	}
 }
@@ -195,12 +195,12 @@ void Planar::readXML(XMLfileUnits& xmlconfig)
 	if(_nWriteFreqProfiles < 1)
 	{
 		Log::global_log->error() << "Long Range Correction: Write frequency < 1! Programm exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	if(_nStopWritingProfiles <= _nStartWritingProfiles)
 	{
 		Log::global_log->error() << "Long Range Correction: Writing profiles 'stop' <= 'start'! Programm exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	bool bInputIsValid = (bRet1 && bRet2 && bRet3);
 	if(true == bInputIsValid)
@@ -212,7 +212,7 @@ void Planar::readXML(XMLfileUnits& xmlconfig)
 	else
 	{
 		Log::global_log->error() << "Long Range Correction: Write control parameters not valid! Programm exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 }
 

--- a/src/molecules/AutoPasSimpleMolecule.cpp
+++ b/src/molecules/AutoPasSimpleMolecule.cpp
@@ -20,7 +20,7 @@ AutoPasSimpleMolecule::AutoPasSimpleMolecule(unsigned long id, Component* compon
 	} else if (_component != component and component != nullptr) {
 		Log::global_log->warning() << "AutoPasSimpleMolecule can only handle one component" << std::endl;
 		_component = component;
-		// mardyn_exit(32);
+		// MARDYN_EXIT(32);
 	}
 }
 

--- a/src/molecules/AutoPasSimpleMolecule.cpp
+++ b/src/molecules/AutoPasSimpleMolecule.cpp
@@ -20,7 +20,7 @@ AutoPasSimpleMolecule::AutoPasSimpleMolecule(unsigned long id, Component* compon
 	} else if (_component != component and component != nullptr) {
 		Log::global_log->warning() << "AutoPasSimpleMolecule can only handle one component" << std::endl;
 		_component = component;
-		// MARDYN_EXIT(error_message);
+		// MARDYN_EXIT(error_message.str());
 	}
 }
 

--- a/src/molecules/AutoPasSimpleMolecule.cpp
+++ b/src/molecules/AutoPasSimpleMolecule.cpp
@@ -20,7 +20,7 @@ AutoPasSimpleMolecule::AutoPasSimpleMolecule(unsigned long id, Component* compon
 	} else if (_component != component and component != nullptr) {
 		Log::global_log->warning() << "AutoPasSimpleMolecule can only handle one component" << std::endl;
 		_component = component;
-		// MARDYN_EXIT(32);
+		// MARDYN_EXIT(error_message);
 	}
 }
 

--- a/src/molecules/Comp2Param.cpp
+++ b/src/molecules/Comp2Param.cpp
@@ -58,8 +58,9 @@ void Comp2Param::initialize(
 					return {[=](double sigi, double sigj) { return eta * (sigi + sigj); },      // mixingSigma
 							[=](double epsi, double epsj) { return xi * sqrt(epsi * epsj); }};  // mixingEpsilon
 				} else {
-					Log::global_log->error() << "Mixing: Only LB rule supported" << std::endl;
-					MARDYN_EXIT(1);
+					std::ostringstream error_message;
+					error_message << "Mixing: Only LB rule supported" << std::endl;
+					MARDYN_EXIT(error_message);
 					return {};
 				}
 			}();

--- a/src/molecules/Comp2Param.cpp
+++ b/src/molecules/Comp2Param.cpp
@@ -60,7 +60,7 @@ void Comp2Param::initialize(
 				} else {
 					std::ostringstream error_message;
 					error_message << "Mixing: Only LB rule supported" << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 					return {};
 				}
 			}();

--- a/src/molecules/Comp2Param.cpp
+++ b/src/molecules/Comp2Param.cpp
@@ -59,7 +59,7 @@ void Comp2Param::initialize(
 							[=](double epsi, double epsj) { return xi * sqrt(epsi * epsj); }};  // mixingEpsilon
 				} else {
 					Log::global_log->error() << "Mixing: Only LB rule supported" << std::endl;
-					mardyn_exit(1);
+					MARDYN_EXIT(1);
 					return {};
 				}
 			}();

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -78,11 +78,11 @@ void Component::readXML(XMLfileUnits& xmlconfig) {
 		} else if (siteType == "Tersoff") {
 			std::ostringstream error_message;
 			error_message << "Tersoff no longer supported:" << siteType << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		} else {
 			std::ostringstream error_message;
 			error_message << "Unknown site type:" << siteType << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		// go back to initial level, to be consistent, even if no site information is found.
 		xmlconfig.changecurrentnode("..");

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -77,10 +77,10 @@ void Component::readXML(XMLfileUnits& xmlconfig) {
 			addQuadrupole(quadrupoleSite);
 		} else if (siteType == "Tersoff") {
 			Log::global_log->error() << "Tersoff no longer supported:" << siteType << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		} else {
 			Log::global_log->error() << "Unknown site type:" << siteType << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 		// go back to initial level, to be consistent, even if no site information is found.
 		xmlconfig.changecurrentnode("..");

--- a/src/molecules/Component.cpp
+++ b/src/molecules/Component.cpp
@@ -76,11 +76,13 @@ void Component::readXML(XMLfileUnits& xmlconfig) {
 			quadrupoleSite.readXML(xmlconfig);
 			addQuadrupole(quadrupoleSite);
 		} else if (siteType == "Tersoff") {
-			Log::global_log->error() << "Tersoff no longer supported:" << siteType << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "Tersoff no longer supported:" << siteType << std::endl;
+			MARDYN_EXIT(error_message);
 		} else {
-			Log::global_log->error() << "Unknown site type:" << siteType << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "Unknown site type:" << siteType << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		// go back to initial level, to be consistent, even if no site information is found.
 		xmlconfig.changecurrentnode("..");

--- a/src/molecules/MoleculeInterface.cpp
+++ b/src/molecules/MoleculeInterface.cpp
@@ -32,7 +32,7 @@ bool MoleculeInterface::isLessThan(const MoleculeInterface& m2) const {
 			else {
 				std::ostringstream error_message;
 				error_message << "LinkedCells::isFirstParticle: both Particles have the same position" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		}
 	}

--- a/src/molecules/MoleculeInterface.cpp
+++ b/src/molecules/MoleculeInterface.cpp
@@ -31,7 +31,7 @@ bool MoleculeInterface::isLessThan(const MoleculeInterface& m2) const {
 				return false;
 			else {
 				Log::global_log->error() << "LinkedCells::isFirstParticle: both Particles have the same position" << std::endl;
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 			}
 		}
 	}

--- a/src/molecules/MoleculeInterface.cpp
+++ b/src/molecules/MoleculeInterface.cpp
@@ -30,8 +30,9 @@ bool MoleculeInterface::isLessThan(const MoleculeInterface& m2) const {
 			else if (r(0) > m2.r(0))
 				return false;
 			else {
-				Log::global_log->error() << "LinkedCells::isFirstParticle: both Particles have the same position" << std::endl;
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;
+				error_message << "LinkedCells::isFirstParticle: both Particles have the same position" << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 		}
 	}

--- a/src/molecules/mixingrules/MixingRuleBase.cpp
+++ b/src/molecules/mixingrules/MixingRuleBase.cpp
@@ -15,11 +15,13 @@ void MixingRuleBase::readXML(const XMLfileUnits& xmlconfig) {
 
     // catch invalid inputs
 	if (cid1 == cid2) {
-		Log::global_log->error() << "Mixing rules: cid1 and cid2 must not be the same but are both " << cid1 << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Mixing rules: cid1 and cid2 must not be the same but are both " << cid1 << std::endl;
+		MARDYN_EXIT(error_message);
 	} else if (std::min(cid1, cid2) < 0) {
-		Log::global_log->error() << "Mixing rules: cid1 and cid2 must be greater than zero" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Mixing rules: cid1 and cid2 must be greater than zero" << std::endl;
+		MARDYN_EXIT(error_message);
 	} 
 	
 	// Symmetry for mixing rules is assumed

--- a/src/molecules/mixingrules/MixingRuleBase.cpp
+++ b/src/molecules/mixingrules/MixingRuleBase.cpp
@@ -17,11 +17,11 @@ void MixingRuleBase::readXML(const XMLfileUnits& xmlconfig) {
 	if (cid1 == cid2) {
 		std::ostringstream error_message;
 		error_message << "Mixing rules: cid1 and cid2 must not be the same but are both " << cid1 << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	} else if (std::min(cid1, cid2) < 0) {
 		std::ostringstream error_message;
 		error_message << "Mixing rules: cid1 and cid2 must be greater than zero" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	} 
 	
 	// Symmetry for mixing rules is assumed

--- a/src/molecules/mixingrules/MixingRuleBase.cpp
+++ b/src/molecules/mixingrules/MixingRuleBase.cpp
@@ -16,10 +16,10 @@ void MixingRuleBase::readXML(const XMLfileUnits& xmlconfig) {
     // catch invalid inputs
 	if (cid1 == cid2) {
 		Log::global_log->error() << "Mixing rules: cid1 and cid2 must not be the same but are both " << cid1 << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	} else if (std::min(cid1, cid2) < 0) {
 		Log::global_log->error() << "Mixing rules: cid1 and cid2 must be greater than zero" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	} 
 	
 	// Symmetry for mixing rules is assumed

--- a/src/parallel/CollectiveCommunication.h
+++ b/src/parallel/CollectiveCommunication.h
@@ -170,8 +170,9 @@ public:
 							commutative, &agglomeratedTypeAddOperator));
 			break;
 		default:
-			Log::global_log->error()<<"invalid reducetype, aborting." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message<<"invalid reducetype, aborting." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		MPI_CHECK(
@@ -192,8 +193,9 @@ public:
 				op = MPI_MAX;
 				break;
 			default:
-				Log::global_log->error()<<"invalid reducetype, aborting." << std::endl;
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;
+				error_message<<"invalid reducetype, aborting." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			MPI_CHECK(MPI_Allreduce( MPI_IN_PLACE, &_values[i], 1, _types[i], op, _communicator ));
 		}

--- a/src/parallel/CollectiveCommunication.h
+++ b/src/parallel/CollectiveCommunication.h
@@ -172,7 +172,7 @@ public:
 		default:
 			std::ostringstream error_message;
 			error_message<<"invalid reducetype, aborting." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		MPI_CHECK(
@@ -195,7 +195,7 @@ public:
 			default:
 				std::ostringstream error_message;
 				error_message<<"invalid reducetype, aborting." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			MPI_CHECK(MPI_Allreduce( MPI_IN_PLACE, &_values[i], 1, _types[i], op, _communicator ));
 		}

--- a/src/parallel/CollectiveCommunication.h
+++ b/src/parallel/CollectiveCommunication.h
@@ -171,7 +171,7 @@ public:
 			break;
 		default:
 			Log::global_log->error()<<"invalid reducetype, aborting." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 
 		MPI_CHECK(
@@ -193,7 +193,7 @@ public:
 				break;
 			default:
 				Log::global_log->error()<<"invalid reducetype, aborting." << std::endl;
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 			}
 			MPI_CHECK(MPI_Allreduce( MPI_IN_PLACE, &_values[i], 1, _types[i], op, _communicator ));
 		}

--- a/src/parallel/CollectiveCommunicationNonBlocking.h
+++ b/src/parallel/CollectiveCommunicationNonBlocking.h
@@ -39,8 +39,10 @@ public:
 	//! @param numValues number of values that shall be communicated
 	void init(MPI_Comm communicator, int numValues, int key = 0) override {
 		if (_currentKey != -1) {
-			std::ostringstream error_message;			error_message << "CollectiveCommunicationNonBlocking: previous communication with key " << _currentKey
-					<< " not yet finalized" << std::endl;			MARDYN_EXIT(error_message);
+			std::ostringstream error_message;
+			error_message << "CollectiveCommunicationNonBlocking: previous communication with key " << _currentKey
+					<< " not yet finalized" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		_currentKey = key;
@@ -56,8 +58,10 @@ public:
 			// Creates the CollectiveCommunicationSingleNonBlocking object
 			auto [_, inserted] = _comms.try_emplace(_currentKey);
 			if (not inserted) {
-				std::ostringstream error_message;				error_message << "CollectiveCommunicationNonBlocking: key " << _currentKey
-									<< " could not be inserted. Aborting!" << std::endl;				MARDYN_EXIT(error_message);
+				std::ostringstream error_message;
+				error_message << "CollectiveCommunicationNonBlocking: key " << _currentKey
+									<< " could not be inserted. Aborting!" << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 		}
 		_comms.at(_currentKey).init(communicator, numValues, _currentKey);

--- a/src/parallel/CollectiveCommunicationNonBlocking.h
+++ b/src/parallel/CollectiveCommunicationNonBlocking.h
@@ -41,7 +41,7 @@ public:
 		if (_currentKey != -1) {
 			Log::global_log->error() << "CollectiveCommunicationNonBlocking: previous communication with key " << _currentKey
 					<< " not yet finalized" << std::endl;
-			mardyn_exit(234);
+			MARDYN_EXIT(234);
 		}
 
 		_currentKey = key;
@@ -59,7 +59,7 @@ public:
 			if (not inserted) {
 				Log::global_log->error() << "CollectiveCommunicationNonBlocking: key " << _currentKey
 									<< " could not be inserted. Aborting!" << std::endl;
-				mardyn_exit(498789);
+				MARDYN_EXIT(498789);
 			}
 		}
 		_comms.at(_currentKey).init(communicator, numValues, _currentKey);

--- a/src/parallel/CollectiveCommunicationNonBlocking.h
+++ b/src/parallel/CollectiveCommunicationNonBlocking.h
@@ -42,7 +42,7 @@ public:
 			std::ostringstream error_message;
 			error_message << "CollectiveCommunicationNonBlocking: previous communication with key " << _currentKey
 					<< " not yet finalized" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		_currentKey = key;
@@ -61,7 +61,7 @@ public:
 				std::ostringstream error_message;
 				error_message << "CollectiveCommunicationNonBlocking: key " << _currentKey
 									<< " could not be inserted. Aborting!" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		}
 		_comms.at(_currentKey).init(communicator, numValues, _currentKey);

--- a/src/parallel/CollectiveCommunicationNonBlocking.h
+++ b/src/parallel/CollectiveCommunicationNonBlocking.h
@@ -39,9 +39,8 @@ public:
 	//! @param numValues number of values that shall be communicated
 	void init(MPI_Comm communicator, int numValues, int key = 0) override {
 		if (_currentKey != -1) {
-			Log::global_log->error() << "CollectiveCommunicationNonBlocking: previous communication with key " << _currentKey
-					<< " not yet finalized" << std::endl;
-			MARDYN_EXIT(234);
+			std::ostringstream error_message;			error_message << "CollectiveCommunicationNonBlocking: previous communication with key " << _currentKey
+					<< " not yet finalized" << std::endl;			MARDYN_EXIT(error_message);
 		}
 
 		_currentKey = key;
@@ -57,9 +56,8 @@ public:
 			// Creates the CollectiveCommunicationSingleNonBlocking object
 			auto [_, inserted] = _comms.try_emplace(_currentKey);
 			if (not inserted) {
-				Log::global_log->error() << "CollectiveCommunicationNonBlocking: key " << _currentKey
-									<< " could not be inserted. Aborting!" << std::endl;
-				MARDYN_EXIT(498789);
+				std::ostringstream error_message;				error_message << "CollectiveCommunicationNonBlocking: key " << _currentKey
+									<< " could not be inserted. Aborting!" << std::endl;				MARDYN_EXIT(error_message);
 			}
 		}
 		_comms.at(_currentKey).init(communicator, numValues, _currentKey);

--- a/src/parallel/CommunicationPartner.cpp
+++ b/src/parallel/CommunicationPartner.cpp
@@ -196,7 +196,7 @@ void CommunicationPartner::initSend(ParticleContainer* moleculeContainer, const 
 		}
 		default:
 			Log::global_log->error() << "[CommunicationPartner] MessageType unknown!" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 	}
 
 	#ifndef NDEBUG
@@ -600,7 +600,7 @@ void CommunicationPartner::collectLeavingMoleculesFromInvalidParticles(std::vect
 	auto shiftAndAdd = [domain, lowCorner, highCorner, shift, this, &numMolsAlreadyIn](Molecule& m) {
 		if (not m.inBox(lowCorner, highCorner)) {
 			Log::global_log->error() << "trying to remove a particle that is not in the halo region" << std::endl;
-			mardyn_exit(456);
+			MARDYN_EXIT(456);
 		}
 		for (int dim = 0; dim < 3; dim++) {
 			if (shift[dim] != 0) {

--- a/src/parallel/CommunicationPartner.cpp
+++ b/src/parallel/CommunicationPartner.cpp
@@ -197,7 +197,7 @@ void CommunicationPartner::initSend(ParticleContainer* moleculeContainer, const 
 		default:
 			std::ostringstream error_message;
 			error_message << "[CommunicationPartner] MessageType unknown!" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 	}
 
 	#ifndef NDEBUG
@@ -602,7 +602,7 @@ void CommunicationPartner::collectLeavingMoleculesFromInvalidParticles(std::vect
 		if (not m.inBox(lowCorner, highCorner)) {
 			std::ostringstream error_message;
 			error_message << "trying to remove a particle that is not in the halo region" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		for (int dim = 0; dim < 3; dim++) {
 			if (shift[dim] != 0) {

--- a/src/parallel/CommunicationPartner.cpp
+++ b/src/parallel/CommunicationPartner.cpp
@@ -195,8 +195,9 @@ void CommunicationPartner::initSend(ParticleContainer* moleculeContainer, const 
 			break;
 		}
 		default:
-			Log::global_log->error() << "[CommunicationPartner] MessageType unknown!" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "[CommunicationPartner] MessageType unknown!" << std::endl;
+			MARDYN_EXIT(error_message);
 	}
 
 	#ifndef NDEBUG
@@ -599,8 +600,9 @@ void CommunicationPartner::collectLeavingMoleculesFromInvalidParticles(std::vect
 	// it will add the given molecule to _sendBuf with the necessary shift.
 	auto shiftAndAdd = [domain, lowCorner, highCorner, shift, this, &numMolsAlreadyIn](Molecule& m) {
 		if (not m.inBox(lowCorner, highCorner)) {
-			Log::global_log->error() << "trying to remove a particle that is not in the halo region" << std::endl;
-			MARDYN_EXIT(456);
+			std::ostringstream error_message;
+			error_message << "trying to remove a particle that is not in the halo region" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		for (int dim = 0; dim < 3; dim++) {
 			if (shift[dim] != 0) {

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -231,8 +231,9 @@ void DomainDecompBase::handleDomainLeavingParticlesDirect(const HaloRegion& halo
 
 	auto shiftAndAdd = [&moleculeContainer, haloRegion, shift](Molecule& m) {
 		if (not m.inBox(haloRegion.rmin, haloRegion.rmax)) {
-			Log::global_log->error() << "trying to remove a particle that is not in the halo region" << std::endl;
-			MARDYN_EXIT(456);
+			std::ostringstream error_message;
+			error_message << "trying to remove a particle that is not in the halo region" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		for (int dim = 0; dim < 3; dim++) {
 			if (shift[dim] != 0) {

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -233,7 +233,7 @@ void DomainDecompBase::handleDomainLeavingParticlesDirect(const HaloRegion& halo
 		if (not m.inBox(haloRegion.rmin, haloRegion.rmax)) {
 			std::ostringstream error_message;
 			error_message << "trying to remove a particle that is not in the halo region" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		for (int dim = 0; dim < 3; dim++) {
 			if (shift[dim] != 0) {

--- a/src/parallel/DomainDecompBase.cpp
+++ b/src/parallel/DomainDecompBase.cpp
@@ -232,7 +232,7 @@ void DomainDecompBase::handleDomainLeavingParticlesDirect(const HaloRegion& halo
 	auto shiftAndAdd = [&moleculeContainer, haloRegion, shift](Molecule& m) {
 		if (not m.inBox(haloRegion.rmin, haloRegion.rmax)) {
 			Log::global_log->error() << "trying to remove a particle that is not in the halo region" << std::endl;
-			mardyn_exit(456);
+			MARDYN_EXIT(456);
 		}
 		for (int dim = 0; dim < 3; dim++) {
 			if (shift[dim] != 0) {

--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -152,7 +152,7 @@ void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, cons
 	} else {
 		std::ostringstream error_message;
 		error_message << "DomainDecompMPIBase: invalid zonal method specified. Valid values are 'fs', 'es', 'hs', 'mp' and 'nt'" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	Log::global_log->info() << "Using zonal method: " << zonalMethod << std::endl;
 
@@ -168,7 +168,7 @@ void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, cons
 	} else {
 		std::ostringstream error_message;
 		error_message << "DomainDecompMPIBase: invalid NeighbourCommunicationScheme specified. Valid values are 'direct' and 'indirect'" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -200,7 +200,7 @@ void DomainDecompMPIBase::assertIntIdentity(int IX) {
 				std::ostringstream error_message;
 				error_message << "[DomainDecompMPIBase] IX is " << IX << " for rank 0, "
 					<< "but " << recv << " for rank " << i << "." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		}
 		Log::global_log->info() << "IX = " << recv << " for all " << _numProcs << " ranks.\n";
@@ -229,7 +229,7 @@ void DomainDecompMPIBase::assertDisjunctivity(ParticleContainer* moleculeContain
 			if(check.find(m->getID()) != check.end()){
 				std::ostringstream error_message;
 				error_message << "Rank 0 contains a duplicated particle with id " << m->getID() << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			check[m->getID()] = 0;
 		}
@@ -254,7 +254,7 @@ void DomainDecompMPIBase::assertDisjunctivity(ParticleContainer* moleculeContain
 		if (not isOk) {
 			std::ostringstream error_message;
 			error_message << "Aborting because of duplicated particles." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		Log::global_log->info() << "Data consistency checked: No duplicate IDs detected among " << check.size()

--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -151,7 +151,7 @@ void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, cons
 	} else {
 		Log::global_log->error() << "DomainDecompMPIBase: invalid zonal method specified. Valid values are 'fs', 'es', 'hs', 'mp' and 'nt'"
 				<< std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	Log::global_log->info() << "Using zonal method: " << zonalMethod << std::endl;
 
@@ -167,7 +167,7 @@ void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, cons
 	} else {
 		Log::global_log->error() << "DomainDecompMPIBase: invalid NeighbourCommunicationScheme specified. Valid values are 'direct' and 'indirect'"
 				<< std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 }
 

--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -149,9 +149,8 @@ void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, cons
 	} else if(zonalMethod=="nt") {
 		zonalMethodP = new NeutralTerritory();
 	} else {
-		Log::global_log->error() << "DomainDecompMPIBase: invalid zonal method specified. Valid values are 'fs', 'es', 'hs', 'mp' and 'nt'"
-				<< std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;		error_message << "DomainDecompMPIBase: invalid zonal method specified. Valid values are 'fs', 'es', 'hs', 'mp' and 'nt'"
+				<< std::endl;		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info() << "Using zonal method: " << zonalMethod << std::endl;
 
@@ -165,9 +164,8 @@ void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, cons
 		Log::global_log->info() << "DomainDecompMPIBase: Using IndirectCommunicationScheme" << std::endl;
 		_neighbourCommunicationScheme = std::make_unique<IndirectNeighbourCommunicationScheme>(zonalMethodP);
 	} else {
-		Log::global_log->error() << "DomainDecompMPIBase: invalid NeighbourCommunicationScheme specified. Valid values are 'direct' and 'indirect'"
-				<< std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;		error_message << "DomainDecompMPIBase: invalid NeighbourCommunicationScheme specified. Valid values are 'direct' and 'indirect'"
+				<< std::endl;		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -197,7 +195,7 @@ void DomainDecompMPIBase::assertIntIdentity(int IX) {
 			MPI_CHECK(MPI_Recv(&recv, 1, MPI_INT, i, 2 * i + 17, _comm, &s));
 			if (recv != IX) {
 				Log::global_log->error() << "IX is " << IX << " for rank 0, but " << recv << " for rank " << i << ".\n";
-				MPI_Abort(_comm, 911);
+				MPI_Abort(_comm, 911); // TODO FIXME
 			}
 		}
 		Log::global_log->info() << "IX = " << recv << " for all " << _numProcs << " ranks.\n";

--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -196,8 +196,10 @@ void DomainDecompMPIBase::assertIntIdentity(int IX) {
 		for (int i = 1; i < _numProcs; i++) {
 			MPI_CHECK(MPI_Recv(&recv, 1, MPI_INT, i, 2 * i + 17, _comm, &s));
 			if (recv != IX) {
-				Log::global_log->error() << "IX is " << IX << " for rank 0, but " << recv << " for rank " << i << ".\n";
-				MPI_Abort(_comm, 911); // TODO FIXME
+				std::ostringstream error_message;
+				error_message << "[DomainDecompMPIBase] IX is " << IX << " for rank 0, "
+					<< "but " << recv << " for rank " << i << "." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 		}
 		Log::global_log->info() << "IX = " << recv << " for all " << _numProcs << " ranks.\n";
@@ -224,8 +226,9 @@ void DomainDecompMPIBase::assertDisjunctivity(ParticleContainer* moleculeContain
 
 		for (auto m = moleculeContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); m.isValid(); ++m) {
 			if(check.find(m->getID()) != check.end()){
-				Log::global_log->error() << "Rank 0 contains a duplicated particle with id " << m->getID() << std::endl;
-				MPI_Abort(_comm, 1);
+				std::ostringstream error_message;
+				error_message << "Rank 0 contains a duplicated particle with id " << m->getID() << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			check[m->getID()] = 0;
 		}
@@ -248,8 +251,9 @@ void DomainDecompMPIBase::assertDisjunctivity(ParticleContainer* moleculeContain
 			}
 		}
 		if (not isOk) {
-			Log::global_log->error() << "Aborting because of duplicated particles." << std::endl;
-			MPI_Abort(_comm, 1);
+			std::ostringstream error_message;
+			error_message << "Aborting because of duplicated particles." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		Log::global_log->info() << "Data consistency checked: No duplicate IDs detected among " << check.size()

--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -6,6 +6,7 @@
  */
 #include <memory>
 #include <algorithm>
+#include <sstream>
 
 #include "DomainDecompMPIBase.h"
 #include "molecules/Molecule.h"

--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -149,8 +149,9 @@ void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, cons
 	} else if(zonalMethod=="nt") {
 		zonalMethodP = new NeutralTerritory();
 	} else {
-		std::ostringstream error_message;		error_message << "DomainDecompMPIBase: invalid zonal method specified. Valid values are 'fs', 'es', 'hs', 'mp' and 'nt'"
-				<< std::endl;		MARDYN_EXIT(error_message);
+		std::ostringstream error_message;
+		error_message << "DomainDecompMPIBase: invalid zonal method specified. Valid values are 'fs', 'es', 'hs', 'mp' and 'nt'" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info() << "Using zonal method: " << zonalMethod << std::endl;
 
@@ -164,8 +165,9 @@ void DomainDecompMPIBase::setCommunicationScheme(const std::string& scheme, cons
 		Log::global_log->info() << "DomainDecompMPIBase: Using IndirectCommunicationScheme" << std::endl;
 		_neighbourCommunicationScheme = std::make_unique<IndirectNeighbourCommunicationScheme>(zonalMethodP);
 	} else {
-		std::ostringstream error_message;		error_message << "DomainDecompMPIBase: invalid NeighbourCommunicationScheme specified. Valid values are 'direct' and 'indirect'"
-				<< std::endl;		MARDYN_EXIT(error_message);
+		std::ostringstream error_message;
+		error_message << "DomainDecompMPIBase: invalid NeighbourCommunicationScheme specified. Valid values are 'direct' and 'indirect'" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 

--- a/src/parallel/DomainDecomposition.cpp
+++ b/src/parallel/DomainDecomposition.cpp
@@ -32,7 +32,7 @@ void DomainDecomposition::initMPIGridDims() {
 			error_message << "\tbut grid is " << _gridSize[0] << " x " << _gridSize[1] << " x " << _gridSize[2] << std::endl;
 			error_message << "\tresulting in " << numProcsGridSize << " subdomains!" << std::endl;
 			error_message << "\tplease check your input file!" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 
@@ -67,7 +67,7 @@ void DomainDecomposition::prepareNonBlockingStage(bool /*forceRebalancing*/, Par
 		error_message << "nonblocking P2P using separate messages for leaving and halo is currently not "
 							   "supported. Please use the indirect neighbor communication scheme!"
 							<< std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -81,7 +81,7 @@ void DomainDecomposition::finishNonBlockingStage(bool /*forceRebalancing*/, Part
 		std::ostringstream error_message;
 		error_message
 			<< "nonblocking P2P using separate messages for leaving and halo is currently not supported." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 

--- a/src/parallel/DomainDecomposition.cpp
+++ b/src/parallel/DomainDecomposition.cpp
@@ -1,10 +1,13 @@
 #include "DomainDecomposition.h"
 
+#include <sstream>
+
 #include "Domain.h"
 #include "molecules/Molecule.h"
 #include "particleContainer/ParticleContainer.h"
 #include "utils/xmlfileUnits.h"
 #include "utils/Logger.h"
+#include "utils/mardyn_assert.h"
 #include "parallel/NeighbourCommunicationScheme.h"
 #include "parallel/HaloRegion.h"
 #include "ParticleData.h"
@@ -23,12 +26,13 @@ void DomainDecomposition::initMPIGridDims() {
 	{
 		auto numProcsGridSize = _gridSize[0] * _gridSize[1] * _gridSize[2];
 		if (numProcsGridSize != _numProcs and numProcsGridSize != 0) {
-			Log::global_log->error() << "DomainDecomposition: Wrong grid size given!" << std::endl;
-			Log::global_log->error() << "\tnumProcs is " << _numProcs << "," << std::endl;
-			Log::global_log->error() << "\tbut grid is " << _gridSize[0] << " x " << _gridSize[1] << " x " << _gridSize[2] << std::endl;
-			Log::global_log->error() << "\tresulting in " << numProcsGridSize << " subdomains!" << std::endl;
-			Log::global_log->error() << "\tplease check your input file!" << std::endl;
-			MARDYN_EXIT(2134);
+			std::ostringstream error_message;
+			error_message << "DomainDecomposition: Wrong grid size given!" << std::endl;
+			error_message << "\tnumProcs is " << _numProcs << "," << std::endl;
+			error_message << "\tbut grid is " << _gridSize[0] << " x " << _gridSize[1] << " x " << _gridSize[2] << std::endl;
+			error_message << "\tresulting in " << numProcsGridSize << " subdomains!" << std::endl;
+			error_message << "\tplease check your input file!" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 
@@ -59,10 +63,11 @@ void DomainDecomposition::prepareNonBlockingStage(bool /*forceRebalancing*/, Par
 														 LEAVING_AND_HALO_COPIES);
 	} else {
 		// Would first need to send leaving, then halo -> not good for overlapping!
-		Log::global_log->error() << "nonblocking P2P using separate messages for leaving and halo is currently not "
+		std::ostringstream error_message;
+		error_message << "nonblocking P2P using separate messages for leaving and halo is currently not "
 							   "supported. Please use the indirect neighbor communication scheme!"
 							<< std::endl;
-		MARDYN_EXIT(235861);
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -73,9 +78,10 @@ void DomainDecomposition::finishNonBlockingStage(bool /*forceRebalancing*/, Part
 														LEAVING_AND_HALO_COPIES);
 	} else {
 		// Would first need to send leaving, then halo -> not good for overlapping!
-		Log::global_log->error()
+		std::ostringstream error_message;
+		error_message
 			<< "nonblocking P2P using separate messages for leaving and halo is currently not supported." << std::endl;
-		MARDYN_EXIT(235861);
+		MARDYN_EXIT(error_message);
 	}
 }
 

--- a/src/parallel/DomainDecomposition.cpp
+++ b/src/parallel/DomainDecomposition.cpp
@@ -28,7 +28,7 @@ void DomainDecomposition::initMPIGridDims() {
 			Log::global_log->error() << "\tbut grid is " << _gridSize[0] << " x " << _gridSize[1] << " x " << _gridSize[2] << std::endl;
 			Log::global_log->error() << "\tresulting in " << numProcsGridSize << " subdomains!" << std::endl;
 			Log::global_log->error() << "\tplease check your input file!" << std::endl;
-			mardyn_exit(2134);
+			MARDYN_EXIT(2134);
 		}
 	}
 
@@ -62,7 +62,7 @@ void DomainDecomposition::prepareNonBlockingStage(bool /*forceRebalancing*/, Par
 		Log::global_log->error() << "nonblocking P2P using separate messages for leaving and halo is currently not "
 							   "supported. Please use the indirect neighbor communication scheme!"
 							<< std::endl;
-		mardyn_exit(235861);
+		MARDYN_EXIT(235861);
 	}
 }
 
@@ -75,7 +75,7 @@ void DomainDecomposition::finishNonBlockingStage(bool /*forceRebalancing*/, Part
 		// Would first need to send leaving, then halo -> not good for overlapping!
 		Log::global_log->error()
 			<< "nonblocking P2P using separate messages for leaving and halo is currently not supported." << std::endl;
-		mardyn_exit(235861);
+		MARDYN_EXIT(235861);
 	}
 }
 

--- a/src/parallel/ForceHelper.cpp
+++ b/src/parallel/ForceHelper.cpp
@@ -1,6 +1,7 @@
 
 #include "ForceHelper.h"
 
+#include <sstream>
 #include <variant>
 
 #include "utils/mardyn_assert.h"
@@ -37,8 +38,9 @@ std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> addValuesAndGet
 		[&](auto originalIter) {
 			if (not originalIter.isValid()) {
 				// This should not happen
-				std::cout << "Original molecule not usePreviousIterator";
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;
+				error_message << "Original molecule not usePreviousIterator" << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 
 			mardyn_assert(originalIter->getID() == haloMolecule.getID());

--- a/src/parallel/ForceHelper.cpp
+++ b/src/parallel/ForceHelper.cpp
@@ -40,7 +40,7 @@ std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> addValuesAndGet
 				// This should not happen
 				std::ostringstream error_message;
 				error_message << "Original molecule not usePreviousIterator" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 
 			mardyn_assert(originalIter->getID() == haloMolecule.getID());

--- a/src/parallel/ForceHelper.cpp
+++ b/src/parallel/ForceHelper.cpp
@@ -38,7 +38,7 @@ std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> addValuesAndGet
 			if (not originalIter.isValid()) {
 				// This should not happen
 				std::cout << "Original molecule not usePreviousIterator";
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 			}
 
 			mardyn_assert(originalIter->getID() == haloMolecule.getID());

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -61,7 +61,7 @@ void GeneralDomainDecomposition::initializeALL() {
 #else
 	std::ostringstream error_message;
 	error_message << "ALL load balancing library not enabled. Aborting." << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 #endif
 	Log::global_log->info() << "GeneralDomainDecomposition initial box: [" << _boxMin[0] << ", " << _boxMax[0] << "] x ["
 					   << _boxMin[1] << ", " << _boxMax[1] << "] x [" << _boxMin[2] << ", " << _boxMax[2] << "]"
@@ -199,7 +199,7 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 				<< particleContainer->getBoundingBoxMax(2) << "\n"
 				<< "Particle: \n" << *iter
 				<< std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 	particleContainer->clear();
@@ -294,7 +294,7 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 				error_message
 					<< "GeneralDomainDecomposition's gridSize should have three entries if a list is given, but has "
 					<< strings.size() << "!" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			_gridSize = {std::stod(strings[0]), std::stod(strings[1]), std::stod(strings[2])};
 		} else {
@@ -307,7 +307,7 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 				error_message << "GeneralDomainDecomposition's gridSize (" << gridSize
 									<< ") is smaller than the interactionLength (" << _interactionLength
 									<< "). This is forbidden, as it leads to errors! " << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		}
 	}
@@ -325,13 +325,13 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 			std::ostringstream error_message;
 			error_message << "GeneralDomainDecomposition: Unknown load balancer " << loadBalancerString
 								<< ". Aborting! Please select a valid option! Valid options: ALL";
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		_loadBalancer->readXML(xmlconfig);
 	} else {
 		std::ostringstream error_message;
 		error_message << "loadBalancer section missing! Aborting!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	xmlconfig.changecurrentnode("..");
 }

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -59,7 +59,7 @@ void GeneralDomainDecomposition::initializeALL() {
 													  gridCoords, minimalDomainSize);
 #else
 	Log::global_log->error() << "ALL load balancing library not enabled. Aborting." << std::endl;
-	mardyn_exit(24235);
+	MARDYN_EXIT(24235);
 #endif
 	Log::global_log->info() << "GeneralDomainDecomposition initial box: [" << _boxMin[0] << ", " << _boxMax[0] << "] x ["
 					   << _boxMin[1] << ", " << _boxMax[1] << "] x [" << _boxMin[2] << ", " << _boxMax[2] << "]"
@@ -196,7 +196,7 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 				<< particleContainer->getBoundingBoxMax(2) << "\n"
 				<< "Particle: \n" << *iter
 				<< std::endl;
-			mardyn_exit(2315);
+			MARDYN_EXIT(2315);
 		}
 	}
 	particleContainer->clear();
@@ -290,7 +290,7 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 				Log::global_log->error()
 					<< "GeneralDomainDecomposition's gridSize should have three entries if a list is given, but has "
 					<< strings.size() << "!" << std::endl;
-				mardyn_exit(8134);
+				MARDYN_EXIT(8134);
 			}
 			_gridSize = {std::stod(strings[0]), std::stod(strings[1]), std::stod(strings[2])};
 		} else {
@@ -302,7 +302,7 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 				Log::global_log->error() << "GeneralDomainDecomposition's gridSize (" << gridSize
 									<< ") is smaller than the interactionLength (" << _interactionLength
 									<< "). This is forbidden, as it leads to errors! " << std::endl;
-				mardyn_exit(8136);
+				MARDYN_EXIT(8136);
 			}
 		}
 	}
@@ -319,12 +319,12 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			Log::global_log->error() << "GeneralDomainDecomposition: Unknown load balancer " << loadBalancerString
 								<< ". Aborting! Please select a valid option! Valid options: ALL";
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		_loadBalancer->readXML(xmlconfig);
 	} else {
 		Log::global_log->error() << "loadBalancer section missing! Aborting!" << std::endl;
-		mardyn_exit(8466);
+		MARDYN_EXIT(8466);
 	}
 	xmlconfig.changecurrentnode("..");
 }

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include <algorithm>
 #include <tuple>
+#include <sstream>
 
 GeneralDomainDecomposition::GeneralDomainDecomposition(double interactionLength, Domain* domain, bool forceGrid)
 	: _boxMin{0.},
@@ -58,8 +59,9 @@ void GeneralDomainDecomposition::initializeALL() {
 	_loadBalancer = std::make_unique<ALLLoadBalancer>(_boxMin, _boxMax, 4 /*gamma*/, this->getCommunicator(), gridSize,
 													  gridCoords, minimalDomainSize);
 #else
-	Log::global_log->error() << "ALL load balancing library not enabled. Aborting." << std::endl;
-	MARDYN_EXIT(24235);
+	std::ostringstream error_message;
+	error_message << "ALL load balancing library not enabled. Aborting." << std::endl;
+	MARDYN_EXIT(error_message);
 #endif
 	Log::global_log->info() << "GeneralDomainDecomposition initial box: [" << _boxMin[0] << ", " << _boxMax[0] << "] x ["
 					   << _boxMin[1] << ", " << _boxMax[1] << "] x [" << _boxMin[2] << ", " << _boxMax[2] << "]"
@@ -184,7 +186,8 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 		ownMolecules.push_back(*iter);
 		// TODO: This check should be in debug mode only
 		if (not iter->inBox(newMin.data(), newMax.data())) {
-			Log::global_log->error_always_output()
+			std::ostringstream error_message;
+			error_message
 				<< "Particle still in domain that should have been migrated."
 				<< "BoxMin: "
 				<< particleContainer->getBoundingBoxMin(0) << ", "
@@ -196,7 +199,7 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 				<< particleContainer->getBoundingBoxMax(2) << "\n"
 				<< "Particle: \n" << *iter
 				<< std::endl;
-			MARDYN_EXIT(2315);
+			MARDYN_EXIT(error_message);
 		}
 	}
 	particleContainer->clear();
@@ -287,10 +290,11 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 		if (gridSizeString.find(',') != std::string::npos) {
 			auto strings = string_utils::split(gridSizeString, ',');
 			if (strings.size() != 3) {
-				Log::global_log->error()
+				std::ostringstream error_message;
+				error_message
 					<< "GeneralDomainDecomposition's gridSize should have three entries if a list is given, but has "
 					<< strings.size() << "!" << std::endl;
-				MARDYN_EXIT(8134);
+				MARDYN_EXIT(error_message);
 			}
 			_gridSize = {std::stod(strings[0]), std::stod(strings[1]), std::stod(strings[2])};
 		} else {
@@ -299,10 +303,11 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 		}
 		for (auto gridSize : *_gridSize) {
 			if (gridSize < _interactionLength) {
-				Log::global_log->error() << "GeneralDomainDecomposition's gridSize (" << gridSize
+				std::ostringstream error_message;
+				error_message << "GeneralDomainDecomposition's gridSize (" << gridSize
 									<< ") is smaller than the interactionLength (" << _interactionLength
 									<< "). This is forbidden, as it leads to errors! " << std::endl;
-				MARDYN_EXIT(8136);
+				MARDYN_EXIT(error_message);
 			}
 		}
 	}
@@ -317,14 +322,16 @@ void GeneralDomainDecomposition::readXML(XMLfileUnits& xmlconfig) {
 		if (loadBalancerString.find("all") != std::string::npos) {
 			initializeALL();
 		} else {
-			Log::global_log->error() << "GeneralDomainDecomposition: Unknown load balancer " << loadBalancerString
+			std::ostringstream error_message;
+			error_message << "GeneralDomainDecomposition: Unknown load balancer " << loadBalancerString
 								<< ". Aborting! Please select a valid option! Valid options: ALL";
-			MARDYN_EXIT(1);
+			MARDYN_EXIT(error_message);
 		}
 		_loadBalancer->readXML(xmlconfig);
 	} else {
-		Log::global_log->error() << "loadBalancer section missing! Aborting!" << std::endl;
-		MARDYN_EXIT(8466);
+		std::ostringstream error_message;
+		error_message << "loadBalancer section missing! Aborting!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	xmlconfig.changecurrentnode("..");
 }

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -68,7 +68,7 @@ void KDDecomposition::init(Domain* domain){
         Log::global_log->error() << "KDDecomposition not possible. Each process needs at least " << minCellCountPerProc
                             << " cells." << std::endl;
         Log::global_log->error() << "The number of Cells is only sufficient for " << _decompTree->getNumMaxProcs() << " Procs!" << std::endl;
-        mardyn_exit(-1);
+        MARDYN_EXIT(-1);
     }
     _decompTree->buildKDTree();
     _ownArea = _decompTree->findAreaForProcess(_rank);
@@ -104,7 +104,7 @@ void KDDecomposition::readXML(XMLfileUnits& xmlconfig) {
 					   << std::endl;
 	if(KDDStaticValues::minNumCellsPerDimension==0u){
 		Log::global_log->error() << "KDDecomposition minNumCellsPerDimension has to be bigger than zero!" << std::endl;
-		mardyn_exit(43);
+		MARDYN_EXIT(43);
 	}
 	xmlconfig.getNodeValue("updateFrequency", _frequency);
 	Log::global_log->info() << "KDDecomposition update frequency: " << _frequency << std::endl;
@@ -126,7 +126,7 @@ void KDDecomposition::readXML(XMLfileUnits& xmlconfig) {
 			} else {
 				Log::global_log->fatal() << "Wrong deviationReductionOperation given: " << _deviationReductionOperation
 									<< ". Should be 'max' or 'sum'." << std::endl;
-				mardyn_exit(45681);
+				MARDYN_EXIT(45681);
 			}
 		}
 		Log::global_log->info() << "KDDecomposition uses " << deviationReductionOperation
@@ -318,7 +318,7 @@ void KDDecomposition::balanceAndExchange(double lastTraversalTime, bool forceReb
 		if (not migrationSuccessful) {
 			Log::global_log->error() << "A problem occurred during particle migration between old decomposition and new decomposition of the KDDecomposition." << std::endl;
 			Log::global_log->error() << "Aborting. Please save your input files and last available checkpoint and contact TUM SCCS." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		delete _decompTree;
 		_decompTree = newDecompRoot;
@@ -555,7 +555,7 @@ bool KDDecomposition::migrateParticles(const KDNode& newRoot, const KDNode& newO
 void KDDecomposition::fillTimeVecs(CellProcessor **cellProc){
 	if(cellProc == nullptr){
 		Log::global_log->error() << "The cellProcessor was not yet set! Please reorder fillTimeVecs, so that there won't be a problem!";
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	auto _tunerLoadCalc = dynamic_cast<TunerLoad*>(_loadCalc);
 	if(_tunerLoadCalc){
@@ -1025,7 +1025,7 @@ bool KDDecomposition::calculateAllPossibleSubdivisions(KDNode* node, std::list<K
 			if (splitLoad) {  // if we split the load in a specific ratio, numProcsLeft is calculated differently
 				if(_accumulatedProcessorSpeeds.empty()){
 					Log::global_log->error() << "no processor speeds given" << std::endl;
-					mardyn_exit(-1);
+					MARDYN_EXIT(-1);
 				}
 				double optimalLoad = (_accumulatedProcessorSpeeds[node->_owningProc + node->_numProcs] - _accumulatedProcessorSpeeds[node->_owningProc]) * leftRightLoadRatio
 						/ (1. + leftRightLoadRatio);
@@ -1088,7 +1088,7 @@ bool KDDecomposition::calculateAllPossibleSubdivisions(KDNode* node, std::list<K
 					(clone->_child2->_numProcs <= 0 || clone->_child2->_numProcs >= node->_numProcs) ){
 				//continue;
 				Log::global_log->error_always_output() << "ERROR in calculateAllPossibleSubdivisions(), part of the domain was not assigned to a proc" << std::endl;
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 			}
 			mardyn_assert( clone->_child1->isResolvable() && clone->_child2->isResolvable() );
 
@@ -1248,7 +1248,7 @@ void KDDecomposition::calculateCostsPar(KDNode* area, std::vector<std::vector<do
 										break;
 									default:
 										Log::global_log->error() << "[KDDecomposition] zeroCounts too large!" << std::endl;
-										mardyn_exit(1);
+										MARDYN_EXIT(1);
 								}
 							}
 						}
@@ -1433,13 +1433,13 @@ void KDDecomposition::calcNumParticlesPerCell(ParticleContainer* moleculeContain
 
 std::vector<int> KDDecomposition::getNeighbourRanks() {
 	//global_log->error() << "not implemented \n";
-	mardyn_exit(-1);
+	MARDYN_EXIT(-1);
 	return std::vector<int> (0);
 }
 
 std::vector<int> KDDecomposition::getNeighbourRanksFullShell() {
 	//global_log->error() << "not implemented \n";
-	mardyn_exit(-1);
+	MARDYN_EXIT(-1);
 	return std::vector<int> (0);
 }
 
@@ -1773,7 +1773,7 @@ bool KDDecomposition::calculateHeteroSubdivision(KDNode* node, KDNode*& optimalN
 
 	if (costsLeft[biggestDim].size()<=2){
 		Log::global_log->error_always_output() << "The domain is far to small!";
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	int startIndex = 1;
@@ -1817,7 +1817,7 @@ bool KDDecomposition::calculateHeteroSubdivision(KDNode* node, KDNode*& optimalN
 	if ( (unsigned int) (optimalNode->_child1->_numProcs + optimalNode->_child2->_numProcs) >
 	        (optimalNode->_child1->getNumMaxProcs() + optimalNode->_child2->getNumMaxProcs())) {
 		Log::global_log->error() << "Domain is not resolvable at all!" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	while ( (! optimalNode->_child1->isResolvable()) && optimalNode->_child2->isResolvable()) {
@@ -1845,7 +1845,7 @@ bool KDDecomposition::calculateHeteroSubdivision(KDNode* node, KDNode*& optimalN
 			(optimalNode->_child2->_numProcs <= 0 || optimalNode->_child2->_numProcs >= node->_numProcs) ){
 		//continue;
 		Log::global_log->error_always_output() << "ERROR in calculateHeteroSubdivision(), part of the domain was not assigned to a proc" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	mardyn_assert( optimalNode->_child1->isResolvable() && optimalNode->_child2->isResolvable() );
 

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -69,7 +69,7 @@ void KDDecomposition::init(Domain* domain){
         error_message << "KDDecomposition not possible. Each process needs at least "
 						<< minCellCountPerProc << " cells." << std::endl;
         error_message << "The number of Cells is only sufficient for " << _decompTree->getNumMaxProcs() << " Procs!" << std::endl;
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
     _decompTree->buildKDTree();
     _ownArea = _decompTree->findAreaForProcess(_rank);
@@ -106,7 +106,7 @@ void KDDecomposition::readXML(XMLfileUnits& xmlconfig) {
 	if(KDDStaticValues::minNumCellsPerDimension==0u){
 		std::ostringstream error_message;
 		error_message << "KDDecomposition minNumCellsPerDimension has to be bigger than zero!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	xmlconfig.getNodeValue("updateFrequency", _frequency);
 	Log::global_log->info() << "KDDecomposition update frequency: " << _frequency << std::endl;
@@ -129,7 +129,7 @@ void KDDecomposition::readXML(XMLfileUnits& xmlconfig) {
 				std::ostringstream error_message;
 				error_message << "Wrong deviationReductionOperation given: " << _deviationReductionOperation
 									<< ". Should be 'max' or 'sum'." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		}
 		Log::global_log->info() << "KDDecomposition uses " << deviationReductionOperation
@@ -322,7 +322,7 @@ void KDDecomposition::balanceAndExchange(double lastTraversalTime, bool forceReb
 			std::ostringstream error_message;
 			error_message << "A problem occurred during particle migration between old decomposition and new decomposition of the KDDecomposition." << std::endl;
 			error_message << "Aborting. Please save your input files and last available checkpoint and contact TUM SCCS." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		delete _decompTree;
 		_decompTree = newDecompRoot;
@@ -560,7 +560,7 @@ void KDDecomposition::fillTimeVecs(CellProcessor **cellProc){
 	if(cellProc == nullptr){
 		std::ostringstream error_message;
 		error_message << "The cellProcessor was not yet set! Please reorder fillTimeVecs, so that there won't be a problem!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	auto _tunerLoadCalc = dynamic_cast<TunerLoad*>(_loadCalc);
 	if(_tunerLoadCalc){
@@ -1031,7 +1031,7 @@ bool KDDecomposition::calculateAllPossibleSubdivisions(KDNode* node, std::list<K
 				if(_accumulatedProcessorSpeeds.empty()){
 					std::ostringstream error_message;
 					error_message << "no processor speeds given" << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 				double optimalLoad = (_accumulatedProcessorSpeeds[node->_owningProc + node->_numProcs] - _accumulatedProcessorSpeeds[node->_owningProc]) * leftRightLoadRatio
 						/ (1. + leftRightLoadRatio);
@@ -1095,7 +1095,7 @@ bool KDDecomposition::calculateAllPossibleSubdivisions(KDNode* node, std::list<K
 				//continue;
 				std::ostringstream error_message;
 				error_message << "ERROR in calculateAllPossibleSubdivisions(), part of the domain was not assigned to a proc" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			mardyn_assert( clone->_child1->isResolvable() && clone->_child2->isResolvable() );
 
@@ -1256,7 +1256,7 @@ void KDDecomposition::calculateCostsPar(KDNode* area, std::vector<std::vector<do
 									default:
 										std::ostringstream error_message;
 										error_message << "[KDDecomposition] zeroCounts too large!" << std::endl;
-										MARDYN_EXIT(error_message);
+										MARDYN_EXIT(error_message.str());
 								}
 							}
 						}
@@ -1442,14 +1442,14 @@ void KDDecomposition::calcNumParticlesPerCell(ParticleContainer* moleculeContain
 std::vector<int> KDDecomposition::getNeighbourRanks() {
 	std::ostringstream error_message;
 	error_message << "KDDecomposition::getNeighbourRanks() not implemented" << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 	return std::vector<int> (0);
 }
 
 std::vector<int> KDDecomposition::getNeighbourRanksFullShell() {
 	std::ostringstream error_message;
 	error_message << "KDDecomposition::getNeighbourRanksFullShell() not implemented" << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 	return std::vector<int> (0);
 }
 
@@ -1784,7 +1784,7 @@ bool KDDecomposition::calculateHeteroSubdivision(KDNode* node, KDNode*& optimalN
 	if (costsLeft[biggestDim].size()<=2){
 		std::ostringstream error_message;
 		error_message << "The domain is far to small!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	int startIndex = 1;
@@ -1829,7 +1829,7 @@ bool KDDecomposition::calculateHeteroSubdivision(KDNode* node, KDNode*& optimalN
 	        (optimalNode->_child1->getNumMaxProcs() + optimalNode->_child2->getNumMaxProcs())) {
 		std::ostringstream error_message;
 		error_message << "Domain is not resolvable at all!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	while ( (! optimalNode->_child1->isResolvable()) && optimalNode->_child2->isResolvable()) {
@@ -1858,7 +1858,7 @@ bool KDDecomposition::calculateHeteroSubdivision(KDNode* node, KDNode*& optimalN
 		//continue;
 		std::ostringstream error_message;
 		error_message << "ERROR in calculateHeteroSubdivision(), part of the domain was not assigned to a proc" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	mardyn_assert( optimalNode->_child1->isResolvable() && optimalNode->_child2->isResolvable() );
 

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -65,10 +65,11 @@ void KDDecomposition::init(Domain* domain){
     _decompTree = new KDNode(_numProcs, lowCorner, highCorner, 0, 0, coversWholeDomain, 0);
     if (!_decompTree->isResolvable()) {
         auto minCellCountPerProc = std::pow(KDDStaticValues::minNumCellsPerDimension, 3);
-        Log::global_log->error() << "KDDecomposition not possible. Each process needs at least " << minCellCountPerProc
-                            << " cells." << std::endl;
-        Log::global_log->error() << "The number of Cells is only sufficient for " << _decompTree->getNumMaxProcs() << " Procs!" << std::endl;
-        MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+        error_message << "KDDecomposition not possible. Each process needs at least "
+						<< minCellCountPerProc << " cells." << std::endl;
+        error_message << "The number of Cells is only sufficient for " << _decompTree->getNumMaxProcs() << " Procs!" << std::endl;
+        MARDYN_EXIT(error_message);
     }
     _decompTree->buildKDTree();
     _ownArea = _decompTree->findAreaForProcess(_rank);
@@ -103,8 +104,9 @@ void KDDecomposition::readXML(XMLfileUnits& xmlconfig) {
     Log::global_log->info() << "KDDecomposition minNumCellsPerDimension: " << KDDStaticValues::minNumCellsPerDimension
 					   << std::endl;
 	if(KDDStaticValues::minNumCellsPerDimension==0u){
-		Log::global_log->error() << "KDDecomposition minNumCellsPerDimension has to be bigger than zero!" << std::endl;
-		MARDYN_EXIT(43);
+		std::ostringstream error_message;
+		error_message << "KDDecomposition minNumCellsPerDimension has to be bigger than zero!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	xmlconfig.getNodeValue("updateFrequency", _frequency);
 	Log::global_log->info() << "KDDecomposition update frequency: " << _frequency << std::endl;
@@ -124,9 +126,10 @@ void KDDecomposition::readXML(XMLfileUnits& xmlconfig) {
 			} else if (deviationReductionOperation == "max") {
 				_deviationReductionOperation = MPI_MAX;
 			} else {
-				Log::global_log->fatal() << "Wrong deviationReductionOperation given: " << _deviationReductionOperation
+				std::ostringstream error_message;
+				error_message << "Wrong deviationReductionOperation given: " << _deviationReductionOperation
 									<< ". Should be 'max' or 'sum'." << std::endl;
-				MARDYN_EXIT(45681);
+				MARDYN_EXIT(error_message);
 			}
 		}
 		Log::global_log->info() << "KDDecomposition uses " << deviationReductionOperation
@@ -316,9 +319,10 @@ void KDDecomposition::balanceAndExchange(double lastTraversalTime, bool forceReb
 		constructNewTree(newDecompRoot, newOwnLeaf, moleculeContainer);
 		bool migrationSuccessful = migrateParticles(*newDecompRoot, *newOwnLeaf, moleculeContainer, domain);
 		if (not migrationSuccessful) {
-			Log::global_log->error() << "A problem occurred during particle migration between old decomposition and new decomposition of the KDDecomposition." << std::endl;
-			Log::global_log->error() << "Aborting. Please save your input files and last available checkpoint and contact TUM SCCS." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "A problem occurred during particle migration between old decomposition and new decomposition of the KDDecomposition." << std::endl;
+			error_message << "Aborting. Please save your input files and last available checkpoint and contact TUM SCCS." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		delete _decompTree;
 		_decompTree = newDecompRoot;
@@ -554,8 +558,9 @@ bool KDDecomposition::migrateParticles(const KDNode& newRoot, const KDNode& newO
 
 void KDDecomposition::fillTimeVecs(CellProcessor **cellProc){
 	if(cellProc == nullptr){
-		Log::global_log->error() << "The cellProcessor was not yet set! Please reorder fillTimeVecs, so that there won't be a problem!";
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "The cellProcessor was not yet set! Please reorder fillTimeVecs, so that there won't be a problem!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	auto _tunerLoadCalc = dynamic_cast<TunerLoad*>(_loadCalc);
 	if(_tunerLoadCalc){
@@ -1024,8 +1029,9 @@ bool KDDecomposition::calculateAllPossibleSubdivisions(KDNode* node, std::list<K
 			int optNumProcsLeft;
 			if (splitLoad) {  // if we split the load in a specific ratio, numProcsLeft is calculated differently
 				if(_accumulatedProcessorSpeeds.empty()){
-					Log::global_log->error() << "no processor speeds given" << std::endl;
-					MARDYN_EXIT(-1);
+					std::ostringstream error_message;
+					error_message << "no processor speeds given" << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 				double optimalLoad = (_accumulatedProcessorSpeeds[node->_owningProc + node->_numProcs] - _accumulatedProcessorSpeeds[node->_owningProc]) * leftRightLoadRatio
 						/ (1. + leftRightLoadRatio);
@@ -1087,8 +1093,9 @@ bool KDDecomposition::calculateAllPossibleSubdivisions(KDNode* node, std::list<K
 			if ((clone->_child1->_numProcs <= 0 || clone->_child1->_numProcs >= node->_numProcs) ||
 					(clone->_child2->_numProcs <= 0 || clone->_child2->_numProcs >= node->_numProcs) ){
 				//continue;
-				Log::global_log->error_always_output() << "ERROR in calculateAllPossibleSubdivisions(), part of the domain was not assigned to a proc" << std::endl;
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;
+				error_message << "ERROR in calculateAllPossibleSubdivisions(), part of the domain was not assigned to a proc" << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			mardyn_assert( clone->_child1->isResolvable() && clone->_child2->isResolvable() );
 
@@ -1247,8 +1254,9 @@ void KDDecomposition::calculateCostsPar(KDNode* area, std::vector<std::vector<do
 									case 3: //3 zeroes is the cell itself which was already counted
 										break;
 									default:
-										Log::global_log->error() << "[KDDecomposition] zeroCounts too large!" << std::endl;
-										MARDYN_EXIT(1);
+										std::ostringstream error_message;
+										error_message << "[KDDecomposition] zeroCounts too large!" << std::endl;
+										MARDYN_EXIT(error_message);
 								}
 							}
 						}
@@ -1432,14 +1440,16 @@ void KDDecomposition::calcNumParticlesPerCell(ParticleContainer* moleculeContain
 }
 
 std::vector<int> KDDecomposition::getNeighbourRanks() {
-	//global_log->error() << "not implemented \n";
-	MARDYN_EXIT(-1);
+	std::ostringstream error_message;
+	error_message << "KDDecomposition::getNeighbourRanks() not implemented" << std::endl;
+	MARDYN_EXIT(error_message);
 	return std::vector<int> (0);
 }
 
 std::vector<int> KDDecomposition::getNeighbourRanksFullShell() {
-	//global_log->error() << "not implemented \n";
-	MARDYN_EXIT(-1);
+	std::ostringstream error_message;
+	error_message << "KDDecomposition::getNeighbourRanksFullShell() not implemented" << std::endl;
+	MARDYN_EXIT(error_message);
 	return std::vector<int> (0);
 }
 
@@ -1772,8 +1782,9 @@ bool KDDecomposition::calculateHeteroSubdivision(KDNode* node, KDNode*& optimalN
 	size_t biggestDim = maxInd;
 
 	if (costsLeft[biggestDim].size()<=2){
-		Log::global_log->error_always_output() << "The domain is far to small!";
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "The domain is far to small!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	int startIndex = 1;
@@ -1816,8 +1827,9 @@ bool KDDecomposition::calculateHeteroSubdivision(KDNode* node, KDNode*& optimalN
 	optimalNode->split(biggestDim, node->_lowCorner[biggestDim] + i, numProcsLeft);
 	if ( (unsigned int) (optimalNode->_child1->_numProcs + optimalNode->_child2->_numProcs) >
 	        (optimalNode->_child1->getNumMaxProcs() + optimalNode->_child2->getNumMaxProcs())) {
-		Log::global_log->error() << "Domain is not resolvable at all!" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Domain is not resolvable at all!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	while ( (! optimalNode->_child1->isResolvable()) && optimalNode->_child2->isResolvable()) {
@@ -1844,8 +1856,9 @@ bool KDDecomposition::calculateHeteroSubdivision(KDNode* node, KDNode*& optimalN
 	if ((optimalNode->_child1->_numProcs <= 0 || optimalNode->_child1->_numProcs >= node->_numProcs) ||
 			(optimalNode->_child2->_numProcs <= 0 || optimalNode->_child2->_numProcs >= node->_numProcs) ){
 		//continue;
-		Log::global_log->error_always_output() << "ERROR in calculateHeteroSubdivision(), part of the domain was not assigned to a proc" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "ERROR in calculateHeteroSubdivision(), part of the domain was not assigned to a proc" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	mardyn_assert( optimalNode->_child1->isResolvable() && optimalNode->_child2->isResolvable() );
 

--- a/src/parallel/LoadCalc.cpp
+++ b/src/parallel/LoadCalc.cpp
@@ -45,7 +45,7 @@ std::vector<double> TunerLoad::readVec(std::istream& in, int& count1, int& count
 						<< " with a different amounts of elements in the second dimension!" << std::endl;
 				error_message << "This means the files is corrupted. "
 						<< "Please remove it (or disallow the tuner to read from inputfiles) before restarting!" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		}
 	}
@@ -124,28 +124,28 @@ TunerLoad::TunerLoad(int count1, int count2, std::vector<double>&& ownTime, std:
 		std::ostringstream error_message;
 		error_message << "_edgeTime was initialized with the wrong size of " << _ownTime.size()
 				<< " expected: " << _count1 * _count2;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if (_faceTime.size() != size_t(count1 * _count2)) {
 		std::ostringstream error_message;
 		error_message << "_edgeTime was initialized with the wrong size of " << _faceTime.size()
 				<< " expected: " << _count1 * _count2;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if (_edgeTime.size() != size_t(_count1 * _count2)) {
 		std::ostringstream error_message;
 		error_message << "_edgeTime was initialized with the wrong size of " << _edgeTime.size()
 				<< " expected: " << _count1 * _count2;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if (_cornerTime.size() != size_t(_count1 * _count2)) {
 		std::ostringstream error_message;
 		error_message << "_edgeTime was initialized with the wrong size of " << _cornerTime.size()
 				<< " expected: " << _count1 * _count2;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -156,7 +156,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 		std::ostringstream error_message;
 		error_message << "The tunerfile is corrupted! Missing header \"Vectorization Tuner File\"";
 		error_message << "Please remove it or fix it before restarting!";
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	int count1;
@@ -167,7 +167,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 		std::ostringstream error_message;
 		error_message << "The tunerfile is corrupted! Missing Section \"own\"";
 		error_message << "Please remove it or fix it before restarting!";
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	auto ownTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
@@ -176,7 +176,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 		std::ostringstream error_message;
 		error_message<< "The tunerfile is corrupted! Missing Section \"face\"";
 		error_message << "Please remove it or fix it before restarting!";
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	auto faceTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
@@ -185,7 +185,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 		std::ostringstream error_message;
 		error_message << "The tunerfile is corrupted! Missing Section \"edge\"";
 		error_message << "Please remove it or fix it before restarting!";
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	auto edgeTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
@@ -194,7 +194,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 		std::ostringstream error_message;
 		error_message << "The tunerfile is corrupted! Missing Section \"corner\"";
 		error_message << "Please remove it or fix it before restarting!";
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	auto cornerTime = readVec(stream, count1, count2);
 	return TunerLoad { count1, count2, std::move(ownTime), std::move(faceTime), std::move(edgeTime), std::move(

--- a/src/parallel/LoadCalc.cpp
+++ b/src/parallel/LoadCalc.cpp
@@ -46,7 +46,7 @@ std::vector<double> TunerLoad::readVec(std::istream& in, int& count1, int& count
 				Log::global_log->error_always_output()
 						<< "This means the files is corrupted. Please remove it (or disallow the tuner to read from inputfiles) before restarting!"
 						<< std::endl;
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 			}
 		}
 	}
@@ -148,7 +148,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	if (inStr != "Vectorization Tuner File") {
 		Log::global_log->error() << "The tunerfile is corrupted! Missing header \"Vectorization Tuner File\"";
 		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	int count1;
@@ -158,7 +158,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	if (inStr != "own") {
 		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"own\"";
 		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	auto ownTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
@@ -166,7 +166,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	if (inStr != "face") {
 		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"face\"";
 		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	auto faceTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
@@ -174,7 +174,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	if (inStr != "edge") {
 		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"edge\"";
 		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	auto edgeTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
@@ -182,7 +182,7 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	if (inStr != "corner") {
 		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"corner\"";
 		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	auto cornerTime = readVec(stream, count1, count2);
 	return TunerLoad { count1, count2, std::move(ownTime), std::move(faceTime), std::move(edgeTime), std::move(

--- a/src/parallel/LoadCalc.cpp
+++ b/src/parallel/LoadCalc.cpp
@@ -40,13 +40,12 @@ std::vector<double> TunerLoad::readVec(std::istream& in, int& count1, int& count
 			tempCount2 = i;
 		} else {
 			if (i != tempCount2) {
-				Log::global_log->error_always_output()
-						<< "The file contains data of 2D-vectors with a different amounts of elements in the second dimension!"
-						<< std::endl;
-				Log::global_log->error_always_output()
-						<< "This means the files is corrupted. Please remove it (or disallow the tuner to read from inputfiles) before restarting!"
-						<< std::endl;
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;
+				error_message << "The file contains data of 2D-vectors"
+						<< " with a different amounts of elements in the second dimension!" << std::endl;
+				error_message << "This means the files is corrupted. "
+						<< "Please remove it (or disallow the tuner to read from inputfiles) before restarting!" << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 		}
 	}
@@ -122,23 +121,31 @@ TunerLoad::TunerLoad(int count1, int count2, std::vector<double>&& ownTime, std:
 				calcConsts(_cornerTime, false)) {
 
 	if (_ownTime.size() != size_t(_count1 * _count2)) {
-		Log::global_log->error_always_output() << "_edgeTime was initialized with the wrong size of " << _ownTime.size()
+		std::ostringstream error_message;
+		error_message << "_edgeTime was initialized with the wrong size of " << _ownTime.size()
 				<< " expected: " << _count1 * _count2;
+		MARDYN_EXIT(error_message);
 	}
 
 	if (_faceTime.size() != size_t(count1 * _count2)) {
-		Log::global_log->error_always_output() << "_edgeTime was initialized with the wrong size of " << _faceTime.size()
+		std::ostringstream error_message;
+		error_message << "_edgeTime was initialized with the wrong size of " << _faceTime.size()
 				<< " expected: " << _count1 * _count2;
+		MARDYN_EXIT(error_message);
 	}
 
 	if (_edgeTime.size() != size_t(_count1 * _count2)) {
-		Log::global_log->error_always_output() << "_edgeTime was initialized with the wrong size of " << _edgeTime.size()
+		std::ostringstream error_message;
+		error_message << "_edgeTime was initialized with the wrong size of " << _edgeTime.size()
 				<< " expected: " << _count1 * _count2;
+		MARDYN_EXIT(error_message);
 	}
 
 	if (_cornerTime.size() != size_t(_count1 * _count2)) {
-		Log::global_log->error_always_output() << "_edgeTime was initialized with the wrong size of " << _cornerTime.size()
+		std::ostringstream error_message;
+		error_message << "_edgeTime was initialized with the wrong size of " << _cornerTime.size()
 				<< " expected: " << _count1 * _count2;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -146,9 +153,10 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 	std::string inStr { };
 	std::getline(stream, inStr);
 	if (inStr != "Vectorization Tuner File") {
-		Log::global_log->error() << "The tunerfile is corrupted! Missing header \"Vectorization Tuner File\"";
-		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "The tunerfile is corrupted! Missing header \"Vectorization Tuner File\"";
+		error_message << "Please remove it or fix it before restarting!";
+		MARDYN_EXIT(error_message);
 	}
 
 	int count1;
@@ -156,33 +164,37 @@ TunerLoad TunerLoad::read(std::istream& stream) {
 
 	std::getline(stream, inStr);
 	if (inStr != "own") {
-		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"own\"";
-		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "The tunerfile is corrupted! Missing Section \"own\"";
+		error_message << "Please remove it or fix it before restarting!";
+		MARDYN_EXIT(error_message);
 	}
 	auto ownTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
 
 	if (inStr != "face") {
-		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"face\"";
-		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message<< "The tunerfile is corrupted! Missing Section \"face\"";
+		error_message << "Please remove it or fix it before restarting!";
+		MARDYN_EXIT(error_message);
 	}
 	auto faceTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
 
 	if (inStr != "edge") {
-		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"edge\"";
-		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "The tunerfile is corrupted! Missing Section \"edge\"";
+		error_message << "Please remove it or fix it before restarting!";
+		MARDYN_EXIT(error_message);
 	}
 	auto edgeTime = readVec(stream, count1, count2);
 	std::getline(stream, inStr);
 
 	if (inStr != "corner") {
-		Log::global_log->error() << "The tunerfile is corrupted! Missing Section \"corner\"";
-		Log::global_log->error() << "Please remove it or fix it before restarting!";
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "The tunerfile is corrupted! Missing Section \"corner\"";
+		error_message << "Please remove it or fix it before restarting!";
+		MARDYN_EXIT(error_message);
 	}
 	auto cornerTime = readVec(stream, count1, count2);
 	return TunerLoad { count1, count2, std::move(ownTime), std::move(faceTime), std::move(edgeTime), std::move(

--- a/src/parallel/NeighbourCommunicationScheme.cpp
+++ b/src/parallel/NeighbourCommunicationScheme.cpp
@@ -266,7 +266,7 @@ void DirectNeighbourCommunicationScheme::initExchangeMoleculesMPI(ParticleContai
 			neighbour.print(ss);
 			Log::global_log->error_always_output() << ss.str() << std::endl;
 		}
-		mardyn_exit(544);
+		MARDYN_EXIT(544);
 	}
 }
 
@@ -396,7 +396,7 @@ void DirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI(ParticleCo
 				});
 			}
 
-			mardyn_exit(457);
+			MARDYN_EXIT(457);
 		}
 
 	}  // while not allDone
@@ -425,7 +425,7 @@ void NeighbourCommunicationScheme::selectNeighbours(MessageType msgType, bool im
 			Log::global_log->error() << "WRONG type in selectNeighbours - this should not be used for push-pull-partners "
 								   "selectNeighbours method"
 								<< std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 			break;
 	}
 }
@@ -594,7 +594,7 @@ void IndirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI1D(Partic
 			for (int i = 0; i < numNeighbours; ++i) {
 				(*_neighbours)[d][i].deadlockDiagnosticSendRecv();
 			}
-			mardyn_exit(457);
+			MARDYN_EXIT(457);
 		}
 
 	} // while not allDone

--- a/src/parallel/NeighbourCommunicationScheme.cpp
+++ b/src/parallel/NeighbourCommunicationScheme.cpp
@@ -269,7 +269,7 @@ void DirectNeighbourCommunicationScheme::initExchangeMoleculesMPI(ParticleContai
 			neighbour.print(ss);
 			error_message << ss.str() << std::endl;
 		}
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -400,7 +400,7 @@ void DirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI(ParticleCo
 				});
 			}
 
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 	}  // while not allDone
@@ -430,7 +430,7 @@ void NeighbourCommunicationScheme::selectNeighbours(MessageType msgType, bool im
 			error_message << "WRONG type in selectNeighbours - this should not be used for push-pull-partners "
 								   "selectNeighbours method"
 								<< std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 			break;
 	}
 }
@@ -600,7 +600,7 @@ void IndirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI1D(Partic
 			for (int i = 0; i < numNeighbours; ++i) {
 				(*_neighbours)[d][i].deadlockDiagnosticSendRecv();
 			}
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 	} // while not allDone

--- a/src/parallel/NeighbourCommunicationScheme.cpp
+++ b/src/parallel/NeighbourCommunicationScheme.cpp
@@ -8,7 +8,9 @@ class NeighbourCommunicationScheme;
 class DirectNeighbourCommunicationScheme;
 class IndirectNeighbourCommunicationScheme;
 
+#include <sstream>
 #include <mpi.h>
+
 #include "NeighbourCommunicationScheme.h"
 #include "Domain.h"
 #include "Simulation.h"
@@ -246,7 +248,8 @@ void DirectNeighbourCommunicationScheme::initExchangeMoleculesMPI(ParticleContai
 		}
 	}
 	if(not invalidParticles.empty()){
-		Log::global_log->error_always_output() << "NeighbourCommunicationScheme: Invalid particles that should have been "
+		std::ostringstream error_message;
+		error_message << "NeighbourCommunicationScheme: Invalid particles that should have been "
 											 "sent, are still existent. They would be lost. Aborting...\n"
 										  << "BoxMin: "
 										  << moleculeContainer->getBoundingBoxMin(0) << ", "
@@ -258,15 +261,15 @@ void DirectNeighbourCommunicationScheme::initExchangeMoleculesMPI(ParticleContai
 										  << moleculeContainer->getBoundingBoxMax(2) << "\n"
 										  << "The particles:" << std::endl;
 		for (auto& invalidParticle : invalidParticles) {
-			Log::global_log->error_always_output() << invalidParticle << std::endl;
+			error_message << invalidParticle << std::endl;
 		}
-		Log::global_log->error_always_output() << "The leavingExportNeighbours:" << std::endl;
+		error_message << "The leavingExportNeighbours:" << std::endl;
 		for (auto& neighbour : (*_leavingExportNeighbours)[0]) {
 			std::stringstream ss;
 			neighbour.print(ss);
-			Log::global_log->error_always_output() << ss.str() << std::endl;
+			error_message << ss.str() << std::endl;
 		}
-		MARDYN_EXIT(544);
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -377,7 +380,8 @@ void DirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI(ParticleCo
 		}
 
 		if (waitingTime > deadlockTimeOut) {
-			Log::global_log->error()
+			std::ostringstream error_message;
+			error_message
 				<< "DirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI1d: Deadlock error: Rank "
 				<< domainDecomp->getRank() << " is waiting for more than " << deadlockTimeOut << " seconds"
 				<< std::endl;
@@ -396,7 +400,7 @@ void DirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI(ParticleCo
 				});
 			}
 
-			MARDYN_EXIT(457);
+			MARDYN_EXIT(error_message);
 		}
 
 	}  // while not allDone
@@ -422,10 +426,11 @@ void NeighbourCommunicationScheme::selectNeighbours(MessageType msgType, bool im
 			else _neighbours = _haloImportForceExportNeighbours;
 			break;
 		case LEAVING_AND_HALO_COPIES:
-			Log::global_log->error() << "WRONG type in selectNeighbours - this should not be used for push-pull-partners "
+			std::ostringstream error_message;
+			error_message << "WRONG type in selectNeighbours - this should not be used for push-pull-partners "
 								   "selectNeighbours method"
 								<< std::endl;
-			MARDYN_EXIT(1);
+			MARDYN_EXIT(error_message);
 			break;
 	}
 }
@@ -587,14 +592,15 @@ void IndirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI1D(Partic
 		}
 
 		if (waitingTime > deadlockTimeOut) {
-			Log::global_log->error()
+			std::ostringstream error_message;
+			error_message
 					<< "IndirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI1d: Deadlock error: Rank "
 					<< domainDecomp->getRank() << " is waiting for more than " << deadlockTimeOut << " seconds"
 					<< std::endl;
 			for (int i = 0; i < numNeighbours; ++i) {
 				(*_neighbours)[d][i].deadlockDiagnosticSendRecv();
 			}
-			MARDYN_EXIT(457);
+			MARDYN_EXIT(error_message);
 		}
 
 	} // while not allDone

--- a/src/parallel/ParticleDataRMM.cpp
+++ b/src/parallel/ParticleDataRMM.cpp
@@ -29,8 +29,9 @@ void ParticleDataRMM::getMPIType(MPI_Datatype &sendPartType) {
 	} else if (sizeof(pdata_dummy.r[0]) == 4) {  // 4 bytes for single
 		types[1] = MPI_FLOAT;
 	} else {
-		Log::global_log->error() << "invalid size of vcp_real_calc";
-		MARDYN_EXIT(4852);
+		std::ostringstream error_message;
+		error_message << "invalid size of vcp_real_calc";
+		MARDYN_EXIT(error_message);
 	}
 
 	//if the following statement is not true, then the 6 double values do not follow one after the other.

--- a/src/parallel/ParticleDataRMM.cpp
+++ b/src/parallel/ParticleDataRMM.cpp
@@ -30,7 +30,7 @@ void ParticleDataRMM::getMPIType(MPI_Datatype &sendPartType) {
 		types[1] = MPI_FLOAT;
 	} else {
 		Log::global_log->error() << "invalid size of vcp_real_calc";
-		mardyn_exit(4852);
+		MARDYN_EXIT(4852);
 	}
 
 	//if the following statement is not true, then the 6 double values do not follow one after the other.

--- a/src/parallel/ParticleDataRMM.cpp
+++ b/src/parallel/ParticleDataRMM.cpp
@@ -31,7 +31,7 @@ void ParticleDataRMM::getMPIType(MPI_Datatype &sendPartType) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "invalid size of vcp_real_calc";
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	//if the following statement is not true, then the 6 double values do not follow one after the other.

--- a/src/parallel/StaticIrregDomainDecomposition.cpp
+++ b/src/parallel/StaticIrregDomainDecomposition.cpp
@@ -75,7 +75,7 @@ void StaticIrregDomainDecomposition::readXML(XMLfileUnits &xmlconfig) {
                 << " axis have a non-natural number! Only integer weights > "
                    "0 allowed, please check XML file!"
                 << std::endl;
-            MARDYN_EXIT(error_message);
+            MARDYN_EXIT(error_message.str());
           }
           _subdomainWeights[i].push_back(temp);
           if (ss.peek() == ',' || ss.peek() == ' ') // skip commas and spaces

--- a/src/parallel/StaticIrregDomainDecomposition.cpp
+++ b/src/parallel/StaticIrregDomainDecomposition.cpp
@@ -74,7 +74,7 @@ void StaticIrregDomainDecomposition::readXML(XMLfileUnits &xmlconfig) {
                 << " axis have a non-natural number! Only integer weights > "
                    "0 allowed, please check XML file!"
                 << std::endl;
-            mardyn_exit(5003);
+            MARDYN_EXIT(5003);
           }
           _subdomainWeights[i].push_back(temp);
           if (ss.peek() == ',' || ss.peek() == ' ') // skip commas and spaces

--- a/src/parallel/StaticIrregDomainDecomposition.cpp
+++ b/src/parallel/StaticIrregDomainDecomposition.cpp
@@ -69,12 +69,13 @@ void StaticIrregDomainDecomposition::readXML(XMLfileUnits &xmlconfig) {
           // We check for this failure, and additionally check for positive
           // integer
           if (!(ss >> temp) || temp <= 0) {
-            Log::global_log->fatal()
+            std::ostringstream error_message;
+            error_message
                 << "Weights in " << axes.at(i)
                 << " axis have a non-natural number! Only integer weights > "
                    "0 allowed, please check XML file!"
                 << std::endl;
-            MARDYN_EXIT(5003);
+            MARDYN_EXIT(error_message);
           }
           _subdomainWeights[i].push_back(temp);
           if (ss.peek() == ',' || ss.peek() == ' ') // skip commas and spaces

--- a/src/parallel/tests/KDDecompositionTest.cpp
+++ b/src/parallel/tests/KDDecompositionTest.cpp
@@ -13,6 +13,7 @@
 #include "particleContainer/LinkedCells.h"
 #include "io/ASCIIReader.h"
 #include "parallel/NeighbourCommunicationScheme.h"
+#include <utils/mardyn_assert.h>
 
 #include <sstream>
 #include <cmath>
@@ -415,9 +416,11 @@ void KDDecompositionTest::testRebalancingDeadlocks() {
 		kdd->barrier();
 
 		ASSERT_TRUE_MSG("Deadlock!", isOK);
-		if (not isOK)
-			MPI_Abort(MPI_COMM_WORLD, 1);
-
+		if (not isOK) {
+			std::ostringstream error_message;
+			error_message << "[KDDecompositionTest] Deadlock detected." << std::endl;
+			MARDYN_EXIT(error_message);
+		}
 		delete kdd->_decompTree;
 		kdd->_decompTree = newDecompRoot;
 		kdd->_ownArea = newOwnLeaf;

--- a/src/parallel/tests/KDDecompositionTest.cpp
+++ b/src/parallel/tests/KDDecompositionTest.cpp
@@ -419,7 +419,7 @@ void KDDecompositionTest::testRebalancingDeadlocks() {
 		if (not isOK) {
 			std::ostringstream error_message;
 			error_message << "[KDDecompositionTest] Deadlock detected." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		delete kdd->_decompTree;
 		kdd->_decompTree = newDecompRoot;

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -7,6 +7,7 @@
 #include <particleContainer/adapter/LegacyCellProcessor.h>
 #include <particleContainer/adapter/VectorizedCellProcessor.h>
 #include <exception>
+#include <sstream>
 #include "Domain.h"
 #include "Simulation.h"
 #include "utils/mardyn_assert.h"
@@ -183,11 +184,12 @@ auto parseAutoPasOption(XMLfileUnits &xmlconfig, const std::string &xmlString,
 	try {
 		return OptionType::template parseOptions<OutputContainer>(stringInXml);
 	} catch (const std::exception &e) {
-		Log::global_log->error() << "AutoPasContainer: error when parsing " << xmlString << ":" << std::endl;
-		Log::global_log->error() << e.what() << std::endl;
-		Log::global_log->error() << "Possible options: "
+		std::ostringstream error_message;
+		error_message << "AutoPasContainer: error when parsing " << xmlString << ":" << std::endl;
+		error_message << e.what() << std::endl;
+		error_message << "Possible options: "
 							<< autopas::utils::ArrayUtils::to_string(OptionType::getAllOptions()) << std::endl;
-		MARDYN_EXIT(4432);
+		MARDYN_EXIT(error_message);
 		// dummy return
 		return decltype(OptionType::template parseOptions<OutputContainer>(""))();
 	}
@@ -240,7 +242,9 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 	} else if (vlSkinPerTimestep == -1 ){
 		_verletSkin = vlSkin;
 	} else {
-		Log::global_log->error() << "Input XML specifies skin AND skinPerTimestep. Please choose only one." << std::endl;
+		std::ostringstream error_message;
+		error_message << "Input XML specifies skin AND skinPerTimestep. Please choose only one." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	_relativeOptimumRange = xmlconfig.getNodeValue_double("optimumRange", _relativeOptimumRange);
 	_relativeBlacklistRange = xmlconfig.getNodeValue_double("blacklistRange", _relativeBlacklistRange);
@@ -394,12 +398,13 @@ bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {
 void AutoPasContainer::update() {
 	// in case we update the container before handling the invalid particles, this might lead to lost particles.
 	if (not _invalidParticles.empty()) {
-		Log::global_log->error() << "AutoPasContainer: trying to update container, even though invalidParticles still "
+		std::ostringstream error_message;
+		error_message << "AutoPasContainer: trying to update container, even though invalidParticles still "
 							   "exist. This would lead to lost particles => ERROR!\n"
 							   "Remaining invalid particles:\n"
 							<< autopas::utils::ArrayUtils::to_string(_invalidParticles, "\n", {"", ""})
 							<< std::endl;
-		MARDYN_EXIT(434);
+		MARDYN_EXIT(error_message);
 	}
 
 	_invalidParticles = _autopasContainer.updateContainer();

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -189,7 +189,7 @@ auto parseAutoPasOption(XMLfileUnits &xmlconfig, const std::string &xmlString,
 		error_message << e.what() << std::endl;
 		error_message << "Possible options: "
 							<< autopas::utils::ArrayUtils::to_string(OptionType::getAllOptions()) << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 		// dummy return
 		return decltype(OptionType::template parseOptions<OutputContainer>(""))();
 	}
@@ -244,7 +244,7 @@ void AutoPasContainer::readXML(XMLfileUnits &xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "Input XML specifies skin AND skinPerTimestep. Please choose only one." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	_relativeOptimumRange = xmlconfig.getNodeValue_double("optimumRange", _relativeOptimumRange);
 	_relativeBlacklistRange = xmlconfig.getNodeValue_double("blacklistRange", _relativeBlacklistRange);
@@ -404,7 +404,7 @@ void AutoPasContainer::update() {
 							   "Remaining invalid particles:\n"
 							<< autopas::utils::ArrayUtils::to_string(_invalidParticles, "\n", {"", ""})
 							<< std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	_invalidParticles = _autopasContainer.updateContainer();

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -187,7 +187,7 @@ auto parseAutoPasOption(XMLfileUnits &xmlconfig, const std::string &xmlString,
 		Log::global_log->error() << e.what() << std::endl;
 		Log::global_log->error() << "Possible options: "
 							<< autopas::utils::ArrayUtils::to_string(OptionType::getAllOptions()) << std::endl;
-		mardyn_exit(4432);
+		MARDYN_EXIT(4432);
 		// dummy return
 		return decltype(OptionType::template parseOptions<OutputContainer>(""))();
 	}
@@ -399,7 +399,7 @@ void AutoPasContainer::update() {
 							   "Remaining invalid particles:\n"
 							<< autopas::utils::ArrayUtils::to_string(_invalidParticles, "\n", {"", ""})
 							<< std::endl;
-		mardyn_exit(434);
+		MARDYN_EXIT(434);
 	}
 
 	_invalidParticles = _autopasContainer.updateContainer();

--- a/src/particleContainer/LinkedCellTraversals/C08CellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/C08CellPairTraversal.h
@@ -80,7 +80,7 @@ void C08CellPairTraversal<CellTemplate, eighthShell>::traverseCellPairsOuter(
 	if(eighthShell){
 		std::ostringstream error_message;
 		error_message << "eightshell + overlapping not yet supported." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	using std::array;
 

--- a/src/particleContainer/LinkedCellTraversals/C08CellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/C08CellPairTraversal.h
@@ -79,7 +79,7 @@ void C08CellPairTraversal<CellTemplate, eighthShell>::traverseCellPairsOuter(
 		CellProcessor& cellProcessor) {
 	if(eighthShell){
 		Log::global_log->error() << "eightshell + overlapping not yet supported." << std::endl;
-		mardyn_exit(-2);
+		MARDYN_EXIT(-2);
 	}
 	using std::array;
 

--- a/src/particleContainer/LinkedCellTraversals/C08CellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/C08CellPairTraversal.h
@@ -78,8 +78,9 @@ template<class CellTemplate, bool eighthShell>
 void C08CellPairTraversal<CellTemplate, eighthShell>::traverseCellPairsOuter(
 		CellProcessor& cellProcessor) {
 	if(eighthShell){
-		Log::global_log->error() << "eightshell + overlapping not yet supported." << std::endl;
-		MARDYN_EXIT(-2);
+		std::ostringstream error_message;
+		error_message << "eightshell + overlapping not yet supported." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	using std::array;
 

--- a/src/particleContainer/LinkedCellTraversals/NeutralTerritoryTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/NeutralTerritoryTraversal.h
@@ -125,14 +125,14 @@ void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairs(CellProcessor& c
 template <class CellTemplate>
 void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairsOuter(CellProcessor& cellProcessor) {
 	Log::global_log->error() << "NT: overlapping Comm not implemented." << std::endl;
-	mardyn_exit(46);
+	MARDYN_EXIT(46);
 }
 
 template <class CellTemplate>
 void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairsInner(CellProcessor& cellProcessor, unsigned stage,
 																	 unsigned stageCount) {
 	Log::global_log->error() << "NT: overlapping Comm not implemented." << std::endl;
-	mardyn_exit(47);
+	MARDYN_EXIT(47);
 }
 
 template <class CellTemplate>

--- a/src/particleContainer/LinkedCellTraversals/NeutralTerritoryTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/NeutralTerritoryTraversal.h
@@ -126,7 +126,7 @@ template <class CellTemplate>
 void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairsOuter(CellProcessor& cellProcessor) {
 	std::ostringstream error_message;
 	error_message << "NT: overlapping Comm not implemented." << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 }
 
 template <class CellTemplate>
@@ -134,7 +134,7 @@ void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairsInner(CellProcess
 																	 unsigned stageCount) {
 	std::ostringstream error_message;
 	error_message << "NT: overlapping Comm not implemented." << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 }
 
 template <class CellTemplate>

--- a/src/particleContainer/LinkedCellTraversals/NeutralTerritoryTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/NeutralTerritoryTraversal.h
@@ -124,15 +124,17 @@ void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairs(CellProcessor& c
 
 template <class CellTemplate>
 void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairsOuter(CellProcessor& cellProcessor) {
-	Log::global_log->error() << "NT: overlapping Comm not implemented." << std::endl;
-	MARDYN_EXIT(46);
+	std::ostringstream error_message;
+	error_message << "NT: overlapping Comm not implemented." << std::endl;
+	MARDYN_EXIT(error_message);
 }
 
 template <class CellTemplate>
 void NeutralTerritoryTraversal<CellTemplate>::traverseCellPairsInner(CellProcessor& cellProcessor, unsigned stage,
 																	 unsigned stageCount) {
-	Log::global_log->error() << "NT: overlapping Comm not implemented." << std::endl;
-	MARDYN_EXIT(47);
+	std::ostringstream error_message;
+	error_message << "NT: overlapping Comm not implemented." << std::endl;
+	MARDYN_EXIT(error_message);
 }
 
 template <class CellTemplate>

--- a/src/particleContainer/LinkedCellTraversals/OriginalCellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/OriginalCellPairTraversal.h
@@ -76,7 +76,7 @@ void OriginalCellPairTraversal<CellTemplate>::rebuild(std::vector<CellTemplate> 
 	} else {
 		std::ostringstream error_message;
 		error_message << "OriginalCellPairTraversalDat::rebuild was called with incompatible Traversal data!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 

--- a/src/particleContainer/LinkedCellTraversals/OriginalCellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/OriginalCellPairTraversal.h
@@ -75,7 +75,7 @@ void OriginalCellPairTraversal<CellTemplate>::rebuild(std::vector<CellTemplate> 
 		}
 	} else {
 		Log::global_log->error() << "OriginalCellPairTraversalDat::rebuild was called with incompatible Traversal data!" << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 }
 

--- a/src/particleContainer/LinkedCellTraversals/OriginalCellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/OriginalCellPairTraversal.h
@@ -74,8 +74,9 @@ void OriginalCellPairTraversal<CellTemplate>::rebuild(std::vector<CellTemplate> 
 			}
 		}
 	} else {
-		Log::global_log->error() << "OriginalCellPairTraversalDat::rebuild was called with incompatible Traversal data!" << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "OriginalCellPairTraversalDat::rebuild was called with incompatible Traversal data!" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 

--- a/src/particleContainer/LinkedCellTraversals/QuickschedTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/QuickschedTraversal.h
@@ -108,10 +108,11 @@ void QuickschedTraversal<CellTemplate>::init() {
             // check that blocksize is within domain size
             for (int i = 0; i < 3; ++i) {
                 if (_taskBlocksize[i] > this->_dims[i]) {
-                    Log::global_log->error() << "Blocksize is bigger than number of cells in dimension "
+                    std::ostringstream error_message;
+                    error_message << "Blocksize is bigger than number of cells in dimension "
                                         << (char) ('x' + i) << ". (" << _taskBlocksize[i] << " > "
                                         << this->_dims[i] << ")" << std::endl;
-                    MARDYN_EXIT(1);
+                    MARDYN_EXIT(error_message);
                 }
             }
 
@@ -175,8 +176,7 @@ void QuickschedTraversal<CellTemplate>::init() {
             break;
         } /* end case PackedAdjustable */
         default:
-            Log::global_log->error() << "QuickschedHandler::init() received non existing task type!"
-                                << std::endl;
+            Log::global_log->error() << "QuickschedHandler::init() received non existing task type!" << std::endl;
     }
 #endif // QUICKSCHED
 }

--- a/src/particleContainer/LinkedCellTraversals/QuickschedTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/QuickschedTraversal.h
@@ -111,7 +111,7 @@ void QuickschedTraversal<CellTemplate>::init() {
                     Log::global_log->error() << "Blocksize is bigger than number of cells in dimension "
                                         << (char) ('x' + i) << ". (" << _taskBlocksize[i] << " > "
                                         << this->_dims[i] << ")" << std::endl;
-                    mardyn_exit(1);
+                    MARDYN_EXIT(1);
                 }
             }
 

--- a/src/particleContainer/LinkedCellTraversals/QuickschedTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/QuickschedTraversal.h
@@ -112,7 +112,7 @@ void QuickschedTraversal<CellTemplate>::init() {
                     error_message << "Blocksize is bigger than number of cells in dimension "
                                         << (char) ('x' + i) << ". (" << _taskBlocksize[i] << " > "
                                         << this->_dims[i] << ")" << std::endl;
-                    MARDYN_EXIT(error_message);
+                    MARDYN_EXIT(error_message.str());
                 }
             }
 

--- a/src/particleContainer/LinkedCellTraversals/SlicedCellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/SlicedCellPairTraversal.h
@@ -192,7 +192,7 @@ inline void SlicedCellPairTraversal<CellTemplate>::traverseCellPairsBackend(
 	if (not isApplicable(start, end) ) {
 		std::ostringstream error_message;
 		error_message << "The SlicedCellPairTraversal is not applicable. Aborting." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	std::array<unsigned long, 3> diff;

--- a/src/particleContainer/LinkedCellTraversals/SlicedCellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/SlicedCellPairTraversal.h
@@ -191,7 +191,7 @@ inline void SlicedCellPairTraversal<CellTemplate>::traverseCellPairsBackend(
 	// Note: in the following we quasi-reimplement an OpenMP for-loop parallelisation with static scheduling
 	if (not isApplicable(start, end) ) {
 		Log::global_log->error() << "The SlicedCellPairTraversal is not applicable. Aborting." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	std::array<unsigned long, 3> diff;

--- a/src/particleContainer/LinkedCellTraversals/SlicedCellPairTraversal.h
+++ b/src/particleContainer/LinkedCellTraversals/SlicedCellPairTraversal.h
@@ -190,8 +190,9 @@ inline void SlicedCellPairTraversal<CellTemplate>::traverseCellPairsBackend(
 
 	// Note: in the following we quasi-reimplement an OpenMP for-loop parallelisation with static scheduling
 	if (not isApplicable(start, end) ) {
-		Log::global_log->error() << "The SlicedCellPairTraversal is not applicable. Aborting." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "The SlicedCellPairTraversal is not applicable. Aborting." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	std::array<unsigned long, 3> diff;

--- a/src/particleContainer/LinkedCells.cpp
+++ b/src/particleContainer/LinkedCells.cpp
@@ -83,19 +83,19 @@ LinkedCells::LinkedCells(double bBoxMin[3], double bBoxMax[3],
 	if (_boxWidthInNumCells[0] < 2 * _haloWidthInNumCells[0]
 			|| _boxWidthInNumCells[1] < 2 * _haloWidthInNumCells[1]
 			|| _boxWidthInNumCells[2] < 2 * _haloWidthInNumCells[2]) {
-		Log::global_log->error_always_output()
-				<< "LinkedCells (constructor): bounding box too small for calculated cell length"
+		std::ostringstream error_message;
+		error_message << "LinkedCells (constructor): bounding box too small for calculated cell length"
 				<< std::endl;
-		Log::global_log->error_always_output() << "_cellsPerDimension: " << _cellsPerDimension[0]
+		error_message << "_cellsPerDimension: " << _cellsPerDimension[0]
 				<< " / " << _cellsPerDimension[1] << " / "
 				<< _cellsPerDimension[2] << std::endl;
-		Log::global_log->error_always_output() << "_haloWidthInNumCells: "
+		error_message << "_haloWidthInNumCells: "
 				<< _haloWidthInNumCells[0] << " / " << _haloWidthInNumCells[1]
 				<< " / " << _haloWidthInNumCells[2] << std::endl;
-		Log::global_log->error_always_output() << "_boxWidthInNumCells: " << _boxWidthInNumCells[0]
+		error_message << "_boxWidthInNumCells: " << _boxWidthInNumCells[0]
 				<< " / " << _boxWidthInNumCells[1] << " / "
 				<< _boxWidthInNumCells[2] << std::endl;
-		MARDYN_EXIT(5);
+		MARDYN_EXIT(error_message);
 	}
 
 	initializeCells();
@@ -155,8 +155,9 @@ bool LinkedCells::rebuild(double bBoxMin[3], double bBoxMax[3]) {
 
 		// in each dimension at least one layer of (inner+boundary) cells necessary
 		if (_cellsPerDimension[dim] == 2 * _haloWidthInNumCells[dim]) {
-			Log::global_log->error_always_output() << "LinkedCells::rebuild: region too small" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "LinkedCells::rebuild: region too small" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		numberOfCells *= _cellsPerDimension[dim];
@@ -224,16 +225,17 @@ void LinkedCells::check_molecules_in_box() {
 	}
 
 	if (numBadMolecules > 0) {
-		Log::global_log->error() << "Found " << numBadMolecules << " outside of bounding box:" << std::endl;
+		std::ostringstream error_message;
+		error_message << "Found " << numBadMolecules << " outside of bounding box:" << std::endl;
 		for (auto & m : badMolecules) {
-			Log::global_log->error() << "Particle (id=" << m.getID() << "), (current position: x="
+			error_message << "Particle (id=" << m.getID() << "), (current position: x="
 					<< m.r(0) << ", y=" << m.r(1) << ", z=" << m.r(2) << ")" << std::endl;
 		}
-		Log::global_log->error() << "The bounding box is: [" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMax[0]
+		error_message << "The bounding box is: [" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMax[0]
 				<< ") x [" << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMax[1] << ") x [" << _haloBoundingBoxMin[2]
 				<< ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
-		Log::global_log->error() << "Particles will be lost. Aborting simulation." << std::endl;
-		MARDYN_EXIT(311);
+		error_message << "Particles will be lost. Aborting simulation." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -292,8 +294,9 @@ void LinkedCells::update() {
 
 
 	if (numBadMolecules > 0) {
-		Log::global_log->error() << "Found " << numBadMolecules << " outside of their correct cells. Aborting." << std::endl;
-		MARDYN_EXIT(311);
+		std::ostringstream error_message;
+		error_message << "Found " << numBadMolecules << " outside of their correct cells. Aborting." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 #endif
 }
@@ -542,8 +545,9 @@ void LinkedCells::addParticles(std::vector<Molecule>& particles, bool checkWheth
 
 void LinkedCells::traverseNonInnermostCells(CellProcessor& cellProcessor) {
 	if (not _cellsValid) {
-		Log::global_log->error() << "Cell structure in LinkedCells (traverseNonInnermostCells) invalid, call update first" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Cell structure in LinkedCells (traverseNonInnermostCells) invalid, call update first" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	_traversalTuner->traverseCellPairsOuter(cellProcessor);
@@ -551,8 +555,9 @@ void LinkedCells::traverseNonInnermostCells(CellProcessor& cellProcessor) {
 
 void LinkedCells::traversePartialInnermostCells(CellProcessor& cellProcessor, unsigned int stage, int stageCount) {
 	if (not _cellsValid) {
-		Log::global_log->error() << "Cell structure in LinkedCells (traversePartialInnermostCells) invalid, call update first" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Cell structure in LinkedCells (traversePartialInnermostCells) invalid, call update first" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	_traversalTuner->traverseCellPairsInner(cellProcessor, stage, stageCount);
@@ -560,10 +565,9 @@ void LinkedCells::traversePartialInnermostCells(CellProcessor& cellProcessor, un
 
 void LinkedCells::traverseCells(CellProcessor& cellProcessor) {
 	if (not _cellsValid) {
-		Log::global_log->error()
-				<< "Cell structure in LinkedCells (traversePairs) invalid, call update first"
-				<< std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Cell structure in LinkedCells (traversePairs) invalid, call update first" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	cellProcessor.initTraversal();
@@ -609,10 +613,9 @@ void LinkedCells::deleteParticlesOutsideBox(double boxMin[3], double boxMax[3]) 
 
 void LinkedCells::deleteOuterParticles() {
 	/*if (_cellsValid == false) {
-		Log::global_log->error()
-				<< "Cell structure in LinkedCells (deleteOuterParticles) invalid, call update first"
-				<< std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "Cell structure in LinkedCells (deleteOuterParticles) invalid, call update first" << std::endl;
+		MARDYN_EXIT(error_message);
 	}*/
 
 	const size_t numHaloCells = _haloCellIndices.size();
@@ -641,7 +644,7 @@ RegionParticleIterator LinkedCells::regionIterator(const double startRegion[3], 
 	const auto &localBoxOfInterestMin = type == ParticleIterator::ALL_CELLS ? _haloBoundingBoxMin : _boundingBoxMin;
 	const auto &localBoxOfInterestMax = type == ParticleIterator::ALL_CELLS ? _haloBoundingBoxMax : _boundingBoxMax;
 
-    // clamp iterated region to local MPI subdomain
+	// clamp iterated region to local MPI subdomain
 	const std::array<double, 3> startRegionClamped = {
 		std::clamp(startRegion[0], localBoxOfInterestMin[0], localBoxOfInterestMax[0]),
 		std::clamp(startRegion[1], localBoxOfInterestMin[1], localBoxOfInterestMax[1]),
@@ -833,11 +836,12 @@ unsigned long int LinkedCells::getCellIndexOfMolecule(Molecule* molecule) const 
 	for (int dim = 0; dim < 3; dim++) {
 		#ifndef NDEBUG
 		if (molecule->r(dim) < _haloBoundingBoxMin[dim] || molecule->r(dim) >= _haloBoundingBoxMax[dim]) {
-			Log::global_log->error() << "Molecule is outside of bounding box" << std::endl;
-			Log::global_log->error() << "Molecule:\n" << *molecule << std::endl;
-			Log::global_log->error() << "_haloBoundingBoxMin = (" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMin[2] << ")" << std::endl;
-			Log::global_log->error() << "_haloBoundingBoxMax = (" << _haloBoundingBoxMax[0] << ", " << _haloBoundingBoxMax[1] << ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Molecule is outside of bounding box" << std::endl;
+			error_message << "Molecule:\n" << *molecule << std::endl;
+			error_message << "_haloBoundingBoxMin = (" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMin[2] << ")" << std::endl;
+			error_message << "_haloBoundingBoxMax = (" << _haloBoundingBoxMax[0] << ", " << _haloBoundingBoxMax[1] << ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		#endif
 		//this version is sensitive to roundoffs, if we have molecules (initialized) precisely at position 0.0:
@@ -882,11 +886,12 @@ unsigned long int LinkedCells::getCellIndexOfPoint(const double point[3]) const 
 		#ifndef NDEBUG
 		//this should never ever happen!
 		if (localPoint[dim] < _haloBoundingBoxMin[dim] || localPoint[dim] >= _haloBoundingBoxMax[dim]) {
-			Log::global_log->error() << "Point is outside of halo bounding box" << std::endl;
-			Log::global_log->error() << "Point p = (" << localPoint[0] << ", " << localPoint[1] << ", " << localPoint[2] << ")" << std::endl;
-			Log::global_log->error() << "_haloBoundingBoxMin = (" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMin[2] << ")" << std::endl;
-			Log::global_log->error() << "_haloBoundingBoxMax = (" << _haloBoundingBoxMax[0] << ", " << _haloBoundingBoxMax[1] << ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "Point is outside of halo bounding box" << std::endl;
+			error_message << "Point p = (" << localPoint[0] << ", " << localPoint[1] << ", " << localPoint[2] << ")" << std::endl;
+			error_message << "_haloBoundingBoxMin = (" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMin[2] << ")" << std::endl;
+			error_message << "_haloBoundingBoxMax = (" << _haloBoundingBoxMax[0] << ", " << _haloBoundingBoxMax[1] << ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		#endif
 
@@ -1003,14 +1008,13 @@ void LinkedCells::deleteMolecule(ParticleIterator &moleculeIter, const bool& reb
 
 	moleculeIter.deleteCurrentParticle();
 
-    if (rebuildCaches) {
-        auto cellid = getCellIndexOfMolecule(&*moleculeIter);
-        if (cellid >= _cells.size()) {
-          Log::global_log->error_always_output()
-              << "coordinates for atom deletion lie outside bounding box."
-              << std::endl;
-          MARDYN_EXIT(1);
-        }
+	if (rebuildCaches) {
+		auto cellid = getCellIndexOfMolecule(&*moleculeIter);
+		if (cellid >= _cells.size()) {
+			std::ostringstream error_message;
+			error_message << "coordinates for atom deletion lie outside bounding box." << std::endl;
+			MARDYN_EXIT(error_message);
+		}
 		_cells[cellid].buildSoACaches();
 	}
 }
@@ -1066,7 +1070,7 @@ double LinkedCells::getEnergy(ParticlePairsHandler* particlePairsHandler, Molecu
 		delete cellProcessor;
 	}
 
-    mardyn_assert(not std::isnan(u)); // catches NaN
+	mardyn_assert(not std::isnan(u)); // catches NaN
 
 	return u;
 }

--- a/src/particleContainer/LinkedCells.cpp
+++ b/src/particleContainer/LinkedCells.cpp
@@ -95,7 +95,7 @@ LinkedCells::LinkedCells(double bBoxMin[3], double bBoxMax[3],
 		Log::global_log->error_always_output() << "_boxWidthInNumCells: " << _boxWidthInNumCells[0]
 				<< " / " << _boxWidthInNumCells[1] << " / "
 				<< _boxWidthInNumCells[2] << std::endl;
-		mardyn_exit(5);
+		MARDYN_EXIT(5);
 	}
 
 	initializeCells();
@@ -156,7 +156,7 @@ bool LinkedCells::rebuild(double bBoxMin[3], double bBoxMax[3]) {
 		// in each dimension at least one layer of (inner+boundary) cells necessary
 		if (_cellsPerDimension[dim] == 2 * _haloWidthInNumCells[dim]) {
 			Log::global_log->error_always_output() << "LinkedCells::rebuild: region too small" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 
 		numberOfCells *= _cellsPerDimension[dim];
@@ -233,7 +233,7 @@ void LinkedCells::check_molecules_in_box() {
 				<< ") x [" << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMax[1] << ") x [" << _haloBoundingBoxMin[2]
 				<< ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
 		Log::global_log->error() << "Particles will be lost. Aborting simulation." << std::endl;
-		mardyn_exit(311);
+		MARDYN_EXIT(311);
 	}
 }
 
@@ -293,7 +293,7 @@ void LinkedCells::update() {
 
 	if (numBadMolecules > 0) {
 		Log::global_log->error() << "Found " << numBadMolecules << " outside of their correct cells. Aborting." << std::endl;
-		mardyn_exit(311);
+		MARDYN_EXIT(311);
 	}
 #endif
 }
@@ -543,7 +543,7 @@ void LinkedCells::addParticles(std::vector<Molecule>& particles, bool checkWheth
 void LinkedCells::traverseNonInnermostCells(CellProcessor& cellProcessor) {
 	if (not _cellsValid) {
 		Log::global_log->error() << "Cell structure in LinkedCells (traverseNonInnermostCells) invalid, call update first" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	_traversalTuner->traverseCellPairsOuter(cellProcessor);
@@ -552,7 +552,7 @@ void LinkedCells::traverseNonInnermostCells(CellProcessor& cellProcessor) {
 void LinkedCells::traversePartialInnermostCells(CellProcessor& cellProcessor, unsigned int stage, int stageCount) {
 	if (not _cellsValid) {
 		Log::global_log->error() << "Cell structure in LinkedCells (traversePartialInnermostCells) invalid, call update first" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	_traversalTuner->traverseCellPairsInner(cellProcessor, stage, stageCount);
@@ -563,7 +563,7 @@ void LinkedCells::traverseCells(CellProcessor& cellProcessor) {
 		Log::global_log->error()
 				<< "Cell structure in LinkedCells (traversePairs) invalid, call update first"
 				<< std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	cellProcessor.initTraversal();
@@ -612,7 +612,7 @@ void LinkedCells::deleteOuterParticles() {
 		Log::global_log->error()
 				<< "Cell structure in LinkedCells (deleteOuterParticles) invalid, call update first"
 				<< std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}*/
 
 	const size_t numHaloCells = _haloCellIndices.size();
@@ -837,7 +837,7 @@ unsigned long int LinkedCells::getCellIndexOfMolecule(Molecule* molecule) const 
 			Log::global_log->error() << "Molecule:\n" << *molecule << std::endl;
 			Log::global_log->error() << "_haloBoundingBoxMin = (" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMin[2] << ")" << std::endl;
 			Log::global_log->error() << "_haloBoundingBoxMax = (" << _haloBoundingBoxMax[0] << ", " << _haloBoundingBoxMax[1] << ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		#endif
 		//this version is sensitive to roundoffs, if we have molecules (initialized) precisely at position 0.0:
@@ -886,7 +886,7 @@ unsigned long int LinkedCells::getCellIndexOfPoint(const double point[3]) const 
 			Log::global_log->error() << "Point p = (" << localPoint[0] << ", " << localPoint[1] << ", " << localPoint[2] << ")" << std::endl;
 			Log::global_log->error() << "_haloBoundingBoxMin = (" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMin[2] << ")" << std::endl;
 			Log::global_log->error() << "_haloBoundingBoxMax = (" << _haloBoundingBoxMax[0] << ", " << _haloBoundingBoxMax[1] << ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		#endif
 
@@ -1009,7 +1009,7 @@ void LinkedCells::deleteMolecule(ParticleIterator &moleculeIter, const bool& reb
           Log::global_log->error_always_output()
               << "coordinates for atom deletion lie outside bounding box."
               << std::endl;
-          mardyn_exit(1);
+          MARDYN_EXIT(1);
         }
 		_cells[cellid].buildSoACaches();
 	}

--- a/src/particleContainer/LinkedCells.cpp
+++ b/src/particleContainer/LinkedCells.cpp
@@ -95,7 +95,7 @@ LinkedCells::LinkedCells(double bBoxMin[3], double bBoxMax[3],
 		error_message << "_boxWidthInNumCells: " << _boxWidthInNumCells[0]
 				<< " / " << _boxWidthInNumCells[1] << " / "
 				<< _boxWidthInNumCells[2] << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	initializeCells();
@@ -157,7 +157,7 @@ bool LinkedCells::rebuild(double bBoxMin[3], double bBoxMax[3]) {
 		if (_cellsPerDimension[dim] == 2 * _haloWidthInNumCells[dim]) {
 			std::ostringstream error_message;
 			error_message << "LinkedCells::rebuild: region too small" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		numberOfCells *= _cellsPerDimension[dim];
@@ -235,7 +235,7 @@ void LinkedCells::check_molecules_in_box() {
 				<< ") x [" << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMax[1] << ") x [" << _haloBoundingBoxMin[2]
 				<< ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
 		error_message << "Particles will be lost. Aborting simulation." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -296,7 +296,7 @@ void LinkedCells::update() {
 	if (numBadMolecules > 0) {
 		std::ostringstream error_message;
 		error_message << "Found " << numBadMolecules << " outside of their correct cells. Aborting." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 #endif
 }
@@ -547,7 +547,7 @@ void LinkedCells::traverseNonInnermostCells(CellProcessor& cellProcessor) {
 	if (not _cellsValid) {
 		std::ostringstream error_message;
 		error_message << "Cell structure in LinkedCells (traverseNonInnermostCells) invalid, call update first" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	_traversalTuner->traverseCellPairsOuter(cellProcessor);
@@ -557,7 +557,7 @@ void LinkedCells::traversePartialInnermostCells(CellProcessor& cellProcessor, un
 	if (not _cellsValid) {
 		std::ostringstream error_message;
 		error_message << "Cell structure in LinkedCells (traversePartialInnermostCells) invalid, call update first" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	_traversalTuner->traverseCellPairsInner(cellProcessor, stage, stageCount);
@@ -567,7 +567,7 @@ void LinkedCells::traverseCells(CellProcessor& cellProcessor) {
 	if (not _cellsValid) {
 		std::ostringstream error_message;
 		error_message << "Cell structure in LinkedCells (traversePairs) invalid, call update first" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	cellProcessor.initTraversal();
@@ -615,7 +615,7 @@ void LinkedCells::deleteOuterParticles() {
 	/*if (_cellsValid == false) {
 		std::ostringstream error_message;
 		error_message << "Cell structure in LinkedCells (deleteOuterParticles) invalid, call update first" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}*/
 
 	const size_t numHaloCells = _haloCellIndices.size();
@@ -841,7 +841,7 @@ unsigned long int LinkedCells::getCellIndexOfMolecule(Molecule* molecule) const 
 			error_message << "Molecule:\n" << *molecule << std::endl;
 			error_message << "_haloBoundingBoxMin = (" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMin[2] << ")" << std::endl;
 			error_message << "_haloBoundingBoxMax = (" << _haloBoundingBoxMax[0] << ", " << _haloBoundingBoxMax[1] << ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		#endif
 		//this version is sensitive to roundoffs, if we have molecules (initialized) precisely at position 0.0:
@@ -891,7 +891,7 @@ unsigned long int LinkedCells::getCellIndexOfPoint(const double point[3]) const 
 			error_message << "Point p = (" << localPoint[0] << ", " << localPoint[1] << ", " << localPoint[2] << ")" << std::endl;
 			error_message << "_haloBoundingBoxMin = (" << _haloBoundingBoxMin[0] << ", " << _haloBoundingBoxMin[1] << ", " << _haloBoundingBoxMin[2] << ")" << std::endl;
 			error_message << "_haloBoundingBoxMax = (" << _haloBoundingBoxMax[0] << ", " << _haloBoundingBoxMax[1] << ", " << _haloBoundingBoxMax[2] << ")" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		#endif
 
@@ -1013,7 +1013,7 @@ void LinkedCells::deleteMolecule(ParticleIterator &moleculeIter, const bool& reb
 		if (cellid >= _cells.size()) {
 			std::ostringstream error_message;
 			error_message << "coordinates for atom deletion lie outside bounding box." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		_cells[cellid].buildSoACaches();
 	}

--- a/src/particleContainer/TraversalTuner.h
+++ b/src/particleContainer/TraversalTuner.h
@@ -156,7 +156,7 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 #ifndef QUICKSCHED
 		std::ostringstream error_message;
 		error_message << "MarDyn was compiled without Quicksched Support. Aborting!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 #endif
 	} else if (dynamic_cast<SlicedCellPairTraversal<CellTemplate> *>(_optimalTraversal))
 		Log::global_log->info() << "Using SlicedCellPairTraversal." << std::endl;
@@ -167,7 +167,7 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 		std::ostringstream error_message;
 		error_message << "Traversal supports up to " << _optimalTraversal->maxCellsInCutoff()
 							<< " cells in cutoff, but value is chosen as " << _cellsInCutoff << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -248,7 +248,7 @@ void TraversalTuner<CellTemplate>::readXML(XMLfileUnits &xmlconfig) {
 												<< " direction is <2 and thereby invalid! ("
 												<< quiData->taskBlockSize[j] << ")"
 												<< std::endl;
-							MARDYN_EXIT(error_message);
+							MARDYN_EXIT(error_message.str());
 						}
 					}
 					break;
@@ -311,7 +311,7 @@ void TraversalTuner<CellTemplate>::rebuild(std::vector<CellTemplate> &cells, con
 				default:
 					std::ostringstream error_message;
 					error_message << "Unknown traversal data found in TraversalTuner._traversals!" << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 			}
 		}
 		traversalPointerReference->rebuild(cells, dims, cellLength, cutoff, traversalData);
@@ -341,7 +341,7 @@ inline void TraversalTuner<CellTemplate>::traverseCellPairs(traversalNames name,
 		default:
 			std::ostringstream error_message;
 			error_message<< "Calling traverseCellPairs(traversalName, CellProcessor&) for something else than the Sliced Traversal is disabled for now. Aborting." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 			break;
 		}
 	}

--- a/src/particleContainer/TraversalTuner.h
+++ b/src/particleContainer/TraversalTuner.h
@@ -155,7 +155,7 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 		Log::global_log->info() << "Using QuickschedTraversal." << std::endl;
 #ifndef QUICKSCHED
 		Log::global_log->error() << "MarDyn was compiled without Quicksched Support. Aborting!" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 #endif
 	} else if (dynamic_cast<SlicedCellPairTraversal<CellTemplate> *>(_optimalTraversal))
 		Log::global_log->info() << "Using SlicedCellPairTraversal." << std::endl;
@@ -165,7 +165,7 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 	if (_cellsInCutoff > _optimalTraversal->maxCellsInCutoff()) {
 		Log::global_log->error() << "Traversal supports up to " << _optimalTraversal->maxCellsInCutoff()
 							<< " cells in cutoff, but value is chosen as " << _cellsInCutoff << std::endl;
-		mardyn_exit(45);
+		MARDYN_EXIT(45);
 	}
 }
 
@@ -245,7 +245,7 @@ void TraversalTuner<CellTemplate>::readXML(XMLfileUnits &xmlconfig) {
 												<< " direction is <2 and thereby invalid! ("
 												<< quiData->taskBlockSize[j] << ")"
 												<< std::endl;
-							mardyn_exit(1);
+							MARDYN_EXIT(1);
 						}
 					}
 					break;
@@ -307,7 +307,7 @@ void TraversalTuner<CellTemplate>::rebuild(std::vector<CellTemplate> &cells, con
 				} break;
 				default:
 					Log::global_log->error() << "Unknown traversal data found in TraversalTuner._traversals!" << std::endl;
-					mardyn_exit(1);
+					MARDYN_EXIT(1);
 			}
 		}
 		traversalPointerReference->rebuild(cells, dims, cellLength, cutoff, traversalData);
@@ -336,7 +336,7 @@ inline void TraversalTuner<CellTemplate>::traverseCellPairs(traversalNames name,
 			break;
 		default:
 			Log::global_log->error()<< "Calling traverseCellPairs(traversalName, CellProcessor&) for something else than the Sliced Traversal is disabled for now. Aborting." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 			break;
 		}
 	}

--- a/src/particleContainer/TraversalTuner.h
+++ b/src/particleContainer/TraversalTuner.h
@@ -164,8 +164,10 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 		Log::global_log->warning() << "Using unknown traversal." << std::endl;
 
 	if (_cellsInCutoff > _optimalTraversal->maxCellsInCutoff()) {
-		std::ostringstream error_message;		error_message << "Traversal supports up to " << _optimalTraversal->maxCellsInCutoff()
-							<< " cells in cutoff, but value is chosen as " << _cellsInCutoff << std::endl;		MARDYN_EXIT(error_message);
+		std::ostringstream error_message;
+		error_message << "Traversal supports up to " << _optimalTraversal->maxCellsInCutoff()
+							<< " cells in cutoff, but value is chosen as " << _cellsInCutoff << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -240,11 +242,13 @@ void TraversalTuner<CellTemplate>::readXML(XMLfileUnits &xmlconfig) {
 						tag += (dimension + j);
 						xmlconfig.getNodeValue(tag, quiData->taskBlockSize[j]);
 						if (quiData->taskBlockSize[j] < 2) {
-							std::ostringstream error_message;							error_message << "Task block size in "
+							std::ostringstream error_message;
+							error_message << "Task block size in "
 												<< (char) (dimension + j)
 												<< " direction is <2 and thereby invalid! ("
 												<< quiData->taskBlockSize[j] << ")"
-												<< std::endl;							MARDYN_EXIT(error_message);
+												<< std::endl;
+							MARDYN_EXIT(error_message);
 						}
 					}
 					break;

--- a/src/particleContainer/TraversalTuner.h
+++ b/src/particleContainer/TraversalTuner.h
@@ -154,8 +154,9 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 	else if (dynamic_cast<QuickschedTraversal<CellTemplate> *>(_optimalTraversal)) {
 		Log::global_log->info() << "Using QuickschedTraversal." << std::endl;
 #ifndef QUICKSCHED
-		Log::global_log->error() << "MarDyn was compiled without Quicksched Support. Aborting!" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "MarDyn was compiled without Quicksched Support. Aborting!" << std::endl;
+		MARDYN_EXIT(error_message);
 #endif
 	} else if (dynamic_cast<SlicedCellPairTraversal<CellTemplate> *>(_optimalTraversal))
 		Log::global_log->info() << "Using SlicedCellPairTraversal." << std::endl;
@@ -163,9 +164,8 @@ void TraversalTuner<CellTemplate>::findOptimalTraversal() {
 		Log::global_log->warning() << "Using unknown traversal." << std::endl;
 
 	if (_cellsInCutoff > _optimalTraversal->maxCellsInCutoff()) {
-		Log::global_log->error() << "Traversal supports up to " << _optimalTraversal->maxCellsInCutoff()
-							<< " cells in cutoff, but value is chosen as " << _cellsInCutoff << std::endl;
-		MARDYN_EXIT(45);
+		std::ostringstream error_message;		error_message << "Traversal supports up to " << _optimalTraversal->maxCellsInCutoff()
+							<< " cells in cutoff, but value is chosen as " << _cellsInCutoff << std::endl;		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -240,12 +240,11 @@ void TraversalTuner<CellTemplate>::readXML(XMLfileUnits &xmlconfig) {
 						tag += (dimension + j);
 						xmlconfig.getNodeValue(tag, quiData->taskBlockSize[j]);
 						if (quiData->taskBlockSize[j] < 2) {
-							Log::global_log->error() << "Task block size in "
+							std::ostringstream error_message;							error_message << "Task block size in "
 												<< (char) (dimension + j)
 												<< " direction is <2 and thereby invalid! ("
 												<< quiData->taskBlockSize[j] << ")"
-												<< std::endl;
-							MARDYN_EXIT(1);
+												<< std::endl;							MARDYN_EXIT(error_message);
 						}
 					}
 					break;
@@ -306,8 +305,9 @@ void TraversalTuner<CellTemplate>::rebuild(std::vector<CellTemplate> &cells, con
 					traversalPointerReference = new QuickschedTraversal<CellTemplate>(cells, dims, quiData->taskBlockSize);
 				} break;
 				default:
-					Log::global_log->error() << "Unknown traversal data found in TraversalTuner._traversals!" << std::endl;
-					MARDYN_EXIT(1);
+					std::ostringstream error_message;
+					error_message << "Unknown traversal data found in TraversalTuner._traversals!" << std::endl;
+					MARDYN_EXIT(error_message);
 			}
 		}
 		traversalPointerReference->rebuild(cells, dims, cellLength, cutoff, traversalData);
@@ -335,8 +335,9 @@ inline void TraversalTuner<CellTemplate>::traverseCellPairs(traversalNames name,
 			slicedTraversal.traverseCellPairs(cellProcessor);
 			break;
 		default:
-			Log::global_log->error()<< "Calling traverseCellPairs(traversalName, CellProcessor&) for something else than the Sliced Traversal is disabled for now. Aborting." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message<< "Calling traverseCellPairs(traversalName, CellProcessor&) for something else than the Sliced Traversal is disabled for now. Aborting." << std::endl;
+			MARDYN_EXIT(error_message);
 			break;
 		}
 	}

--- a/src/particleContainer/adapter/ParticlePairs2PotForceAdapter.h
+++ b/src/particleContainer/adapter/ParticlePairs2PotForceAdapter.h
@@ -175,7 +175,9 @@ public:
                 FluidPot(molecule1, molecule2, params, distanceVector, dummy1, dummy2, dummy3, calculateLJ);
                 return dummy1 / 6.0 + dummy2 + dummy3;
             default:
-                MARDYN_EXIT(666);
+				std::ostringstream error_message;
+				error_message << "[ParticlePairs2PotForceAdapter9] pairType is unknown" << std::endl;
+                MARDYN_EXIT(error_message);
         }
         return 0.0;
 	}

--- a/src/particleContainer/adapter/ParticlePairs2PotForceAdapter.h
+++ b/src/particleContainer/adapter/ParticlePairs2PotForceAdapter.h
@@ -175,7 +175,7 @@ public:
                 FluidPot(molecule1, molecule2, params, distanceVector, dummy1, dummy2, dummy3, calculateLJ);
                 return dummy1 / 6.0 + dummy2 + dummy3;
             default:
-                mardyn_exit(666);
+                MARDYN_EXIT(666);
         }
         return 0.0;
 	}

--- a/src/particleContainer/adapter/ParticlePairs2PotForceAdapter.h
+++ b/src/particleContainer/adapter/ParticlePairs2PotForceAdapter.h
@@ -177,7 +177,7 @@ public:
             default:
 				std::ostringstream error_message;
 				error_message << "[ParticlePairs2PotForceAdapter9] pairType is unknown" << std::endl;
-                MARDYN_EXIT(error_message);
+                MARDYN_EXIT(error_message.str());
         }
         return 0.0;
 	}

--- a/src/plugins/COMaligner.cpp
+++ b/src/plugins/COMaligner.cpp
@@ -31,7 +31,7 @@ void COMaligner::readXML(XMLfileUnits& xmlconfig){
         Log::global_log -> error() << "[COMaligner] HALTING SIMULATION" << std::endl;
         _enabled = false;
         // HALT SIM
-        mardyn_exit(1);
+        MARDYN_EXIT(1);
         return;
     }
 

--- a/src/plugins/COMaligner.cpp
+++ b/src/plugins/COMaligner.cpp
@@ -7,6 +7,10 @@
 
 #include "COMaligner.h"
 
+#include <sstream>
+
+#include "utils/mardyn_assert.h"
+
 //! @brief will be called to read configuration
 //!
 //! All values have defaults and are not mandatory to be supplied<br>
@@ -27,11 +31,12 @@ void COMaligner::readXML(XMLfileUnits& xmlconfig){
 
     // SANITY CHECK
     if(_interval < 1 || _alignmentCorrection < 0 || _alignmentCorrection > 1){
-        Log::global_log -> error() << "[COMaligner] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
-        Log::global_log -> error() << "[COMaligner] HALTING SIMULATION" << std::endl;
+        std::ostringstream error_message;
+        error_message << "[COMaligner] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
+        error_message << "[COMaligner] HALTING SIMULATION" << std::endl;
         _enabled = false;
         // HALT SIM
-        MARDYN_EXIT(1);
+        MARDYN_EXIT(error_message);
         return;
     }
 

--- a/src/plugins/COMaligner.cpp
+++ b/src/plugins/COMaligner.cpp
@@ -36,7 +36,7 @@ void COMaligner::readXML(XMLfileUnits& xmlconfig){
         error_message << "[COMaligner] HALTING SIMULATION" << std::endl;
         _enabled = false;
         // HALT SIM
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
         return;
     }
 

--- a/src/plugins/DirectedPM.cpp
+++ b/src/plugins/DirectedPM.cpp
@@ -100,19 +100,20 @@ void DirectedPM::beforeForces(ParticleContainer* particleContainer, DomainDecomp
 							(phiUN < _phiIncrements)) {
 							unID = (hUN * _rIncrements * _phiIncrements) + (rUN * _phiIncrements) + phiUN;
 						} else {
-							Log::global_log->error()
+							std::ostringstream error_message;
+							error_message
 								<< "INV PROFILE UNITS " << _universalInvProfileUnit[0] << " "
 								<< _universalInvProfileUnit[1] << " " << _universalInvProfileUnit[2] << "\n";
-							Log::global_log->error() << "PROFILE UNITS " << _rIncrements << " " << _hIncrements << " "
+							error_message << "PROFILE UNITS " << _rIncrements << " " << _hIncrements << " "
 												<< _phiIncrements << "\n";
-							Log::global_log->error() << "Severe error!! Invalid profile ID (" << rUN << " / " << hUN << " / "
+							error_message << "Severe error!! Invalid profile ID (" << rUN << " / " << hUN << " / "
 												<< phiUN << ").\n\n";
-							Log::global_log->error() << "Severe error!! Invalid profile unit (" << R2 << " / " << yc << " / "
+							error_message << "Severe error!! Invalid profile unit (" << R2 << " / " << yc << " / "
 												<< phi << ").\n\n";
-							Log::global_log->error()
+							error_message
 								<< "Coordinates off center (" << xc << " / " << yc << " / " << zc << ").\n";
-							Log::global_log->error() << "unID = " << unID << "\n";
-							MARDYN_EXIT(707);
+							error_message << "unID = " << unID << "\n";
+							MARDYN_EXIT(error_message);
 						}
 						// ADD VELOCITCY AND VIRIAL TO RESPECTIVE BIN
 						_localnumberOfParticles[unID] += 1.;

--- a/src/plugins/DirectedPM.cpp
+++ b/src/plugins/DirectedPM.cpp
@@ -113,7 +113,7 @@ void DirectedPM::beforeForces(ParticleContainer* particleContainer, DomainDecomp
 							error_message
 								<< "Coordinates off center (" << xc << " / " << yc << " / " << zc << ").\n";
 							error_message << "unID = " << unID << "\n";
-							MARDYN_EXIT(error_message);
+							MARDYN_EXIT(error_message.str());
 						}
 						// ADD VELOCITCY AND VIRIAL TO RESPECTIVE BIN
 						_localnumberOfParticles[unID] += 1.;

--- a/src/plugins/DirectedPM.cpp
+++ b/src/plugins/DirectedPM.cpp
@@ -112,7 +112,7 @@ void DirectedPM::beforeForces(ParticleContainer* particleContainer, DomainDecomp
 							Log::global_log->error()
 								<< "Coordinates off center (" << xc << " / " << yc << " / " << zc << ").\n";
 							Log::global_log->error() << "unID = " << unID << "\n";
-							mardyn_exit(707);
+							MARDYN_EXIT(707);
 						}
 						// ADD VELOCITCY AND VIRIAL TO RESPECTIVE BIN
 						_localnumberOfParticles[unID] += 1.;

--- a/src/plugins/Dropaccelerator.cpp
+++ b/src/plugins/Dropaccelerator.cpp
@@ -31,11 +31,12 @@ void Dropaccelerator::readXML(XMLfileUnits& xmlconfig) {
 	// SANITY CHECK
 	if (_interval < 1 || _steps <= 0 || _startSimStep < 0 || _xPosition <= 0. || _yPosition <= 0. || _zPosition <= 0. ||
 		_dropRadius <= 0) {
-		Log::global_log->error() << "[Dropaccelerator] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
-		Log::global_log->error() << "[Dropaccelerator] HALTING SIMULATION" << std::endl;
+		std::ostringstream error_message;
+		error_message << "[Dropaccelerator] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
+		error_message << "[Dropaccelerator] HALTING SIMULATION" << std::endl;
 		_enabled = false;
 		// HALT SIM
-		MARDYN_EXIT(1);
+		MARDYN_EXIT(error_message);
 		return;
 	}
 

--- a/src/plugins/Dropaccelerator.cpp
+++ b/src/plugins/Dropaccelerator.cpp
@@ -36,7 +36,7 @@ void Dropaccelerator::readXML(XMLfileUnits& xmlconfig) {
 		error_message << "[Dropaccelerator] HALTING SIMULATION" << std::endl;
 		_enabled = false;
 		// HALT SIM
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 		return;
 	}
 

--- a/src/plugins/Dropaccelerator.cpp
+++ b/src/plugins/Dropaccelerator.cpp
@@ -35,7 +35,7 @@ void Dropaccelerator::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->error() << "[Dropaccelerator] HALTING SIMULATION" << std::endl;
 		_enabled = false;
 		// HALT SIM
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 		return;
 	}
 

--- a/src/plugins/Dropaligner.cpp
+++ b/src/plugins/Dropaligner.cpp
@@ -28,7 +28,7 @@ void Dropaligner::readXML(XMLfileUnits& xmlconfig) {
 		error_message << "[Dropaligner] HALTING SIMULATION" << std::endl;
 		_enabled = false;
 		// HALT SIM
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 		return;
 	}
 

--- a/src/plugins/Dropaligner.cpp
+++ b/src/plugins/Dropaligner.cpp
@@ -23,11 +23,12 @@ void Dropaligner::readXML(XMLfileUnits& xmlconfig) {
 	// SANITY CHECK
 	if (_interval < 1 || _alignmentCorrection < 0 || _alignmentCorrection > 1 || _xPos <= 0. || _yPos <= 0. ||
 		_zPos <= 0. || _radius <= 0) {
-		Log::global_log->error() << "[Dropaligner] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
-		Log::global_log->error() << "[Dropaligner] HALTING SIMULATION" << std::endl;
+		std::ostringstream error_message;
+		error_message << "[Dropaligner] INVALID CONFIGURATION!!! DISABLED!" << std::endl;
+		error_message << "[Dropaligner] HALTING SIMULATION" << std::endl;
 		_enabled = false;
 		// HALT SIM
-		MARDYN_EXIT(1);
+		MARDYN_EXIT(error_message);
 		return;
 	}
 

--- a/src/plugins/Dropaligner.cpp
+++ b/src/plugins/Dropaligner.cpp
@@ -27,7 +27,7 @@ void Dropaligner::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->error() << "[Dropaligner] HALTING SIMULATION" << std::endl;
 		_enabled = false;
 		// HALT SIM
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 		return;
 	}
 

--- a/src/plugins/ExamplePlugin.cpp
+++ b/src/plugins/ExamplePlugin.cpp
@@ -60,7 +60,7 @@ void ExamplePlugin::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->error()
 				<< "Valid options are: all, beforeEventNewTimestep, beforeForces, afterForces, endStep, init, finish."
 				<< std::endl;
-		mardyn_exit(11);
+		MARDYN_EXIT(11);
 	}
 }
 

--- a/src/plugins/ExamplePlugin.cpp
+++ b/src/plugins/ExamplePlugin.cpp
@@ -54,13 +54,13 @@ void ExamplePlugin::readXML(XMLfileUnits& xmlconfig) {
 		_displaySelector = WhereToDisplay::AT_FINISH;
 		Log::global_log->info() << "Displaying at finish." << std::endl;
 	} else {
-		Log::global_log->error()
-				<< "Unknown option specified to ExamplePlugin::where_to_display."
-				<< std::endl;
-		Log::global_log->error()
+		std::ostringstream error_message;
+		error_message
+				<< "Unknown option specified to ExamplePlugin::where_to_display." << std::endl;
+		error_message
 				<< "Valid options are: all, beforeEventNewTimestep, beforeForces, afterForces, endStep, init, finish."
 				<< std::endl;
-		MARDYN_EXIT(11);
+		MARDYN_EXIT(error_message);
 	}
 }
 

--- a/src/plugins/ExamplePlugin.cpp
+++ b/src/plugins/ExamplePlugin.cpp
@@ -60,7 +60,7 @@ void ExamplePlugin::readXML(XMLfileUnits& xmlconfig) {
 		error_message
 				<< "Valid options are: all, beforeEventNewTimestep, beforeForces, afterForces, endStep, init, finish."
 				<< std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 

--- a/src/plugins/FixRegion.cpp
+++ b/src/plugins/FixRegion.cpp
@@ -29,10 +29,11 @@ void FixRegion::init(ParticleContainer* particleContainer, DomainDecompBase* dom
 	// SANITY CHECK
 	if (_xMin < 0. || _yMin < 0. || _zMin < 0. || _xMax > _boxLength[0] || _yMax > _boxLength[1] ||
 		_zMax > _boxLength[2]) {
-		Log::global_log->error() << "[FixRegion] INVALID INPUT!!! DISABLED!" << std::endl;
-		Log::global_log->error() << "[FixRegion] HALTING SIMULATION" << std::endl;
+		std::ostringstream error_message;
+		error_message << "[FixRegion] INVALID INPUT!!! DISABLED!" << std::endl;
+		error_message << "[FixRegion] HALTING SIMULATION" << std::endl;
 		// HALT SIM
-		MARDYN_EXIT(1);
+		MARDYN_EXIT(error_message);
 		return;
 	}
 

--- a/src/plugins/FixRegion.cpp
+++ b/src/plugins/FixRegion.cpp
@@ -32,7 +32,7 @@ void FixRegion::init(ParticleContainer* particleContainer, DomainDecompBase* dom
 		Log::global_log->error() << "[FixRegion] INVALID INPUT!!! DISABLED!" << std::endl;
 		Log::global_log->error() << "[FixRegion] HALTING SIMULATION" << std::endl;
 		// HALT SIM
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 		return;
 	}
 

--- a/src/plugins/FixRegion.cpp
+++ b/src/plugins/FixRegion.cpp
@@ -33,7 +33,7 @@ void FixRegion::init(ParticleContainer* particleContainer, DomainDecompBase* dom
 		error_message << "[FixRegion] INVALID INPUT!!! DISABLED!" << std::endl;
 		error_message << "[FixRegion] HALTING SIMULATION" << std::endl;
 		// HALT SIM
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 		return;
 	}
 

--- a/src/plugins/MaxCheck.cpp
+++ b/src/plugins/MaxCheck.cpp
@@ -16,6 +16,7 @@
 #include "utils/mardyn_assert.h"
 
 #include <array>
+#include <sstream>
 
 
 MaxCheck::MaxCheck() {
@@ -75,8 +76,9 @@ void MaxCheck::readXML(XMLfileUnits& xmlconfig) {
 	numTargets = query.card();
 	Log::global_log->info() << "[MaxCheck] Number of component targets: " << numTargets << std::endl;
 	if (numTargets < 1) {
-		Log::global_log->warning() << "[MaxCheck] No target parameters specified. Program exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[MaxCheck] No target parameters specified. Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator nodeIter;

--- a/src/plugins/MaxCheck.cpp
+++ b/src/plugins/MaxCheck.cpp
@@ -76,7 +76,7 @@ void MaxCheck::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "[MaxCheck] Number of component targets: " << numTargets << std::endl;
 	if (numTargets < 1) {
 		Log::global_log->warning() << "[MaxCheck] No target parameters specified. Program exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator nodeIter;

--- a/src/plugins/MaxCheck.cpp
+++ b/src/plugins/MaxCheck.cpp
@@ -78,7 +78,7 @@ void MaxCheck::readXML(XMLfileUnits& xmlconfig) {
 	if (numTargets < 1) {
 		std::ostringstream error_message;
 		error_message << "[MaxCheck] No target parameters specified. Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator nodeIter;

--- a/src/plugins/Mirror.cpp
+++ b/src/plugins/Mirror.cpp
@@ -85,8 +85,9 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 		if(nullptr != subject)
 			subject->registerObserver(this);
 		else {
-			Log::global_log->error() << "[Mirror] Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[Mirror] Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 	Log::global_log->info() << "[Mirror] Enabled at position: y = " << _position.coord << std::endl;
@@ -124,15 +125,17 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 	/** zero gradient */
 	if(MT_ZERO_GRADIENT == _type)
 	{
-		Log::global_log->error() << "[Mirror] Method 3 (MT_ZERO_GRADIENT) is deprecated. Use 5 (MT_MELAND_2004) instead. Program exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[Mirror] Method 3 (MT_ZERO_GRADIENT) is deprecated. Use 5 (MT_MELAND_2004) instead. Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	/** normal distributions */
 	if(MT_NORMDISTR_MB == _type)
 	{
-		Log::global_log->error() << "[Mirror] Method 4 (MT_NORMDISTR_MB) is deprecated. Use 5 (MT_MELAND_2004) instead. Program exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[Mirror] Method 4 (MT_NORMDISTR_MB) is deprecated. Use 5 (MT_MELAND_2004) instead. Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	/** Meland2004 */
@@ -142,8 +145,9 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 
 		if(!xmlconfig.getNodeValue("meland/velo_target", _melandParams.velo_target))
 		{
-			Log::global_log->error() << "[Mirror] Meland: Parameters for method 5 (MT_MELAND_2004) provided in config-file *.xml corrupted/incomplete. Program exit ..." << std::endl;
-			MARDYN_EXIT(-2004);
+			std::ostringstream error_message;
+			error_message << "[Mirror] Meland: Parameters for method 5 (MT_MELAND_2004) provided in config-file *.xml corrupted/incomplete. Program exit ..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		else {
 			Log::global_log->info() << "[Mirror] Meland: target velocity = " << _melandParams.velo_target << std::endl;
@@ -168,13 +172,15 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 		bRet = bRet && xmlconfig.getNodeValue("ramping/treatment", _rampingParams.treatment);
 
 		if (not bRet) {
-			Log::global_log->error() << "[Mirror] Ramping: Parameters for method 5 (MT_RAMPING) provided in config-file *.xml corrupted/incomplete. Program exit ..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[Mirror] Ramping: Parameters for method 5 (MT_RAMPING) provided in config-file *.xml corrupted/incomplete. Program exit ..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		else {
 			if(_rampingParams.startStep > _rampingParams.stopStep) {
-				Log::global_log->error() << "[Mirror] Ramping: Start > Stop. Program exit ..." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "[Mirror] Ramping: Start > Stop. Program exit ..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			else {
 				Log::global_log->info() << "[Mirror] Ramping from " << _rampingParams.startStep << " to " << _rampingParams.stopStep << std::endl;
@@ -185,8 +191,9 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 					case 1 : treatmentStr = "Transmission";
 						break;
 					default:
-						Log::global_log->error() << "[Mirror] Ramping: No proper treatment was set. Use 0 (Deletion) or 1 (Transmission). Program exit ..." << std::endl;
-						MARDYN_EXIT(-1);
+						std::ostringstream error_message;
+						error_message << "[Mirror] Ramping: No proper treatment was set. Use 0 (Deletion) or 1 (Transmission). Program exit ..." << std::endl;
+						MARDYN_EXIT(error_message);
 				}
 				Log::global_log->info() << "[Mirror] Ramping: Treatment for non-reflected particles: " << _rampingParams.treatment << " ( " << treatmentStr << " ) " << std::endl;
 			}

--- a/src/plugins/Mirror.cpp
+++ b/src/plugins/Mirror.cpp
@@ -86,7 +86,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 			subject->registerObserver(this);
 		else {
 			Log::global_log->error() << "[Mirror] Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 	}
 	Log::global_log->info() << "[Mirror] Enabled at position: y = " << _position.coord << std::endl;
@@ -125,14 +125,14 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 	if(MT_ZERO_GRADIENT == _type)
 	{
 		Log::global_log->error() << "[Mirror] Method 3 (MT_ZERO_GRADIENT) is deprecated. Use 5 (MT_MELAND_2004) instead. Program exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	/** normal distributions */
 	if(MT_NORMDISTR_MB == _type)
 	{
 		Log::global_log->error() << "[Mirror] Method 4 (MT_NORMDISTR_MB) is deprecated. Use 5 (MT_MELAND_2004) instead. Program exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	/** Meland2004 */
@@ -143,7 +143,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 		if(!xmlconfig.getNodeValue("meland/velo_target", _melandParams.velo_target))
 		{
 			Log::global_log->error() << "[Mirror] Meland: Parameters for method 5 (MT_MELAND_2004) provided in config-file *.xml corrupted/incomplete. Program exit ..." << std::endl;
-			mardyn_exit(-2004);
+			MARDYN_EXIT(-2004);
 		}
 		else {
 			Log::global_log->info() << "[Mirror] Meland: target velocity = " << _melandParams.velo_target << std::endl;
@@ -169,12 +169,12 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 
 		if (not bRet) {
 			Log::global_log->error() << "[Mirror] Ramping: Parameters for method 5 (MT_RAMPING) provided in config-file *.xml corrupted/incomplete. Program exit ..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 		else {
 			if(_rampingParams.startStep > _rampingParams.stopStep) {
 				Log::global_log->error() << "[Mirror] Ramping: Start > Stop. Program exit ..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 			else {
 				Log::global_log->info() << "[Mirror] Ramping from " << _rampingParams.startStep << " to " << _rampingParams.stopStep << std::endl;
@@ -186,7 +186,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 						break;
 					default:
 						Log::global_log->error() << "[Mirror] Ramping: No proper treatment was set. Use 0 (Deletion) or 1 (Transmission). Program exit ..." << std::endl;
-						mardyn_exit(-1);
+						MARDYN_EXIT(-1);
 				}
 				Log::global_log->info() << "[Mirror] Ramping: Treatment for non-reflected particles: " << _rampingParams.treatment << " ( " << treatmentStr << " ) " << std::endl;
 			}

--- a/src/plugins/Mirror.cpp
+++ b/src/plugins/Mirror.cpp
@@ -87,7 +87,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 		else {
 			std::ostringstream error_message;
 			error_message << "[Mirror] Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 	Log::global_log->info() << "[Mirror] Enabled at position: y = " << _position.coord << std::endl;
@@ -127,7 +127,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 	{
 		std::ostringstream error_message;
 		error_message << "[Mirror] Method 3 (MT_ZERO_GRADIENT) is deprecated. Use 5 (MT_MELAND_2004) instead. Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	/** normal distributions */
@@ -135,7 +135,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 	{
 		std::ostringstream error_message;
 		error_message << "[Mirror] Method 4 (MT_NORMDISTR_MB) is deprecated. Use 5 (MT_MELAND_2004) instead. Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	/** Meland2004 */
@@ -147,7 +147,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 		{
 			std::ostringstream error_message;
 			error_message << "[Mirror] Meland: Parameters for method 5 (MT_MELAND_2004) provided in config-file *.xml corrupted/incomplete. Program exit ..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		else {
 			Log::global_log->info() << "[Mirror] Meland: target velocity = " << _melandParams.velo_target << std::endl;
@@ -174,13 +174,13 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 		if (not bRet) {
 			std::ostringstream error_message;
 			error_message << "[Mirror] Ramping: Parameters for method 5 (MT_RAMPING) provided in config-file *.xml corrupted/incomplete. Program exit ..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		else {
 			if(_rampingParams.startStep > _rampingParams.stopStep) {
 				std::ostringstream error_message;
 				error_message << "[Mirror] Ramping: Start > Stop. Program exit ..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			else {
 				Log::global_log->info() << "[Mirror] Ramping from " << _rampingParams.startStep << " to " << _rampingParams.stopStep << std::endl;
@@ -193,7 +193,7 @@ void Mirror::readXML(XMLfileUnits& xmlconfig)
 					default:
 						std::ostringstream error_message;
 						error_message << "[Mirror] Ramping: No proper treatment was set. Use 0 (Deletion) or 1 (Transmission). Program exit ..." << std::endl;
-						MARDYN_EXIT(error_message);
+						MARDYN_EXIT(error_message.str());
 				}
 				Log::global_log->info() << "[Mirror] Ramping: Treatment for non-reflected particles: " << _rampingParams.treatment << " ( " << treatmentStr << " ) " << std::endl;
 			}

--- a/src/plugins/NEMD/DensityControl.cpp
+++ b/src/plugins/NEMD/DensityControl.cpp
@@ -84,9 +84,11 @@ void DensityControl::readXML(XMLfileUnits& xmlconfig) {
 	_vecPriority.push_back(0);
 	const uint32_t nRet = this->tokenize_int_list(_vecPriority, strPrio);
 	if (nRet != numComponents) {
-		std::ostringstream error_message;		error_message << "[DensityControl] Number of component IDs specified in element <priority>...</priority>"
+		std::ostringstream error_message;
+		error_message << "[DensityControl] Number of component IDs specified in element <priority>...</priority>"
 							<< " does not match the number of components in the simulation. Programm exit ..."
-							<< std::endl;		MARDYN_EXIT(error_message);
+							<< std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	// targets

--- a/src/plugins/NEMD/DensityControl.cpp
+++ b/src/plugins/NEMD/DensityControl.cpp
@@ -84,10 +84,9 @@ void DensityControl::readXML(XMLfileUnits& xmlconfig) {
 	_vecPriority.push_back(0);
 	const uint32_t nRet = this->tokenize_int_list(_vecPriority, strPrio);
 	if (nRet != numComponents) {
-		Log::global_log->error() << "[DensityControl] Number of component IDs specified in element <priority>...</priority>"
+		std::ostringstream error_message;		error_message << "[DensityControl] Number of component IDs specified in element <priority>...</priority>"
 							<< " does not match the number of components in the simulation. Programm exit ..."
-							<< std::endl;
-		MARDYN_EXIT(-1);
+							<< std::endl;		MARDYN_EXIT(error_message);
 	}
 
 	// targets
@@ -111,8 +110,9 @@ void DensityControl::readXML(XMLfileUnits& xmlconfig) {
 	numTargets = query.card();
 	Log::global_log->info() << "[DensityControl] Number of component targets: " << numTargets << std::endl;
 	if (numTargets < 1) {
-		Log::global_log->error() << "[DensityControl] No target parameters specified. Program exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[DensityControl] No target parameters specified. Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	const std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator nodeIter;

--- a/src/plugins/NEMD/DensityControl.cpp
+++ b/src/plugins/NEMD/DensityControl.cpp
@@ -88,7 +88,7 @@ void DensityControl::readXML(XMLfileUnits& xmlconfig) {
 		error_message << "[DensityControl] Number of component IDs specified in element <priority>...</priority>"
 							<< " does not match the number of components in the simulation. Programm exit ..."
 							<< std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	// targets
@@ -114,7 +114,7 @@ void DensityControl::readXML(XMLfileUnits& xmlconfig) {
 	if (numTargets < 1) {
 		std::ostringstream error_message;
 		error_message << "[DensityControl] No target parameters specified. Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	const std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator nodeIter;

--- a/src/plugins/NEMD/DensityControl.cpp
+++ b/src/plugins/NEMD/DensityControl.cpp
@@ -87,7 +87,7 @@ void DensityControl::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->error() << "[DensityControl] Number of component IDs specified in element <priority>...</priority>"
 							<< " does not match the number of components in the simulation. Programm exit ..."
 							<< std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	// targets
@@ -112,7 +112,7 @@ void DensityControl::readXML(XMLfileUnits& xmlconfig) {
 	Log::global_log->info() << "[DensityControl] Number of component targets: " << numTargets << std::endl;
 	if (numTargets < 1) {
 		Log::global_log->error() << "[DensityControl] No target parameters specified. Program exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	const std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator nodeIter;

--- a/src/plugins/NEMD/DistControl.cpp
+++ b/src/plugins/NEMD/DistControl.cpp
@@ -81,7 +81,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 	{
 		std::ostringstream error_message;
 		error_message << "[DistControl] Missing attribute \"subdivision@type\"! Programm exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	if("number" == strSubdivisionType)
 	{
@@ -90,7 +90,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		{
 			std::ostringstream error_message;
 			error_message << "[DistControl] Missing element \"subdivision/number\"! Programm exit..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		else
 			this->SetSubdivision(nNumSlabs);
@@ -102,7 +102,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		{
 			std::ostringstream error_message;
 			error_message << "[DistControl] Missing element \"subdivision/width\"! Programm exit..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		else
 			this->SetSubdivision(dSlabWidth);
@@ -111,7 +111,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 	{
 		std::ostringstream error_message;
 		error_message << "[DistControl] Wrong attribute \"subdivision@type\". Expected: type=\"number|width\"! Programm exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	// init method
@@ -143,7 +143,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		{
 			std::ostringstream error_message;
 			error_message << "[DistControl] Missing elements \"init/values/left\" or \"init/values/right\" or both! Programm exit..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 	else if("file" == strInitMethodType)
@@ -161,7 +161,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		{
 			std::ostringstream error_message;
 			error_message << "[DistControl] Missing elements \"init/file\" or \"init/simstep\" or both! Programm exit..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 	else
@@ -169,7 +169,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		std::ostringstream error_message;
 		error_message << "[DistControl] Wrong attribute \"init@type\", type = " << strInitMethodType << ", "
 				"expected: type=\"startconfig|values|file\"! Programm exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	// update method
@@ -198,7 +198,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		{
 			std::ostringstream error_message;
 			error_message << "[DistControl] Missing elements \"method/componentID\" or \"method/density\" or both! Programm exit..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 	else if("denderiv" == strUpdateMethodType)
@@ -223,7 +223,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		{
 			std::ostringstream error_message;
 			error_message << "[DistControl] Missing elements \"method/componentID\" or \"method/density\" or both! Programm exit..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 	else
@@ -231,7 +231,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		std::ostringstream error_message;
 		error_message << "[DistControl] Wrong attribute \"method@type\", type = " << strUpdateMethodType << ", "
 				"expected: type=\"density|denderiv\"! Programm exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -278,7 +278,7 @@ void DistControl::PrepareSubdivision()
 	default:
 		std::ostringstream error_message;
 		error_message << "[DistControl] PrepareSubdivision(): Neither _binParams.width nor _binParams.count was set correctly! Programm exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	_binParams.invWidth = 1. / _binParams.width;
@@ -715,7 +715,7 @@ void DistControl::UpdatePositionsInit(ParticleContainer* particleContainer)
 	default:
 		std::ostringstream error_message;
 		error_message << "[DistControl] Wrong Init Method! Programm exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 #ifndef NDEBUG
@@ -752,7 +752,7 @@ void DistControl::UpdatePositions(const uint64_t& simstep)
 	default:
 		std::ostringstream error_message;
 		error_message << "[DistControl] UpdatePositions() Corrupted code!!! Programm exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	// update positions

--- a/src/plugins/NEMD/DistControl.cpp
+++ b/src/plugins/NEMD/DistControl.cpp
@@ -79,16 +79,18 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 	std::string strSubdivisionType;
 	if( !xmlconfig.getNodeValue("subdivision@type", strSubdivisionType) )
 	{
-		Log::global_log->error() << "[DistControl] Missing attribute \"subdivision@type\"! Programm exit..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[DistControl] Missing attribute \"subdivision@type\"! Programm exit..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	if("number" == strSubdivisionType)
 	{
 		unsigned int nNumSlabs = 0;
 		if( !xmlconfig.getNodeValue("subdivision/number", nNumSlabs) )
 		{
-			Log::global_log->error() << "[DistControl] Missing element \"subdivision/number\"! Programm exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[DistControl] Missing element \"subdivision/number\"! Programm exit..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		else
 			this->SetSubdivision(nNumSlabs);
@@ -98,16 +100,18 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		double dSlabWidth = 0.;
 		if( !xmlconfig.getNodeValue("subdivision/width", dSlabWidth) )
 		{
-			Log::global_log->error() << "[DistControl] Missing element \"subdivision/width\"! Programm exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[DistControl] Missing element \"subdivision/width\"! Programm exit..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		else
 			this->SetSubdivision(dSlabWidth);
 	}
 	else
 	{
-		Log::global_log->error() << "[DistControl] Wrong attribute \"subdivision@type\". Expected: type=\"number|width\"! Programm exit..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[DistControl] Wrong attribute \"subdivision@type\". Expected: type=\"number|width\"! Programm exit..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	// init method
@@ -137,8 +141,9 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		}
 		else
 		{
-			Log::global_log->error() << "[DistControl] Missing elements \"init/values/left\" or \"init/values/right\" or both! Programm exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[DistControl] Missing elements \"init/values/left\" or \"init/values/right\" or both! Programm exit..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 	else if("file" == strInitMethodType)
@@ -154,15 +159,17 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		}
 		else
 		{
-			Log::global_log->error() << "[DistControl] Missing elements \"init/file\" or \"init/simstep\" or both! Programm exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[DistControl] Missing elements \"init/file\" or \"init/simstep\" or both! Programm exit..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 	else
 	{
-		Log::global_log->error() << "[DistControl] Wrong attribute \"init@type\", type = " << strInitMethodType << ", "
+		std::ostringstream error_message;
+		error_message << "[DistControl] Wrong attribute \"init@type\", type = " << strInitMethodType << ", "
 				"expected: type=\"startconfig|values|file\"! Programm exit..." << std::endl;
-		MARDYN_EXIT(-1);
+		MARDYN_EXIT(error_message);
 	}
 
 	// update method
@@ -189,8 +196,9 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		}
 		else
 		{
-			Log::global_log->error() << "[DistControl] Missing elements \"method/componentID\" or \"method/density\" or both! Programm exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[DistControl] Missing elements \"method/componentID\" or \"method/density\" or both! Programm exit..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 	else if("denderiv" == strUpdateMethodType)
@@ -213,15 +221,17 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		}
 		else
 		{
-			Log::global_log->error() << "[DistControl] Missing elements \"method/componentID\" or \"method/density\" or both! Programm exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[DistControl] Missing elements \"method/componentID\" or \"method/density\" or both! Programm exit..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 	else
 	{
-		Log::global_log->error() << "[DistControl] Wrong attribute \"method@type\", type = " << strUpdateMethodType << ", "
+		std::ostringstream error_message;
+		error_message << "[DistControl] Wrong attribute \"method@type\", type = " << strUpdateMethodType << ", "
 				"expected: type=\"density|denderiv\"! Programm exit..." << std::endl;
-		MARDYN_EXIT(-1);
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -266,8 +276,9 @@ void DistControl::PrepareSubdivision()
 		break;
 	case SDOPT_UNKNOWN:
 	default:
-		Log::global_log->error() << "[DistControl] PrepareSubdivision(): Neither _binParams.width nor _binParams.count was set correctly! Programm exit..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[DistControl] PrepareSubdivision(): Neither _binParams.width nor _binParams.count was set correctly! Programm exit..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	_binParams.invWidth = 1. / _binParams.width;
@@ -702,13 +713,14 @@ void DistControl::UpdatePositionsInit(ParticleContainer* particleContainer)
 		}
 	case DCIM_UNKNOWN:
 	default:
-		Log::global_log->error() << "[DistControl] Wrong Init Method! Programm exit..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[DistControl] Wrong Init Method! Programm exit..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 #ifndef NDEBUG
-	Log::global_log->error() << "[DistControl] _dInterfaceMidLeft = " << _dInterfaceMidLeft << std::endl;
-	Log::global_log->error() << "[DistControl] _dInterfaceMidRight = " << _dInterfaceMidRight << std::endl;
+	Log::global_log->debug() << "[DistControl] _dInterfaceMidLeft = " << _dInterfaceMidLeft << std::endl;
+	Log::global_log->debug() << "[DistControl] _dInterfaceMidRight = " << _dInterfaceMidRight << std::endl;
 #endif
 
 	// update positions
@@ -738,8 +750,9 @@ void DistControl::UpdatePositions(const uint64_t& simstep)
 		break;
 	case DCUM_UNKNOWN:
 	default:
-		Log::global_log->error() << "[DistControl] UpdatePositions() Corrupted code!!! Programm exit..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[DistControl] UpdatePositions() Corrupted code!!! Programm exit..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	// update positions

--- a/src/plugins/NEMD/DistControl.cpp
+++ b/src/plugins/NEMD/DistControl.cpp
@@ -80,7 +80,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 	if( !xmlconfig.getNodeValue("subdivision@type", strSubdivisionType) )
 	{
 		Log::global_log->error() << "[DistControl] Missing attribute \"subdivision@type\"! Programm exit..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	if("number" == strSubdivisionType)
 	{
@@ -88,7 +88,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		if( !xmlconfig.getNodeValue("subdivision/number", nNumSlabs) )
 		{
 			Log::global_log->error() << "[DistControl] Missing element \"subdivision/number\"! Programm exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 		else
 			this->SetSubdivision(nNumSlabs);
@@ -99,7 +99,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		if( !xmlconfig.getNodeValue("subdivision/width", dSlabWidth) )
 		{
 			Log::global_log->error() << "[DistControl] Missing element \"subdivision/width\"! Programm exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 		else
 			this->SetSubdivision(dSlabWidth);
@@ -107,7 +107,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 	else
 	{
 		Log::global_log->error() << "[DistControl] Wrong attribute \"subdivision@type\". Expected: type=\"number|width\"! Programm exit..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	// init method
@@ -138,7 +138,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "[DistControl] Missing elements \"init/values/left\" or \"init/values/right\" or both! Programm exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 	}
 	else if("file" == strInitMethodType)
@@ -155,14 +155,14 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "[DistControl] Missing elements \"init/file\" or \"init/simstep\" or both! Programm exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 	}
 	else
 	{
 		Log::global_log->error() << "[DistControl] Wrong attribute \"init@type\", type = " << strInitMethodType << ", "
 				"expected: type=\"startconfig|values|file\"! Programm exit..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	// update method
@@ -190,7 +190,7 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "[DistControl] Missing elements \"method/componentID\" or \"method/density\" or both! Programm exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 	}
 	else if("denderiv" == strUpdateMethodType)
@@ -214,14 +214,14 @@ void DistControl::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "[DistControl] Missing elements \"method/componentID\" or \"method/density\" or both! Programm exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 	}
 	else
 	{
 		Log::global_log->error() << "[DistControl] Wrong attribute \"method@type\", type = " << strUpdateMethodType << ", "
 				"expected: type=\"density|denderiv\"! Programm exit..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 }
 
@@ -267,7 +267,7 @@ void DistControl::PrepareSubdivision()
 	case SDOPT_UNKNOWN:
 	default:
 		Log::global_log->error() << "[DistControl] PrepareSubdivision(): Neither _binParams.width nor _binParams.count was set correctly! Programm exit..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	_binParams.invWidth = 1. / _binParams.width;
@@ -703,7 +703,7 @@ void DistControl::UpdatePositionsInit(ParticleContainer* particleContainer)
 	case DCIM_UNKNOWN:
 	default:
 		Log::global_log->error() << "[DistControl] Wrong Init Method! Programm exit..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 #ifndef NDEBUG
@@ -739,7 +739,7 @@ void DistControl::UpdatePositions(const uint64_t& simstep)
 	case DCUM_UNKNOWN:
 	default:
 		Log::global_log->error() << "[DistControl] UpdatePositions() Corrupted code!!! Programm exit..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	// update positions

--- a/src/plugins/NEMD/MettDeamon.cpp
+++ b/src/plugins/NEMD/MettDeamon.cpp
@@ -419,7 +419,7 @@ void MettDeamon::readXML(XMLfileUnits& xmlconfig)
 		if(numChanges < 1) {
 			std::ostringstream error_message;
 			error_message << "[MettDeamon] No component change defined in XML-config file. Program exit ..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		std::string oldpath = xmlconfig.getcurrentnodepath();
 		XMLfile::Query::const_iterator changeIter;
@@ -438,7 +438,7 @@ void MettDeamon::readXML(XMLfileUnits& xmlconfig)
 	else {
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] No component changes defined in XML-config file. Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -1193,7 +1193,7 @@ void MettDeamon::InsertReservoirSlab(ParticleContainer* particleContainer)
 	if(not _reservoir->nextBin(_nMaxMoleculeID.global) ) {
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] Failed to activate new bin of particle Reservoir's BinQueue => Program exit." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	Log::global_log->debug() << "[" << nRank << "]: ADDED " << numAdded.local << "/" << numParticlesCurrentSlab.local << " particles (" << numAdded.local/static_cast<float>(numParticlesCurrentSlab.local)*100 << ")%." << std::endl;
 	// calc global values
@@ -1214,7 +1214,7 @@ void MettDeamon::initRestart()
 	{
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] Failed to activate reservoir bin after restart! Program exit ... " << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	_feedrate.feed.sum = _restartInfo.dYsum;
 }
@@ -1232,7 +1232,7 @@ void MettDeamon::readNormDistr()
 	if (!ifs.vxz.is_open() || !ifs.vy.is_open() ) {
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] There was a problem opening the input file!\n";
-		MARDYN_EXIT(error_message);//exit or do additional error checking
+		MARDYN_EXIT(error_message.str());//exit or do additional error checking
 	}
 
 	double dVal = 0.0;
@@ -1250,7 +1250,7 @@ void MettDeamon::readNormDistr()
 		else {
 			std::ostringstream error_message;
 			error_message << "[MettDeamon] Something went wrong with the direction." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 	// close files
@@ -1321,7 +1321,7 @@ void Reservoir::readXML(XMLfileUnits& xmlconfig)
 	else {
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] Reservoir file type not specified or unknown. Programm exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	// Possibly change component IDs
@@ -1332,7 +1332,7 @@ void Reservoir::readXML(XMLfileUnits& xmlconfig)
 		if(numChanges < 1) {
 			std::ostringstream error_message;
 			error_message << "[MettDeamon] No component change defined in XML-config file. Program exit ..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		std::string oldpath = xmlconfig.getcurrentnodepath();
 		XMLfile::Query::const_iterator changeIter;
@@ -1362,7 +1362,7 @@ void Reservoir::readParticleData(DomainDecompBase* domainDecomp, ParticleContain
 		default:
 			std::ostringstream error_message;
 			error_message << "[MettDeamon] Unknown (or ambiguous) method to read reservoir for feature MettDeamon. Program exit ..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 	}
 
 	// sort particles into bins
@@ -1492,7 +1492,7 @@ void Reservoir::sortParticlesToBins(DomainDecompBase* domainDecomp, ParticleCont
 			default:
 				std::ostringstream error_message;
 				error_message << "[MettDeamon] Unknown moving direction" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 		}
 		// check if molecule is in bounding box of the process domain
 		bool bIsInsideBB = domainDecomp->procOwnsPos(mol.r(0), mol.r(1), mol.r(2), domain);
@@ -1524,7 +1524,7 @@ void Reservoir::sortParticlesToBins(DomainDecompBase* domainDecomp, ParticleCont
 		default:
 			std::ostringstream error_message;
 			error_message << "[MettDeamon] Unknown moving direction" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -1538,7 +1538,7 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 	if (!ifs.is_open()) {
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] Could not open Mettdeamon Reservoirfile " << _filepath.data << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	Log::global_log->info() << "[MettDeamon] Reading Mettdeamon Reservoirfile " << _filepath.data << std::endl;
 
@@ -1568,7 +1568,7 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 	if((token != "NumberOfMolecules") && (token != "N")) {
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] Expected the token 'NumberOfMolecules (N)' instead of '" << token << "'" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	ifs >> _numMoleculesRead;
 
@@ -1589,7 +1589,7 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 		else {
 			std::ostringstream error_message;
 			error_message << "[MettDeamon] Unknown molecule format '" << ntypestring << "'" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	} else {
 		ifs.seekg(spos);
@@ -1632,7 +1632,7 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 			default:
 				std::ostringstream error_message;
 				error_message << "[MettDeamon] Unknown molecule format" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 		}
 
 		if( componentid > numcomponents ) {
@@ -1642,7 +1642,7 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 								<< componentid
 								<< ">"
 								<< numcomponents << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.
@@ -1672,7 +1672,7 @@ void Reservoir::readFromFileBinaryHeader()
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] Could not find root node /mardyn in XML header file or file itself." << std::endl;
 		error_message << "[MettDeamon] Not a valid MarDyn XML header file." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	bool bInputOk = true;
@@ -1701,7 +1701,7 @@ void Reservoir::readFromFileBinaryHeader()
 	{
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] Content of file: '" << _filepath.header << "' corrupted! Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -1714,7 +1714,7 @@ void Reservoir::readFromFileBinaryHeader()
 	{
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -1734,7 +1734,7 @@ void Reservoir::readFromFileBinary(DomainDecompBase* domainDecomp, ParticleConta
 	if (!ifs.is_open()) {
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] Could not open reservoir phaseSpaceFile " << _filepath.data << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	Log::global_log->info() << "[MettDeamon] Reading phase space file " << _filepath.data << std::endl;
@@ -1755,7 +1755,7 @@ void Reservoir::readFromFileBinary(DomainDecompBase* domainDecomp, ParticleConta
 		default:
 			std::ostringstream error_message;
 			error_message << "[MettDeamon] Unknown molecule format" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 	}
 
 	for (uint64_t pi=0; pi<_numMoleculesRead; pi++) {
@@ -1840,7 +1840,7 @@ bool Reservoir::isRelevant(DomainDecompBase* domainDecomp, Domain* domain, Molec
 	default:
 		std::ostringstream error_message;
 		error_message << "[MettDeamon] Unknown moving direction" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	return domainDecomp->procOwnsPos(mol.r(0), y-dOffset, mol.r(2), domain);
 }

--- a/src/plugins/NEMD/MettDeamon.cpp
+++ b/src/plugins/NEMD/MettDeamon.cpp
@@ -417,7 +417,7 @@ void MettDeamon::readXML(XMLfileUnits& xmlconfig)
 		Log::global_log->info() << "[MettDeamon] Number of fixed molecules components: " << numChanges << std::endl;
 		if(numChanges < 1) {
 			Log::global_log->error() << "[MettDeamon] No component change defined in XML-config file. Program exit ..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 		std::string oldpath = xmlconfig.getcurrentnodepath();
 		XMLfile::Query::const_iterator changeIter;
@@ -435,7 +435,7 @@ void MettDeamon::readXML(XMLfileUnits& xmlconfig)
 	}
 	else {
 		Log::global_log->error() << "[MettDeamon] No component changes defined in XML-config file. Program exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 }
 
@@ -1189,7 +1189,7 @@ void MettDeamon::InsertReservoirSlab(ParticleContainer* particleContainer)
 	_feedrate.feed.sum -= _reservoir->getBinWidth();  // reset feed sum
 	if(not _reservoir->nextBin(_nMaxMoleculeID.global) ) {
 		Log::global_log->error() << "[MettDeamon] Failed to activate new bin of particle Reservoir's BinQueue => Program exit." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	Log::global_log->debug() << "[" << nRank << "]: ADDED " << numAdded.local << "/" << numParticlesCurrentSlab.local << " particles (" << numAdded.local/static_cast<float>(numParticlesCurrentSlab.local)*100 << ")%." << std::endl;
 	// calc global values
@@ -1209,7 +1209,7 @@ void MettDeamon::initRestart()
 	if(not bRet)
 	{
 		Log::global_log->info() << "[MettDeamon] Failed to activate reservoir bin after restart! Program exit ... " << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	_feedrate.feed.sum = _restartInfo.dYsum;
 }
@@ -1226,7 +1226,7 @@ void MettDeamon::readNormDistr()
 	//check to see that the file was opened correctly:
 	if (!ifs.vxz.is_open() || !ifs.vy.is_open() ) {
 		std::cerr << "[MettDeamon] There was a problem opening the input file!\n";
-		mardyn_exit(-1);//exit or do additional error checking
+		MARDYN_EXIT(-1);//exit or do additional error checking
 	}
 
 	double dVal = 0.0;
@@ -1240,7 +1240,7 @@ void MettDeamon::readNormDistr()
 		else if (MD_RIGHT_TO_LEFT == _nMovingDirection)
 			_norm.vy.push_back( abs(dVal) * (-1.) );
 		else
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 	}
 	// close files
 	ifs.vxz.close();
@@ -1309,7 +1309,7 @@ void Reservoir::readXML(XMLfileUnits& xmlconfig)
 	}
 	else {
 		Log::global_log->error() << "[MettDeamon] Reservoir file type not specified or unknown. Programm exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	// Possibly change component IDs
@@ -1319,7 +1319,7 @@ void Reservoir::readXML(XMLfileUnits& xmlconfig)
 		numChanges = query.card();
 		if(numChanges < 1) {
 			Log::global_log->error() << "[MettDeamon] No component change defined in XML-config file. Program exit ..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 		std::string oldpath = xmlconfig.getcurrentnodepath();
 		XMLfile::Query::const_iterator changeIter;
@@ -1348,7 +1348,7 @@ void Reservoir::readParticleData(DomainDecompBase* domainDecomp, ParticleContain
 			break;
 		default:
 			Log::global_log->error() << "[MettDeamon] Unknown (or ambiguous) method to read reservoir for feature MettDeamon. Program exit ..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 	}
 
 	// sort particles into bins
@@ -1519,7 +1519,7 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 	ifs.open( _filepath.data.c_str() );
 	if (!ifs.is_open()) {
 		Log::global_log->error() << "[MettDeamon] Could not open Mettdeamon Reservoirfile " << _filepath.data << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	Log::global_log->info() << "[MettDeamon] Reading Mettdeamon Reservoirfile " << _filepath.data << std::endl;
 
@@ -1548,7 +1548,7 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 
 	if((token != "NumberOfMolecules") && (token != "N")) {
 		Log::global_log->error() << "[MettDeamon] Expected the token 'NumberOfMolecules (N)' instead of '" << token << "'" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	ifs >> _numMoleculesRead;
 
@@ -1568,7 +1568,7 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 		else if (ntypestring == "IRV")  ntype = IRV;
 		else {
 			Log::global_log->error() << "[MettDeamon] Unknown molecule format '" << ntypestring << "'" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 	} else {
 		ifs.seekg(spos);
@@ -1618,7 +1618,7 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 								<< componentid
 								<< ">"
 								<< numcomponents << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.
@@ -1647,7 +1647,7 @@ void Reservoir::readFromFileBinaryHeader()
 	if(not inp.changecurrentnode("/mardyn")) {
 		Log::global_log->error() << "[MettDeamon] Could not find root node /mardyn in XML header file or file itself." << std::endl;
 		Log::global_log->fatal() << "[MettDeamon] Not a valid MarDyn XML header file." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	bool bInputOk = true;
@@ -1675,7 +1675,7 @@ void Reservoir::readFromFileBinaryHeader()
 	if(not bInputOk)
 	{
 		Log::global_log->error() << "[MettDeamon] Content of file: '" << _filepath.header << "' corrupted! Program exit ..." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -1687,7 +1687,7 @@ void Reservoir::readFromFileBinaryHeader()
 	else
 	{
 		Log::global_log->error() << "[MettDeamon] Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 }
 
@@ -1706,7 +1706,7 @@ void Reservoir::readFromFileBinary(DomainDecompBase* domainDecomp, ParticleConta
 	ifs.open(_filepath.data.c_str(), std::ios::binary | std::ios::in);
 	if (!ifs.is_open()) {
 		Log::global_log->error() << "[MettDeamon] Could not open reservoir phaseSpaceFile " << _filepath.data << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	Log::global_log->info() << "[MettDeamon] Reading phase space file " << _filepath.data << std::endl;

--- a/src/plugins/NEMD/MettDeamon.cpp
+++ b/src/plugins/NEMD/MettDeamon.cpp
@@ -24,6 +24,7 @@
 #include <map>
 #include <array>
 #include <fstream>
+#include <sstream>
 #include <vector>
 #include <cmath>
 #include <iomanip>
@@ -416,8 +417,9 @@ void MettDeamon::readXML(XMLfileUnits& xmlconfig)
 		numChanges = query.card();
 		Log::global_log->info() << "[MettDeamon] Number of fixed molecules components: " << numChanges << std::endl;
 		if(numChanges < 1) {
-			Log::global_log->error() << "[MettDeamon] No component change defined in XML-config file. Program exit ..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[MettDeamon] No component change defined in XML-config file. Program exit ..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		std::string oldpath = xmlconfig.getcurrentnodepath();
 		XMLfile::Query::const_iterator changeIter;
@@ -434,8 +436,9 @@ void MettDeamon::readXML(XMLfileUnits& xmlconfig)
 		xmlconfig.changecurrentnode("..");
 	}
 	else {
-		Log::global_log->error() << "[MettDeamon] No component changes defined in XML-config file. Program exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] No component changes defined in XML-config file. Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -1188,8 +1191,9 @@ void MettDeamon::InsertReservoirSlab(ParticleContainer* particleContainer)
 	}
 	_feedrate.feed.sum -= _reservoir->getBinWidth();  // reset feed sum
 	if(not _reservoir->nextBin(_nMaxMoleculeID.global) ) {
-		Log::global_log->error() << "[MettDeamon] Failed to activate new bin of particle Reservoir's BinQueue => Program exit." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] Failed to activate new bin of particle Reservoir's BinQueue => Program exit." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->debug() << "[" << nRank << "]: ADDED " << numAdded.local << "/" << numParticlesCurrentSlab.local << " particles (" << numAdded.local/static_cast<float>(numParticlesCurrentSlab.local)*100 << ")%." << std::endl;
 	// calc global values
@@ -1208,8 +1212,9 @@ void MettDeamon::initRestart()
 	bool bRet = _reservoir->activateBin(_restartInfo.nBindindex);
 	if(not bRet)
 	{
-		Log::global_log->info() << "[MettDeamon] Failed to activate reservoir bin after restart! Program exit ... " << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] Failed to activate reservoir bin after restart! Program exit ... " << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	_feedrate.feed.sum = _restartInfo.dYsum;
 }
@@ -1225,8 +1230,9 @@ void MettDeamon::readNormDistr()
 
 	//check to see that the file was opened correctly:
 	if (!ifs.vxz.is_open() || !ifs.vy.is_open() ) {
-		std::cerr << "[MettDeamon] There was a problem opening the input file!\n";
-		MARDYN_EXIT(-1);//exit or do additional error checking
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] There was a problem opening the input file!\n";
+		MARDYN_EXIT(error_message);//exit or do additional error checking
 	}
 
 	double dVal = 0.0;
@@ -1235,12 +1241,17 @@ void MettDeamon::readNormDistr()
 		_norm.vxz.push_back(dVal);
 	}
 	while (ifs.vy >> dVal) {
-		if(MD_LEFT_TO_RIGHT == _nMovingDirection)
+		if (MD_LEFT_TO_RIGHT == _nMovingDirection) {
 			_norm.vy.push_back( abs(dVal) );
-		else if (MD_RIGHT_TO_LEFT == _nMovingDirection)
+		}
+		else if (MD_RIGHT_TO_LEFT == _nMovingDirection) {
 			_norm.vy.push_back( abs(dVal) * (-1.) );
-		else
-			MARDYN_EXIT(-1);
+		}
+		else {
+			std::ostringstream error_message;
+			error_message << "[MettDeamon] Something went wrong with the direction." << std::endl;
+			MARDYN_EXIT(error_message);
+		}
 	}
 	// close files
 	ifs.vxz.close();
@@ -1308,8 +1319,9 @@ void Reservoir::readXML(XMLfileUnits& xmlconfig)
 		xmlconfig.getNodeValue("file/data", _filepath.data);
 	}
 	else {
-		Log::global_log->error() << "[MettDeamon] Reservoir file type not specified or unknown. Programm exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] Reservoir file type not specified or unknown. Programm exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	// Possibly change component IDs
@@ -1318,8 +1330,9 @@ void Reservoir::readXML(XMLfileUnits& xmlconfig)
 		XMLfile::Query query = xmlconfig.query("change");
 		numChanges = query.card();
 		if(numChanges < 1) {
-			Log::global_log->error() << "[MettDeamon] No component change defined in XML-config file. Program exit ..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[MettDeamon] No component change defined in XML-config file. Program exit ..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		std::string oldpath = xmlconfig.getcurrentnodepath();
 		XMLfile::Query::const_iterator changeIter;
@@ -1347,8 +1360,9 @@ void Reservoir::readParticleData(DomainDecompBase* domainDecomp, ParticleContain
 			this->readFromFileBinary(domainDecomp, particleContainer);
 			break;
 		default:
-			Log::global_log->error() << "[MettDeamon] Unknown (or ambiguous) method to read reservoir for feature MettDeamon. Program exit ..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[MettDeamon] Unknown (or ambiguous) method to read reservoir for feature MettDeamon. Program exit ..." << std::endl;
+			MARDYN_EXIT(error_message);
 	}
 
 	// sort particles into bins
@@ -1476,7 +1490,9 @@ void Reservoir::sortParticlesToBins(DomainDecompBase* domainDecomp, ParticleCont
 				mol.setr(1, y - nBinIndex*_dBinWidth + (domain->getGlobalLength(1) - _dBinWidth) );
 				break;
 			default:
-				Log::global_log->error() << "[MettDeamon] Unknown moving direction" << std::endl;
+				std::ostringstream error_message;
+				error_message << "[MettDeamon] Unknown moving direction" << std::endl;
+				MARDYN_EXIT(error_message);
 		}
 		// check if molecule is in bounding box of the process domain
 		bool bIsInsideBB = domainDecomp->procOwnsPos(mol.r(0), mol.r(1), mol.r(2), domain);
@@ -1506,7 +1522,9 @@ void Reservoir::sortParticlesToBins(DomainDecompBase* domainDecomp, ParticleCont
 			}
 			break;
 		default:
-			Log::global_log->error() << "[MettDeamon] Unknown moving direction" << std::endl;
+			std::ostringstream error_message;
+			error_message << "[MettDeamon] Unknown moving direction" << std::endl;
+			MARDYN_EXIT(error_message);
 	}
 }
 
@@ -1518,8 +1536,9 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 	Log::global_log->info() << "[MettDeamon] Opening Reservoirfile " << _filepath.data << std::endl;
 	ifs.open( _filepath.data.c_str() );
 	if (!ifs.is_open()) {
-		Log::global_log->error() << "[MettDeamon] Could not open Mettdeamon Reservoirfile " << _filepath.data << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] Could not open Mettdeamon Reservoirfile " << _filepath.data << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info() << "[MettDeamon] Reading Mettdeamon Reservoirfile " << _filepath.data << std::endl;
 
@@ -1547,8 +1566,9 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 	}
 
 	if((token != "NumberOfMolecules") && (token != "N")) {
-		Log::global_log->error() << "[MettDeamon] Expected the token 'NumberOfMolecules (N)' instead of '" << token << "'" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] Expected the token 'NumberOfMolecules (N)' instead of '" << token << "'" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	ifs >> _numMoleculesRead;
 
@@ -1567,8 +1587,9 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 		else if (ntypestring == "ICRV") ntype = ICRV;
 		else if (ntypestring == "IRV")  ntype = IRV;
 		else {
-			Log::global_log->error() << "[MettDeamon] Unknown molecule format '" << ntypestring << "'" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "[MettDeamon] Unknown molecule format '" << ntypestring << "'" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	} else {
 		ifs.seekg(spos);
@@ -1609,16 +1630,19 @@ void Reservoir::readFromFile(DomainDecompBase* domainDecomp, ParticleContainer* 
 				ifs >> id >> x >> y >> z >> vx >> vy >> vz;
 				break;
 			default:
-				Log::global_log->error() << "[MettDeamon] Unknown molecule format" << std::endl;
+				std::ostringstream error_message;
+				error_message << "[MettDeamon] Unknown molecule format" << std::endl;
+				MARDYN_EXIT(error_message);
 		}
 
 		if( componentid > numcomponents ) {
-			Log::global_log->error() << "[MettDeamon] Molecule id " << id
+			std::ostringstream error_message;
+			error_message << "[MettDeamon] Molecule id " << id
 								<< " has a component ID greater than the existing number of components: "
 								<< componentid
 								<< ">"
 								<< numcomponents << std::endl;
-			MARDYN_EXIT(1);
+			MARDYN_EXIT(error_message);
 		}
 		// ComponentIDs are used as array IDs, hence need to start at 0.
 		// In the input files they always start with 1 so we need to adapt that all the time.
@@ -1645,9 +1669,10 @@ void Reservoir::readFromFileBinaryHeader()
 	XMLfileUnits inp(_filepath.header);
 
 	if(not inp.changecurrentnode("/mardyn")) {
-		Log::global_log->error() << "[MettDeamon] Could not find root node /mardyn in XML header file or file itself." << std::endl;
-		Log::global_log->fatal() << "[MettDeamon] Not a valid MarDyn XML header file." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] Could not find root node /mardyn in XML header file or file itself." << std::endl;
+		error_message << "[MettDeamon] Not a valid MarDyn XML header file." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	bool bInputOk = true;
@@ -1674,8 +1699,9 @@ void Reservoir::readFromFileBinaryHeader()
 
 	if(not bInputOk)
 	{
-		Log::global_log->error() << "[MettDeamon] Content of file: '" << _filepath.header << "' corrupted! Program exit ..." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] Content of file: '" << _filepath.header << "' corrupted! Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	if("ICRVQD" == strMoleculeFormat)
@@ -1686,8 +1712,9 @@ void Reservoir::readFromFileBinaryHeader()
 		_nMoleculeFormat = ICRV;
 	else
 	{
-		Log::global_log->error() << "[MettDeamon] Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] Not a valid molecule format: " << strMoleculeFormat << ", program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -1705,8 +1732,9 @@ void Reservoir::readFromFileBinary(DomainDecompBase* domainDecomp, ParticleConta
 	std::ifstream ifs;
 	ifs.open(_filepath.data.c_str(), std::ios::binary | std::ios::in);
 	if (!ifs.is_open()) {
-		Log::global_log->error() << "[MettDeamon] Could not open reservoir phaseSpaceFile " << _filepath.data << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] Could not open reservoir phaseSpaceFile " << _filepath.data << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	Log::global_log->info() << "[MettDeamon] Reading phase space file " << _filepath.data << std::endl;
@@ -1724,7 +1752,10 @@ void Reservoir::readFromFileBinary(DomainDecompBase* domainDecomp, ParticleConta
 		case IRV:
 			_moleculeDataReader = std::make_unique<MoleculeDataReaderIRV>();
 			break;
-		default: Log::global_log->error() << "[MettDeamon] Unknown molecule format" << std::endl;
+		default:
+			std::ostringstream error_message;
+			error_message << "[MettDeamon] Unknown molecule format" << std::endl;
+			MARDYN_EXIT(error_message);
 	}
 
 	for (uint64_t pi=0; pi<_numMoleculesRead; pi++) {
@@ -1807,7 +1838,9 @@ bool Reservoir::isRelevant(DomainDecompBase* domainDecomp, Domain* domain, Molec
 		dOffset = nBinIndex*_dBinWidth + (domain->getGlobalLength(1) - _dBinWidth);
 		break;
 	default:
-		Log::global_log->error() << "[MettDeamon] Unknown moving direction" << std::endl;
+		std::ostringstream error_message;
+		error_message << "[MettDeamon] Unknown moving direction" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	return domainDecomp->procOwnsPos(mol.r(0), y-dOffset, mol.r(2), domain);
 }

--- a/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
+++ b/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
@@ -134,12 +134,14 @@ void MettDeamonFeedrateDirector::beforeForces(
 
 	// Check if other plugins were found
 	if(nullptr == mirror) {
-		Log::global_log->error() << "[MettDeamonFeedrateDirector] No Mirror plugin found in plugin list. Program exit ..." << std::endl;
-		MARDYN_EXIT(-2004);
+		std::ostringstream error_message;
+		error_message << "[MettDeamonFeedrateDirector] No Mirror plugin found in plugin list. Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	if(nullptr == mettDeamon) {
-		Log::global_log->error() << "[MettDeamonFeedrateDirector] No MettDeamon plugin found in plugin list. Program exit ..." << std::endl;
-		MARDYN_EXIT(-2004);
+		std::ostringstream error_message;
+		error_message << "[MettDeamonFeedrateDirector] No MettDeamon plugin found in plugin list. Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	// Get number of deleted/reflected particles from Mirror plugin

--- a/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
+++ b/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
@@ -136,12 +136,12 @@ void MettDeamonFeedrateDirector::beforeForces(
 	if(nullptr == mirror) {
 		std::ostringstream error_message;
 		error_message << "[MettDeamonFeedrateDirector] No Mirror plugin found in plugin list. Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	if(nullptr == mettDeamon) {
 		std::ostringstream error_message;
 		error_message << "[MettDeamonFeedrateDirector] No MettDeamon plugin found in plugin list. Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	// Get number of deleted/reflected particles from Mirror plugin

--- a/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
+++ b/src/plugins/NEMD/MettDeamonFeedrateDirector.cpp
@@ -135,11 +135,11 @@ void MettDeamonFeedrateDirector::beforeForces(
 	// Check if other plugins were found
 	if(nullptr == mirror) {
 		Log::global_log->error() << "[MettDeamonFeedrateDirector] No Mirror plugin found in plugin list. Program exit ..." << std::endl;
-		mardyn_exit(-2004);
+		MARDYN_EXIT(-2004);
 	}
 	if(nullptr == mettDeamon) {
 		Log::global_log->error() << "[MettDeamonFeedrateDirector] No MettDeamon plugin found in plugin list. Program exit ..." << std::endl;
-		mardyn_exit(-2004);
+		MARDYN_EXIT(-2004);
 	}
 
 	// Get number of deleted/reflected particles from Mirror plugin

--- a/src/plugins/NEMD/RegionSampling.cpp
+++ b/src/plugins/NEMD/RegionSampling.cpp
@@ -172,7 +172,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "RegionSampling->region["<<this->GetID()<<"]: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 	}
 
@@ -184,7 +184,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 	Log::global_log->info() << "RegionSampling->region["<<this->GetID()-1<<"]: Number of sampling modules: " << numSamplingModules << std::endl;
 	if(numSamplingModules < 1) {
 		Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: No sampling module parameters specified. Program exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	XMLfile::Query::const_iterator outputSamplingIter;
@@ -220,7 +220,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			if( !xmlconfig.getNodeValue("subdivision@type", strSubdivisionType) )
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing attribute subdivision@type! Program exit..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 			if("number" == strSubdivisionType)
 			{
@@ -228,7 +228,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if( !xmlconfig.getNodeValue("subdivision/number", nNumSlabs) )
 				{
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/number! Program exit..." << std::endl;
-					mardyn_exit(-1);
+					MARDYN_EXIT(-1);
 				}
 				else
 				{
@@ -242,7 +242,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if( !xmlconfig.getNodeValue("subdivision/width", dSlabWidth) )
 				{
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/width! Program exit..." << std::endl;
-					mardyn_exit(-1);
+					MARDYN_EXIT(-1);
 				}
 				else
 				{
@@ -253,7 +253,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			else
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Wrong attribute subdivision@type. Expected type=\"number|width\"! Program exit..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 		}
 		else if("VDF" == strSamplingModuleType || "FDF" == strSamplingModuleType)
@@ -297,7 +297,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				Log::global_log->info() << "RegionSampling->region["<<this->GetID()-1<<"]: Number of velocity discretizations: " << numDiscretizations << std::endl;
 				if(numDiscretizations < 1) {
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: No velocity discretizations specified for VDF sampling. Program exit ..." << std::endl;
-					mardyn_exit(-1);
+					MARDYN_EXIT(-1);
 				}
 				XMLfile::Query::const_iterator nodeIter;
 				for( nodeIter = query_vd.begin(); nodeIter != query_vd.end(); nodeIter++ )
@@ -307,7 +307,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 					bool bVal = xmlconfig.getNodeValue("@cid", cid);
 					if( (cid > _numComponents) || ((not bVal) && (not _boolSingleComp)) ){
 						Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: VDF velocity discretization corrupted. Program exit ..." << std::endl;
-						mardyn_exit(-1);
+						MARDYN_EXIT(-1);
 					}
 
 					if(_boolSingleComp){
@@ -334,7 +334,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			if( !xmlconfig.getNodeValue("subdivision@type", strSubdivisionType) )
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing attribute subdivision@type! Program exit..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 			if("number" == strSubdivisionType)
 			{
@@ -342,7 +342,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if( !xmlconfig.getNodeValue("subdivision/number", nNumSlabs) )
 				{
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/number! Program exit..." << std::endl;
-					mardyn_exit(-1);
+					MARDYN_EXIT(-1);
 				}
 				else
 				{
@@ -356,7 +356,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if( !xmlconfig.getNodeValue("subdivision/width", dSlabWidth) )
 				{
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/width! Program exit..." << std::endl;
-					mardyn_exit(-1);
+					MARDYN_EXIT(-1);
 				}
 				else
 				{
@@ -367,7 +367,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			else
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Wrong attribute subdivision@type. Expected type=\"number|width\"! Program exit..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 		}
 		else if("fieldYR" == strSamplingModuleType)
@@ -398,7 +398,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			else
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters of element: 'outputfile' corrupted! Program exit..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 
 			// control
@@ -415,7 +415,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			else
 			{
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters of element: 'control' corrupted! Program exit..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 
 			// subdivision of region
@@ -425,7 +425,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			if(numSubdivisions != 2) {
 				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: Found " << numSubdivisions << " 'subdivision' elements, "
 						"expected: 2. Program exit ..." << std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 			std::string oldpath = xmlconfig.getcurrentnodepath();
 			XMLfile::Query::const_iterator outputSubdivisionIter;
@@ -474,7 +474,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if(not bInputIsValid)
 				{
 					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters for elements: 'subdivision' corrupted! Program exit..." << std::endl;
-					mardyn_exit(-1);
+					MARDYN_EXIT(-1);
 				}
 			}  // for( outputSubdivisionIter = query.begin(); outputSubdivisionIter; outputSubdivisionIter++ )
 			xmlconfig.changecurrentnode(oldpath);
@@ -482,7 +482,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 		else
 		{
 			Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: Wrong attribute 'sampling@type', expected type='profiles|VDF|fieldYR'! Program exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 	}  // for( outputSamplingIter = query.begin(); outputSamplingIter; outputSamplingIter++ )
 }
@@ -555,7 +555,7 @@ void SampleRegion::prepareSubdivisionFieldYR()
 	case SDOPT_UNKNOWN:
 	default:
 		Log::global_log->error() << "SampleRegion::PrepareSubdivisionFieldYR(): Unknown subdivision type! Program exit..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	dWidth = (this->GetWidth(0) < this->GetWidth(2) ) ? this->GetWidth(0) : this->GetWidth(2);
@@ -574,7 +574,7 @@ void SampleRegion::prepareSubdivisionFieldYR()
 	case SDOPT_UNKNOWN:
 	default:
 		Log::global_log->error() << "SampleRegion::PrepareSubdivisionFieldYR(): Unknown subdivision type! Program exit..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 }
 
@@ -2048,7 +2048,7 @@ void RegionSampling::readXML(XMLfileUnits& xmlconfig)
 	Log::global_log->info() << "RegionSampling: Number of sampling regions: " << numRegions << std::endl;
 	if(numRegions < 1) {
 		Log::global_log->warning() << "RegionSampling: No region parameters specified. Program exit ..." << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator outputRegionIter;

--- a/src/plugins/NEMD/RegionSampling.cpp
+++ b/src/plugins/NEMD/RegionSampling.cpp
@@ -173,7 +173,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 		{
 			std::ostringstream error_message;
 			error_message << "RegionSampling->region["<<this->GetID()<<"]: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 
@@ -186,7 +186,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 	if(numSamplingModules < 1) {
 		std::ostringstream error_message;
 		error_message << "RegionSampling->region["<<this->GetID()-1<<"]: No sampling module parameters specified. Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	XMLfile::Query::const_iterator outputSamplingIter;
@@ -223,7 +223,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			{
 				std::ostringstream error_message;
 				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing attribute subdivision@type! Program exit..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			if("number" == strSubdivisionType)
 			{
@@ -232,7 +232,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				{
 					std::ostringstream error_message;
 					error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/number! Program exit..." << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 				else
 				{
@@ -247,7 +247,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				{
 					std::ostringstream error_message;
 					error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/width! Program exit..." << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 				else
 				{
@@ -259,7 +259,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			{
 				std::ostringstream error_message;
 				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Wrong attribute subdivision@type. Expected type=\"number|width\"! Program exit..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		}
 		else if("VDF" == strSamplingModuleType || "FDF" == strSamplingModuleType)
@@ -304,7 +304,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				if(numDiscretizations < 1) {
 					std::ostringstream error_message;
 					error_message << "RegionSampling->region["<<this->GetID()-1<<"]: No velocity discretizations specified for VDF sampling. Program exit ..." << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 				XMLfile::Query::const_iterator nodeIter;
 				for( nodeIter = query_vd.begin(); nodeIter != query_vd.end(); nodeIter++ )
@@ -315,7 +315,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 					if( (cid > _numComponents) || ((not bVal) && (not _boolSingleComp)) ){
 						std::ostringstream error_message;
 						error_message << "RegionSampling->region["<<this->GetID()-1<<"]: VDF velocity discretization corrupted. Program exit ..." << std::endl;
-						MARDYN_EXIT(error_message);
+						MARDYN_EXIT(error_message.str());
 					}
 
 					if(_boolSingleComp){
@@ -343,7 +343,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			{
 				std::ostringstream error_message;
 				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing attribute subdivision@type! Program exit..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			if("number" == strSubdivisionType)
 			{
@@ -352,7 +352,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				{
 					std::ostringstream error_message;
 					error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/number! Program exit..." << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 				else
 				{
@@ -367,7 +367,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				{
 					std::ostringstream error_message;
 					error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/width! Program exit..." << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 				else
 				{
@@ -379,7 +379,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			{
 				std::ostringstream error_message;
 				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Wrong attribute subdivision@type. Expected type=\"number|width\"! Program exit..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		}
 		else if("fieldYR" == strSamplingModuleType)
@@ -411,7 +411,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			{
 				std::ostringstream error_message;
 				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters of element: 'outputfile' corrupted! Program exit..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 
 			// control
@@ -429,7 +429,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			{
 				std::ostringstream error_message;
 				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters of element: 'control' corrupted! Program exit..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 
 			// subdivision of region
@@ -440,7 +440,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				std::ostringstream error_message;
 				error_message << "RegionSampling->region["<<this->GetID()-1<<"]: Found " << numSubdivisions << " 'subdivision' elements, "
 						"expected: 2. Program exit ..." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 			std::string oldpath = xmlconfig.getcurrentnodepath();
 			XMLfile::Query::const_iterator outputSubdivisionIter;
@@ -490,7 +490,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				{
 					std::ostringstream error_message;
 					error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters for elements: 'subdivision' corrupted! Program exit..." << std::endl;
-					MARDYN_EXIT(error_message);
+					MARDYN_EXIT(error_message.str());
 				}
 			}  // for( outputSubdivisionIter = query.begin(); outputSubdivisionIter; outputSubdivisionIter++ )
 			xmlconfig.changecurrentnode(oldpath);
@@ -499,7 +499,7 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 		{
 			std::ostringstream error_message;
 			error_message << "RegionSampling->region["<<this->GetID()-1<<"]: Wrong attribute 'sampling@type', expected type='profiles|VDF|fieldYR'! Program exit..." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}  // for( outputSamplingIter = query.begin(); outputSamplingIter; outputSamplingIter++ )
 }
@@ -525,7 +525,7 @@ void SampleRegion::prepareSubdivisionProfiles()
 	default:
 		std::ostringstream error_message;
 		error_message << "tec::ControlRegion::PrepareSubdivisionProfiles(): Unknown subdivision type! Program exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -550,7 +550,7 @@ void SampleRegion::prepareSubdivisionVDF()
 	default:
 		std::ostringstream error_message;
 		error_message << "ERROR in SampleRegion::PrepareSubdivisionVDF(): Unknown subdivision type! Program exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -575,7 +575,7 @@ void SampleRegion::prepareSubdivisionFieldYR()
 	default:
 		std::ostringstream error_message;
 		error_message << "SampleRegion::PrepareSubdivisionFieldYR(): Unknown subdivision type! Program exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	dWidth = (this->GetWidth(0) < this->GetWidth(2) ) ? this->GetWidth(0) : this->GetWidth(2);
@@ -595,7 +595,7 @@ void SampleRegion::prepareSubdivisionFieldYR()
 	default:
 		std::ostringstream error_message;
 		error_message << "SampleRegion::PrepareSubdivisionFieldYR(): Unknown subdivision type! Program exit..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -2070,7 +2070,7 @@ void RegionSampling::readXML(XMLfileUnits& xmlconfig)
 	if(numRegions < 1) {
 		std::ostringstream error_message;
 		error_message << "RegionSampling: No region parameters specified. Program exit ..." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator outputRegionIter;

--- a/src/plugins/NEMD/RegionSampling.cpp
+++ b/src/plugins/NEMD/RegionSampling.cpp
@@ -171,8 +171,9 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			distControl->registerObserver(this);
 		else
 		{
-			Log::global_log->error() << "RegionSampling->region["<<this->GetID()<<"]: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "RegionSampling->region["<<this->GetID()<<"]: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 
@@ -183,8 +184,9 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 	numSamplingModules = query.card();
 	Log::global_log->info() << "RegionSampling->region["<<this->GetID()-1<<"]: Number of sampling modules: " << numSamplingModules << std::endl;
 	if(numSamplingModules < 1) {
-		Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: No sampling module parameters specified. Program exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "RegionSampling->region["<<this->GetID()-1<<"]: No sampling module parameters specified. Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	XMLfile::Query::const_iterator outputSamplingIter;
@@ -219,16 +221,18 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			std::string strSubdivisionType;
 			if( !xmlconfig.getNodeValue("subdivision@type", strSubdivisionType) )
 			{
-				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing attribute subdivision@type! Program exit..." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing attribute subdivision@type! Program exit..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			if("number" == strSubdivisionType)
 			{
 				unsigned int nNumSlabs = 0;
 				if( !xmlconfig.getNodeValue("subdivision/number", nNumSlabs) )
 				{
-					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/number! Program exit..." << std::endl;
-					MARDYN_EXIT(-1);
+					std::ostringstream error_message;
+					error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/number! Program exit..." << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 				else
 				{
@@ -241,8 +245,9 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				double dSlabWidth = 0.;
 				if( !xmlconfig.getNodeValue("subdivision/width", dSlabWidth) )
 				{
-					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/width! Program exit..." << std::endl;
-					MARDYN_EXIT(-1);
+					std::ostringstream error_message;
+					error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/width! Program exit..." << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 				else
 				{
@@ -252,8 +257,9 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			}
 			else
 			{
-				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Wrong attribute subdivision@type. Expected type=\"number|width\"! Program exit..." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Wrong attribute subdivision@type. Expected type=\"number|width\"! Program exit..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 		}
 		else if("VDF" == strSamplingModuleType || "FDF" == strSamplingModuleType)
@@ -296,8 +302,9 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				numDiscretizations = query_vd.card();
 				Log::global_log->info() << "RegionSampling->region["<<this->GetID()-1<<"]: Number of velocity discretizations: " << numDiscretizations << std::endl;
 				if(numDiscretizations < 1) {
-					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: No velocity discretizations specified for VDF sampling. Program exit ..." << std::endl;
-					MARDYN_EXIT(-1);
+					std::ostringstream error_message;
+					error_message << "RegionSampling->region["<<this->GetID()-1<<"]: No velocity discretizations specified for VDF sampling. Program exit ..." << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 				XMLfile::Query::const_iterator nodeIter;
 				for( nodeIter = query_vd.begin(); nodeIter != query_vd.end(); nodeIter++ )
@@ -306,8 +313,9 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 					uint32_t cid = 0;
 					bool bVal = xmlconfig.getNodeValue("@cid", cid);
 					if( (cid > _numComponents) || ((not bVal) && (not _boolSingleComp)) ){
-						Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: VDF velocity discretization corrupted. Program exit ..." << std::endl;
-						MARDYN_EXIT(-1);
+						std::ostringstream error_message;
+						error_message << "RegionSampling->region["<<this->GetID()-1<<"]: VDF velocity discretization corrupted. Program exit ..." << std::endl;
+						MARDYN_EXIT(error_message);
 					}
 
 					if(_boolSingleComp){
@@ -333,16 +341,18 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			std::string strSubdivisionType;
 			if( !xmlconfig.getNodeValue("subdivision@type", strSubdivisionType) )
 			{
-				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing attribute subdivision@type! Program exit..." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing attribute subdivision@type! Program exit..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 			if("number" == strSubdivisionType)
 			{
 				unsigned int nNumSlabs = 0;
 				if( !xmlconfig.getNodeValue("subdivision/number", nNumSlabs) )
 				{
-					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/number! Program exit..." << std::endl;
-					MARDYN_EXIT(-1);
+					std::ostringstream error_message;
+					error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/number! Program exit..." << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 				else
 				{
@@ -355,8 +365,9 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				double dSlabWidth = 0.;
 				if( !xmlconfig.getNodeValue("subdivision/width", dSlabWidth) )
 				{
-					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/width! Program exit..." << std::endl;
-					MARDYN_EXIT(-1);
+					std::ostringstream error_message;
+					error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Missing element subdivision/width! Program exit..." << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 				else
 				{
@@ -366,8 +377,9 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			}
 			else
 			{
-				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Wrong attribute subdivision@type. Expected type=\"number|width\"! Program exit..." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Wrong attribute subdivision@type. Expected type=\"number|width\"! Program exit..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 		}
 		else if("fieldYR" == strSamplingModuleType)
@@ -397,8 +409,9 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 				"staring with prefix: " << _strFilePrefixFieldYR << std::endl;
 			else
 			{
-				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters of element: 'outputfile' corrupted! Program exit..." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters of element: 'outputfile' corrupted! Program exit..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 
 			// control
@@ -414,8 +427,9 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			}
 			else
 			{
-				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters of element: 'control' corrupted! Program exit..." << std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;
+				error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters of element: 'control' corrupted! Program exit..." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 
 			// subdivision of region
@@ -423,9 +437,10 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 			XMLfile::Query query_sd = xmlconfig.query("subdivision");
 			numSubdivisions = query_sd.card();
 			if(numSubdivisions != 2) {
-				Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: Found " << numSubdivisions << " 'subdivision' elements, "
+				std::ostringstream error_message;
+				error_message << "RegionSampling->region["<<this->GetID()-1<<"]: Found " << numSubdivisions << " 'subdivision' elements, "
 						"expected: 2. Program exit ..." << std::endl;
-				MARDYN_EXIT(-1);
+				MARDYN_EXIT(error_message);
 			}
 			std::string oldpath = xmlconfig.getcurrentnodepath();
 			XMLfile::Query::const_iterator outputSubdivisionIter;
@@ -473,16 +488,18 @@ void SampleRegion::readXML(XMLfileUnits& xmlconfig)
 
 				if(not bInputIsValid)
 				{
-					Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters for elements: 'subdivision' corrupted! Program exit..." << std::endl;
-					MARDYN_EXIT(-1);
+					std::ostringstream error_message;
+					error_message << "RegionSampling->region["<<this->GetID()-1<<"]->sampling('"<<strSamplingModuleType<<"'): Parameters for elements: 'subdivision' corrupted! Program exit..." << std::endl;
+					MARDYN_EXIT(error_message);
 				}
 			}  // for( outputSubdivisionIter = query.begin(); outputSubdivisionIter; outputSubdivisionIter++ )
 			xmlconfig.changecurrentnode(oldpath);
 		}
 		else
 		{
-			Log::global_log->error() << "RegionSampling->region["<<this->GetID()-1<<"]: Wrong attribute 'sampling@type', expected type='profiles|VDF|fieldYR'! Program exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "RegionSampling->region["<<this->GetID()-1<<"]: Wrong attribute 'sampling@type', expected type='profiles|VDF|fieldYR'! Program exit..." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}  // for( outputSamplingIter = query.begin(); outputSamplingIter; outputSamplingIter++ )
 }
@@ -506,8 +523,9 @@ void SampleRegion::prepareSubdivisionProfiles()
 		break;
 	case SDOPT_UNKNOWN:
 	default:
-		Log::global_log->error() << "tec::ControlRegion::PrepareSubdivisionProfiles(): Unknown subdivision type! Program exit..." << std::endl;
-		exit(-1);
+		std::ostringstream error_message;
+		error_message << "tec::ControlRegion::PrepareSubdivisionProfiles(): Unknown subdivision type! Program exit..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -530,8 +548,9 @@ void SampleRegion::prepareSubdivisionVDF()
 		break;
 	case SDOPT_UNKNOWN:
 	default:
-		Log::global_log->error() << "ERROR in SampleRegion::PrepareSubdivisionVDF(): Unknown subdivision type! Program exit..." << std::endl;
-		exit(-1);
+		std::ostringstream error_message;
+		error_message << "ERROR in SampleRegion::PrepareSubdivisionVDF(): Unknown subdivision type! Program exit..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -554,8 +573,9 @@ void SampleRegion::prepareSubdivisionFieldYR()
 		break;
 	case SDOPT_UNKNOWN:
 	default:
-		Log::global_log->error() << "SampleRegion::PrepareSubdivisionFieldYR(): Unknown subdivision type! Program exit..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "SampleRegion::PrepareSubdivisionFieldYR(): Unknown subdivision type! Program exit..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	dWidth = (this->GetWidth(0) < this->GetWidth(2) ) ? this->GetWidth(0) : this->GetWidth(2);
@@ -573,8 +593,9 @@ void SampleRegion::prepareSubdivisionFieldYR()
 		break;
 	case SDOPT_UNKNOWN:
 	default:
-		Log::global_log->error() << "SampleRegion::PrepareSubdivisionFieldYR(): Unknown subdivision type! Program exit..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "SampleRegion::PrepareSubdivisionFieldYR(): Unknown subdivision type! Program exit..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -2047,8 +2068,9 @@ void RegionSampling::readXML(XMLfileUnits& xmlconfig)
 	numRegions = query.card();
 	Log::global_log->info() << "RegionSampling: Number of sampling regions: " << numRegions << std::endl;
 	if(numRegions < 1) {
-		Log::global_log->warning() << "RegionSampling: No region parameters specified. Program exit ..." << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "RegionSampling: No region parameters specified. Program exit ..." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	std::string oldpath = xmlconfig.getcurrentnodepath();
 	XMLfile::Query::const_iterator outputRegionIter;

--- a/src/plugins/Permittivity.cpp
+++ b/src/plugins/Permittivity.cpp
@@ -10,6 +10,9 @@
  // If a simulation is resumed from a restart file, then the existing running average file is ammended but the computation of the running averages starts anew at the time step of the restart file
 #include "Permittivity.h"
 
+#include <sstream>
+
+#include "utils/mardyn_assert.h"
 #include "Simulation.h"
 
 void Permittivity::readXML(XMLfileUnits& xmlconfig) {
@@ -74,7 +77,9 @@ void Permittivity::init(ParticleContainer* particleContainer, DomainDecompBase* 
 			bool orientationIsCorrect = ci.dipole(0).e() == std::array<double, 3>{0,0,1};
 			_myAbs[i] = ci.dipole(0).abs();
 			if(not orientationIsCorrect){
-				Log::global_log->error() << "Wrong dipole vector chosen! Please always choose [eMyx eMyy eMyz] = [0 0 1] when using the permittivity plugin" << std::endl;
+				std::ostringstream error_message;
+				error_message << "Wrong dipole vector chosen! Please always choose [eMyx eMyy eMyz] = [0 0 1] when using the permittivity plugin" << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 		}
 	}

--- a/src/plugins/Permittivity.cpp
+++ b/src/plugins/Permittivity.cpp
@@ -79,7 +79,7 @@ void Permittivity::init(ParticleContainer* particleContainer, DomainDecompBase* 
 			if(not orientationIsCorrect){
 				std::ostringstream error_message;
 				error_message << "Wrong dipole vector chosen! Please always choose [eMyx eMyy eMyz] = [0 0 1] when using the permittivity plugin" << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		}
 	}

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -192,9 +192,8 @@ long PluginFactory<PluginBase>::enablePlugins(std::list<PluginBase*>& _plugins, 
 			} else if ("multi" == sphere_representation) {
 				plugin = new MmpldWriterMultiSphere();
 			} else {
-				Log::global_log->error() << "[MMPLD Writer] Unknown sphere representation type: " << sphere_representation
-									<< std::endl;
-				MARDYN_EXIT(-1);
+				std::ostringstream error_message;				error_message << "[MMPLD Writer] Unknown sphere representation type: " << sphere_representation
+									<< std::endl;				MARDYN_EXIT(error_message);
 			}
 		} else if (pluginname == "DomainProfiles") {
 			plugin = this->create("DensityProfileWriter");

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -192,8 +192,9 @@ long PluginFactory<PluginBase>::enablePlugins(std::list<PluginBase*>& _plugins, 
 			} else if ("multi" == sphere_representation) {
 				plugin = new MmpldWriterMultiSphere();
 			} else {
-				std::ostringstream error_message;				error_message << "[MMPLD Writer] Unknown sphere representation type: " << sphere_representation
-									<< std::endl;				MARDYN_EXIT(error_message);
+				std::ostringstream error_message;
+				error_message << "[MMPLD Writer] Unknown sphere representation type: " << sphere_representation << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 		} else if (pluginname == "DomainProfiles") {
 			plugin = this->create("DensityProfileWriter");

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -194,7 +194,7 @@ long PluginFactory<PluginBase>::enablePlugins(std::list<PluginBase*>& _plugins, 
 			} else {
 				Log::global_log->error() << "[MMPLD Writer] Unknown sphere representation type: " << sphere_representation
 									<< std::endl;
-				mardyn_exit(-1);
+				MARDYN_EXIT(-1);
 			}
 		} else if (pluginname == "DomainProfiles") {
 			plugin = this->create("DensityProfileWriter");

--- a/src/plugins/PluginFactory.cpp
+++ b/src/plugins/PluginFactory.cpp
@@ -194,7 +194,7 @@ long PluginFactory<PluginBase>::enablePlugins(std::list<PluginBase*>& _plugins, 
 			} else {
 				std::ostringstream error_message;
 				error_message << "[MMPLD Writer] Unknown sphere representation type: " << sphere_representation << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		} else if (pluginname == "DomainProfiles") {
 			plugin = this->create("DensityProfileWriter");

--- a/src/plugins/SpatialProfile.cpp
+++ b/src/plugins/SpatialProfile.cpp
@@ -46,7 +46,7 @@ void SpatialProfile::readXML(XMLfileUnits& xmlconfig) {
 		samplInfo.cylinder = false;
 	} else {
 		Log::global_log->error() << "[SpatialProfile] Invalid mode. cylinder/cartesian" << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 
 	Log::global_log->info() << "[SpatialProfile] Binning units: " << samplInfo.universalProfileUnit[0] << " "
@@ -404,7 +404,7 @@ long SpatialProfile::getCylUID(ParticleIterator& thismol) {
 		Log::global_log->error() << "Severe error!! Invalid profile unit (" << R2 << " / " << yc << " / " << phi << ").\n\n";
 		Log::global_log->error() << "Coordinates off center (" << xc << " / " << yc << " / " << zc << ").\n";
 		Log::global_log->error() << "unID = " << unID << "\n";
-		mardyn_exit(707);
+		MARDYN_EXIT(707);
 	}
 	return unID;
 }

--- a/src/plugins/SpatialProfile.cpp
+++ b/src/plugins/SpatialProfile.cpp
@@ -45,8 +45,9 @@ void SpatialProfile::readXML(XMLfileUnits& xmlconfig) {
 		xmlconfig.getNodeValue("z", samplInfo.universalProfileUnit[2]);
 		samplInfo.cylinder = false;
 	} else {
-		Log::global_log->error() << "[SpatialProfile] Invalid mode. cylinder/cartesian" << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[SpatialProfile] Invalid mode. cylinder/cartesian" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	Log::global_log->info() << "[SpatialProfile] Binning units: " << samplInfo.universalProfileUnit[0] << " "
@@ -394,17 +395,18 @@ long SpatialProfile::getCylUID(ParticleIterator& thismol) {
 		unID = (long) (hUn * samplInfo.universalProfileUnit[0] * samplInfo.universalProfileUnit[2]
 					   + rUn * samplInfo.universalProfileUnit[2] + phiUn);
 	} else {
-		Log::global_log->error() << "INV PROFILE UNITS " << samplInfo.universalInvProfileUnit[0] << " "
+		std::ostringstream error_message;
+		error_message << "INV PROFILE UNITS " << samplInfo.universalInvProfileUnit[0] << " "
 							<< samplInfo.universalInvProfileUnit[1] << " " << samplInfo.universalInvProfileUnit[2]
 							<< "\n";
-		Log::global_log->error() << "PROFILE UNITS " << samplInfo.universalProfileUnit[0] << " "
+		error_message << "PROFILE UNITS " << samplInfo.universalProfileUnit[0] << " "
 							<< samplInfo.universalProfileUnit[1] << " " << samplInfo.universalProfileUnit[2] << "\n";
-		Log::global_log->error() << "Severe error!! Invalid profile ID (" << rUn << " / " << hUn << " / " << phiUn
+		error_message << "Severe error!! Invalid profile ID (" << rUn << " / " << hUn << " / " << phiUn
 							<< ").\n\n";
-		Log::global_log->error() << "Severe error!! Invalid profile unit (" << R2 << " / " << yc << " / " << phi << ").\n\n";
-		Log::global_log->error() << "Coordinates off center (" << xc << " / " << yc << " / " << zc << ").\n";
-		Log::global_log->error() << "unID = " << unID << "\n";
-		MARDYN_EXIT(707);
+		error_message << "Severe error!! Invalid profile unit (" << R2 << " / " << yc << " / " << phi << ").\n\n";
+		error_message << "Coordinates off center (" << xc << " / " << yc << " / " << zc << ").\n";
+		error_message << "unID = " << unID << "\n";
+		MARDYN_EXIT(error_message);
 	}
 	return unID;
 }

--- a/src/plugins/SpatialProfile.cpp
+++ b/src/plugins/SpatialProfile.cpp
@@ -47,7 +47,7 @@ void SpatialProfile::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "[SpatialProfile] Invalid mode. cylinder/cartesian" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	Log::global_log->info() << "[SpatialProfile] Binning units: " << samplInfo.universalProfileUnit[0] << " "
@@ -406,7 +406,7 @@ long SpatialProfile::getCylUID(ParticleIterator& thismol) {
 		error_message << "Severe error!! Invalid profile unit (" << R2 << " / " << yc << " / " << phi << ").\n\n";
 		error_message << "Coordinates off center (" << xc << " / " << yc << " / " << zc << ").\n";
 		error_message << "unID = " << unID << "\n";
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	return unID;
 }

--- a/src/plugins/VectorizationTuner.cpp
+++ b/src/plugins/VectorizationTuner.cpp
@@ -62,9 +62,11 @@ void VectorizationTuner::readXML(XMLfileUnits& xmlconfig) {
 	} else if (incTypeStr == "both") {
 		_moleculeCntIncreaseType = MoleculeCntIncreaseTypeEnum::both;
 	} else {
-		std::ostringstream error_message;		error_message
+		std::ostringstream error_message;
+		error_message
 			<< R"(Unknown FlopRateOutputPlugin::moleculecntincreasetype. Choose "linear" or "exponential" or "both".)"
-			<< std::endl;		MARDYN_EXIT(error_message);
+			<< std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info() << "Molecule count increase type: " << incTypeStr << std::endl;
 

--- a/src/plugins/VectorizationTuner.cpp
+++ b/src/plugins/VectorizationTuner.cpp
@@ -36,7 +36,7 @@ void VectorizationTuner::readXML(XMLfileUnits& xmlconfig) {
 	} else {
 		std::ostringstream error_message;
 		error_message << R"(Unknown FlopRateOutputPlugin::mode. Choose "stdout" or "file".)" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	_outputPrefix = "mardyn";
@@ -66,7 +66,7 @@ void VectorizationTuner::readXML(XMLfileUnits& xmlconfig) {
 		error_message
 			<< R"(Unknown FlopRateOutputPlugin::moleculecntincreasetype. Choose "linear" or "exponential" or "both".)"
 			<< std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	Log::global_log->info() << "Molecule count increase type: " << incTypeStr << std::endl;
 
@@ -286,7 +286,7 @@ void VectorizationTuner::tune(std::vector<Component>& componentList, TunerLoad& 
 		if(componentList.size() > 2){
 			std::ostringstream error_message;
 			error_message << "The tuner currently supports only two different particle types!" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 
 		int maxMols = particleNums.at(0);

--- a/src/plugins/VectorizationTuner.cpp
+++ b/src/plugins/VectorizationTuner.cpp
@@ -35,7 +35,7 @@ void VectorizationTuner::readXML(XMLfileUnits& xmlconfig) {
 		vtWriter.reset(new VTWriter());
 	} else {
 		Log::global_log->error() << R"(Unknown FlopRateOutputPlugin::mode. Choose "stdout" or "file".)" << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	_outputPrefix = "mardyn";
@@ -64,7 +64,7 @@ void VectorizationTuner::readXML(XMLfileUnits& xmlconfig) {
 		Log::global_log->error()
 			<< R"(Unknown FlopRateOutputPlugin::moleculecntincreasetype. Choose "linear" or "exponential" or "both".)"
 			<< std::endl;
-		mardyn_exit(798123);
+		MARDYN_EXIT(798123);
 	}
 	Log::global_log->info() << "Molecule count increase type: " << incTypeStr << std::endl;
 
@@ -283,7 +283,7 @@ void VectorizationTuner::tune(std::vector<Component>& componentList, TunerLoad& 
 
 		if(componentList.size() > 2){
 			Log::global_log->error_always_output() << "The tuner currently supports only two different particle types!" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 
 		int maxMols = particleNums.at(0);

--- a/src/plugins/VectorizationTuner.cpp
+++ b/src/plugins/VectorizationTuner.cpp
@@ -34,8 +34,9 @@ void VectorizationTuner::readXML(XMLfileUnits& xmlconfig) {
 	} else if (mode == "file") {
 		vtWriter.reset(new VTWriter());
 	} else {
-		Log::global_log->error() << R"(Unknown FlopRateOutputPlugin::mode. Choose "stdout" or "file".)" << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << R"(Unknown FlopRateOutputPlugin::mode. Choose "stdout" or "file".)" << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	_outputPrefix = "mardyn";
@@ -61,10 +62,9 @@ void VectorizationTuner::readXML(XMLfileUnits& xmlconfig) {
 	} else if (incTypeStr == "both") {
 		_moleculeCntIncreaseType = MoleculeCntIncreaseTypeEnum::both;
 	} else {
-		Log::global_log->error()
+		std::ostringstream error_message;		error_message
 			<< R"(Unknown FlopRateOutputPlugin::moleculecntincreasetype. Choose "linear" or "exponential" or "both".)"
-			<< std::endl;
-		MARDYN_EXIT(798123);
+			<< std::endl;		MARDYN_EXIT(error_message);
 	}
 	Log::global_log->info() << "Molecule count increase type: " << incTypeStr << std::endl;
 
@@ -282,8 +282,9 @@ void VectorizationTuner::tune(std::vector<Component>& componentList, TunerLoad& 
 		mardyn_assert(componentList.size() == particleNums.size());
 
 		if(componentList.size() > 2){
-			Log::global_log->error_always_output() << "The tuner currently supports only two different particle types!" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "The tuner currently supports only two different particle types!" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 
 		int maxMols = particleNums.at(0);

--- a/src/plugins/WallPotential.cpp
+++ b/src/plugins/WallPotential.cpp
@@ -5,6 +5,8 @@
 
 #include "WallPotential.h"
 
+#include <sstream>
+
 #include "Simulation.h"
 #include "utils/mardyn_assert.h"
 
@@ -40,7 +42,7 @@ void WallPotential::readXML(XMLfileUnits &xmlconfig) {
         _potential = LJ9_3;
         // TODO: is this allowed or should simulation be halted
         // HALT SIM
-        //MARDYN_EXIT(1);
+        //MARDYN_EXIT(error_message);
     }
 
     XMLfile::Query query = xmlconfig.query("component");
@@ -87,8 +89,9 @@ void WallPotential::readXML(XMLfileUnits &xmlconfig) {
         Log::global_log->info() << "[WallPotential] LJ10_4 initialized." << std::endl;
     }
     else{
-        Log::global_log -> error() << "[WallPotential] UNKNOWN WALL POTENTIAL! EXITING!" << std::endl;
-        MARDYN_EXIT(11);
+        std::ostringstream error_message;
+        error_message << "[WallPotential] Unknown wall potential" << std::endl;
+        MARDYN_EXIT(error_message);
     }
 
 }

--- a/src/plugins/WallPotential.cpp
+++ b/src/plugins/WallPotential.cpp
@@ -42,7 +42,7 @@ void WallPotential::readXML(XMLfileUnits &xmlconfig) {
         _potential = LJ9_3;
         // TODO: is this allowed or should simulation be halted
         // HALT SIM
-        //MARDYN_EXIT(error_message);
+        //MARDYN_EXIT(error_message.str());
     }
 
     XMLfile::Query query = xmlconfig.query("component");
@@ -91,7 +91,7 @@ void WallPotential::readXML(XMLfileUnits &xmlconfig) {
     else{
         std::ostringstream error_message;
         error_message << "[WallPotential] Unknown wall potential" << std::endl;
-        MARDYN_EXIT(error_message);
+        MARDYN_EXIT(error_message.str());
     }
 
 }

--- a/src/plugins/WallPotential.cpp
+++ b/src/plugins/WallPotential.cpp
@@ -40,7 +40,7 @@ void WallPotential::readXML(XMLfileUnits &xmlconfig) {
         _potential = LJ9_3;
         // TODO: is this allowed or should simulation be halted
         // HALT SIM
-        //mardyn_exit(1);
+        //MARDYN_EXIT(1);
     }
 
     XMLfile::Query query = xmlconfig.query("component");
@@ -88,7 +88,7 @@ void WallPotential::readXML(XMLfileUnits &xmlconfig) {
     }
     else{
         Log::global_log -> error() << "[WallPotential] UNKNOWN WALL POTENTIAL! EXITING!" << std::endl;
-        mardyn_exit(11);
+        MARDYN_EXIT(11);
     }
 
 }

--- a/src/plugins/profiles/ProfileBase.cpp
+++ b/src/plugins/profiles/ProfileBase.cpp
@@ -48,7 +48,7 @@ void ProfileBase::writeKartMatrix (std::ofstream& outfile) {
 void ProfileBase::writeSimpleMatrix (std::ofstream& outfile) {
 	std::ostringstream error_message;
 	error_message << "SIMPLE MATRIX OUTPUT NOT IMPLEMENTED!\n";
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 }
 
 void ProfileBase::writeCylMatrix (std::ofstream& outfile) {

--- a/src/plugins/profiles/ProfileBase.cpp
+++ b/src/plugins/profiles/ProfileBase.cpp
@@ -2,8 +2,11 @@
 // Created by Kruegener on 10/25/2018.
 //
 
+#include <sstream>
+
 #include "ProfileBase.h"
 #include "plugins/SpatialProfile.h"
+#include "utils/mardyn_assert.h"
 
 void ProfileBase::writeMatrix (std::ofstream& outfile) {
 	if (_samplInfo.cylinder) {
@@ -43,7 +46,9 @@ void ProfileBase::writeKartMatrix (std::ofstream& outfile) {
 }
 
 void ProfileBase::writeSimpleMatrix (std::ofstream& outfile) {
-	Log::global_log->error() << "SIMPLE MATRIX OUTPUT NOT IMPLEMENTED!\n";
+	std::ostringstream error_message;
+	error_message << "SIMPLE MATRIX OUTPUT NOT IMPLEMENTED!\n";
+	MARDYN_EXIT(error_message);
 }
 
 void ProfileBase::writeCylMatrix (std::ofstream& outfile) {

--- a/src/thermostats/TemperatureControl.cpp
+++ b/src/thermostats/TemperatureControl.cpp
@@ -168,7 +168,7 @@ void ControlRegionT::readXML(XMLfileUnits& xmlconfig) {
 			_nuDt = _nuAndersen * _timestep;
 		} else {
 			Log::global_log->error() << "[TemperatureControl] REGION: Invalid 'method' param: " << methods << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 		Log::global_log->info() << "[TemperatureControl] REGION 'method' param: " << methods << std::endl;
 	}
@@ -192,7 +192,7 @@ void ControlRegionT::VelocityScalingInit(XMLfileUnits& xmlconfig, std::string st
 	xmlconfig.getNodeValue("settings/numslabs", _nNumSlabs);
 	if (_nNumSlabs < 1) {
 		Log::global_log->fatal() << "TemperatureControl: need at least one slab! (settings/numslabs)";
-		mardyn_exit(932);
+		MARDYN_EXIT(932);
 	}
 	xmlconfig.getNodeValue("settings/exponent", _dTemperatureExponent);
 	xmlconfig.getNodeValue("settings/directions", strDirections);
@@ -418,7 +418,7 @@ void ControlRegionT::ControlTemperature(Molecule* mol) {
 		}
 	} else {
 		Log::global_log->error() << "[TemperatureControl] Invalid localMethod param: " << _localMethod << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 }
 
@@ -506,7 +506,7 @@ void ControlRegionT::registerAsObserver() {
 		else {
 			Log::global_log->error() << "TemperatureControl->region[" << this->GetID()
 								<< "]: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			mardyn_exit(-1);
+			MARDYN_EXIT(-1);
 		}
 	}
 }

--- a/src/thermostats/TemperatureControl.cpp
+++ b/src/thermostats/TemperatureControl.cpp
@@ -169,7 +169,7 @@ void ControlRegionT::readXML(XMLfileUnits& xmlconfig) {
 		} else {
 			std::ostringstream error_message;
 			error_message << "[TemperatureControl] REGION: Invalid 'method' param: " << methods << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		Log::global_log->info() << "[TemperatureControl] REGION 'method' param: " << methods << std::endl;
 	}
@@ -194,7 +194,7 @@ void ControlRegionT::VelocityScalingInit(XMLfileUnits& xmlconfig, std::string st
 	if (_nNumSlabs < 1) {
 		std::ostringstream error_message;
 		error_message << "TemperatureControl: need at least one slab! (settings/numslabs)";
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	xmlconfig.getNodeValue("settings/exponent", _dTemperatureExponent);
 	xmlconfig.getNodeValue("settings/directions", strDirections);
@@ -421,7 +421,7 @@ void ControlRegionT::ControlTemperature(Molecule* mol) {
 	} else {
 		std::ostringstream error_message;
 		error_message << "[TemperatureControl] Invalid localMethod param: " << _localMethod << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 }
 
@@ -510,7 +510,7 @@ void ControlRegionT::registerAsObserver() {
 			std::ostringstream error_message;
 			error_message << "TemperatureControl->region[" << this->GetID()
 								<< "]: Initialization of plugin DistControl is needed before!" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 }

--- a/src/thermostats/TemperatureControl.cpp
+++ b/src/thermostats/TemperatureControl.cpp
@@ -507,8 +507,10 @@ void ControlRegionT::registerAsObserver() {
 		if (distControl != nullptr)
 			distControl->registerObserver(this);
 		else {
-			std::ostringstream error_message;			error_message << "TemperatureControl->region[" << this->GetID()
-								<< "]: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;			MARDYN_EXIT(error_message);
+			std::ostringstream error_message;
+			error_message << "TemperatureControl->region[" << this->GetID()
+								<< "]: Initialization of plugin DistControl is needed before!" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 	}
 }

--- a/src/thermostats/TemperatureControl.cpp
+++ b/src/thermostats/TemperatureControl.cpp
@@ -167,8 +167,9 @@ void ControlRegionT::readXML(XMLfileUnits& xmlconfig) {
 			_timestep = global_simulation->getIntegrator()->getTimestepLength();
 			_nuDt = _nuAndersen * _timestep;
 		} else {
-			Log::global_log->error() << "[TemperatureControl] REGION: Invalid 'method' param: " << methods << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;
+			error_message << "[TemperatureControl] REGION: Invalid 'method' param: " << methods << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		Log::global_log->info() << "[TemperatureControl] REGION 'method' param: " << methods << std::endl;
 	}
@@ -191,8 +192,9 @@ void ControlRegionT::VelocityScalingInit(XMLfileUnits& xmlconfig, std::string st
 	// settings
 	xmlconfig.getNodeValue("settings/numslabs", _nNumSlabs);
 	if (_nNumSlabs < 1) {
-		Log::global_log->fatal() << "TemperatureControl: need at least one slab! (settings/numslabs)";
-		MARDYN_EXIT(932);
+		std::ostringstream error_message;
+		error_message << "TemperatureControl: need at least one slab! (settings/numslabs)";
+		MARDYN_EXIT(error_message);
 	}
 	xmlconfig.getNodeValue("settings/exponent", _dTemperatureExponent);
 	xmlconfig.getNodeValue("settings/directions", strDirections);
@@ -417,8 +419,9 @@ void ControlRegionT::ControlTemperature(Molecule* mol) {
 			}
 		}
 	} else {
-		Log::global_log->error() << "[TemperatureControl] Invalid localMethod param: " << _localMethod << std::endl;
-		MARDYN_EXIT(-1);
+		std::ostringstream error_message;
+		error_message << "[TemperatureControl] Invalid localMethod param: " << _localMethod << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 }
 
@@ -504,9 +507,8 @@ void ControlRegionT::registerAsObserver() {
 		if (distControl != nullptr)
 			distControl->registerObserver(this);
 		else {
-			Log::global_log->error() << "TemperatureControl->region[" << this->GetID()
-								<< "]: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;
-			MARDYN_EXIT(-1);
+			std::ostringstream error_message;			error_message << "TemperatureControl->region[" << this->GetID()
+								<< "]: Initialization of plugin DistControl is needed before! Program exit..." << std::endl;			MARDYN_EXIT(error_message);
 		}
 	}
 }

--- a/src/utils/OptionParser.cpp
+++ b/src/utils/OptionParser.cpp
@@ -450,13 +450,13 @@ void OptionParser::print_version() const {
 void OptionParser::exit() const {
 	std::ostringstream error_message;
 	error_message << "OptionParser::exit() called" << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 }
 void OptionParser::error(const std::string& msg) const {
 	print_usage(std::cerr);
 	std::ostringstream error_message;
 	error_message << prog() << ": " << _("error") << ": " << msg << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 }
 ////////// } class OptionParser //////////
 

--- a/src/utils/OptionParser.cpp
+++ b/src/utils/OptionParser.cpp
@@ -345,11 +345,11 @@ void OptionParser::process_opt(const Option& o, const std::string& opt, const st
 	}
 	else if (o.action() == "help") {
 		print_help();
-		mardyn_exit(0);
+		MARDYN_EXIT(0);
 	}
 	else if (o.action() == "version") {
 		print_version();
-		mardyn_exit(0);
+		MARDYN_EXIT(0);
 	}
 	else if (o.action() == "callback" && o.callback()) {
 		(*o.callback())(o, opt, value, *this);
@@ -437,12 +437,12 @@ void OptionParser::print_version() const {
 }
 
 void OptionParser::exit() const {
-	mardyn_exit(2);
+	MARDYN_EXIT(2);
 }
 void OptionParser::error(const std::string& msg) const {
 	print_usage(std::cerr);
 	std::cerr << prog() << ": " << _("error") << ": " << msg << std::endl;
-	mardyn_exit(-4);
+	MARDYN_EXIT(-4);
 }
 ////////// } class OptionParser //////////
 

--- a/src/utils/OptionParser.cpp
+++ b/src/utils/OptionParser.cpp
@@ -14,6 +14,10 @@
 #include <complex>
 #include <sstream>
 
+#ifdef ENABLE_MPI
+#include <mpi.h>  // For MPI_Finalize()
+#endif
+
 #if defined(ENABLE_NLS) && ENABLE_NLS
 # include <libintl.h>
 # define _(s) gettext(s)
@@ -346,13 +350,17 @@ void OptionParser::process_opt(const Option& o, const std::string& opt, const st
 	}
 	else if (o.action() == "help") {
 		print_help();
-		std::ostringstream empty_message;
-		mardyn_exit(empty_message, __FILE__, __LINE__, EXIT_SUCCESS);
+		#ifdef ENABLE_MPI
+			MPI_Finalize();
+		#endif
+		std::exit(EXIT_SUCCESS);
 	}
 	else if (o.action() == "version") {
 		print_version();
-		std::ostringstream empty_message;
-		mardyn_exit(empty_message, __FILE__, __LINE__, EXIT_SUCCESS);
+		#ifdef ENABLE_MPI
+			MPI_Finalize();
+		#endif
+		std::exit(EXIT_SUCCESS);
 	}
 	else if (o.action() == "callback" && o.callback()) {
 		(*o.callback())(o, opt, value, *this);

--- a/src/utils/OptionParser.cpp
+++ b/src/utils/OptionParser.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <algorithm>
 #include <complex>
+#include <sstream>
 
 #if defined(ENABLE_NLS) && ENABLE_NLS
 # include <libintl.h>
@@ -345,11 +346,13 @@ void OptionParser::process_opt(const Option& o, const std::string& opt, const st
 	}
 	else if (o.action() == "help") {
 		print_help();
-		MARDYN_EXIT(0);
+		std::ostringstream empty_message;
+		mardyn_exit(empty_message, __FILE__, __LINE__, EXIT_SUCCESS);
 	}
 	else if (o.action() == "version") {
 		print_version();
-		MARDYN_EXIT(0);
+		std::ostringstream empty_message;
+		mardyn_exit(empty_message, __FILE__, __LINE__, EXIT_SUCCESS);
 	}
 	else if (o.action() == "callback" && o.callback()) {
 		(*o.callback())(o, opt, value, *this);
@@ -437,12 +440,15 @@ void OptionParser::print_version() const {
 }
 
 void OptionParser::exit() const {
-	MARDYN_EXIT(2);
+	std::ostringstream error_message;
+	error_message << "OptionParser::exit() called" << std::endl;
+	MARDYN_EXIT(error_message);
 }
 void OptionParser::error(const std::string& msg) const {
 	print_usage(std::cerr);
-	std::cerr << prog() << ": " << _("error") << ": " << msg << std::endl;
-	MARDYN_EXIT(-4);
+	std::ostringstream error_message;
+	error_message << prog() << ": " << _("error") << ": " << msg << std::endl;
+	MARDYN_EXIT(error_message);
 }
 ////////// } class OptionParser //////////
 

--- a/src/utils/SigsegvHandler.h
+++ b/src/utils/SigsegvHandler.h
@@ -28,7 +28,7 @@ void handler(int sig) {
   // print out all the frames to stderr
   fprintf(stderr, "Error: signal %d:\n", sig);
   backtrace_symbols_fd(array, size, STDERR_FILENO);
-  MARDYN_EXIT(1);
+  MARDYN_EXIT(error_message);
 }
 
 void registerSigsegvHandler() {

--- a/src/utils/SigsegvHandler.h
+++ b/src/utils/SigsegvHandler.h
@@ -28,7 +28,7 @@ void handler(int sig) {
   // print out all the frames to stderr
   fprintf(stderr, "Error: signal %d:\n", sig);
   backtrace_symbols_fd(array, size, STDERR_FILENO);
-  MARDYN_EXIT(error_message);
+  MARDYN_EXIT(error_message.str());
 }
 
 void registerSigsegvHandler() {

--- a/src/utils/SigsegvHandler.h
+++ b/src/utils/SigsegvHandler.h
@@ -28,7 +28,7 @@ void handler(int sig) {
   // print out all the frames to stderr
   fprintf(stderr, "Error: signal %d:\n", sig);
   backtrace_symbols_fd(array, size, STDERR_FILENO);
-  mardyn_exit(1);
+  MARDYN_EXIT(1);
 }
 
 void registerSigsegvHandler() {

--- a/src/utils/Testing.cpp
+++ b/src/utils/Testing.cpp
@@ -93,7 +93,8 @@ utils::Test::~Test() { }
 
 void utils::Test::setTestDataDirectory(std::string& testDataDir) {
 	if (!fileExists(testDataDir.c_str())) {
-		test_log->error() << "Directory '" << testDataDirectory << "' for test input data does not exist!" << std::endl;
+		std::ostringstream error_message;
+		error_message << "Directory '" << testDataDir.c_str() << "' for test input data does not exist!" << std::endl;
 		MARDYN_EXIT(error_message);
 	}
 	testDataDirectory = testDataDir;
@@ -104,7 +105,8 @@ std::string utils::Test::getTestDataFilename(const std::string& file, bool check
 	std::string fullPath = testDataDirectory +"/"+ file;
 
 	if (!fileExists(fullPath.c_str()) and checkExistence) {
-		test_log->error() << "File " << fullPath << " for test input data does not exist!" << std::endl;
+		std::ostringstream error_message;
+		error_message << "File " << fullPath << " for test input data does not exist!" << std::endl;
 		MARDYN_EXIT(error_message);
 	}
 	return fullPath;

--- a/src/utils/Testing.cpp
+++ b/src/utils/Testing.cpp
@@ -94,7 +94,7 @@ utils::Test::~Test() { }
 void utils::Test::setTestDataDirectory(std::string& testDataDir) {
 	if (!fileExists(testDataDir.c_str())) {
 		test_log->error() << "Directory '" << testDataDirectory << "' for test input data does not exist!" << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	testDataDirectory = testDataDir;
 }
@@ -105,7 +105,7 @@ std::string utils::Test::getTestDataFilename(const std::string& file, bool check
 
 	if (!fileExists(fullPath.c_str()) and checkExistence) {
 		test_log->error() << "File " << fullPath << " for test input data does not exist!" << std::endl;
-		mardyn_exit(-1);
+		MARDYN_EXIT(-1);
 	}
 	return fullPath;
 }

--- a/src/utils/Testing.cpp
+++ b/src/utils/Testing.cpp
@@ -95,7 +95,7 @@ void utils::Test::setTestDataDirectory(std::string& testDataDir) {
 	if (!fileExists(testDataDir.c_str())) {
 		std::ostringstream error_message;
 		error_message << "Directory '" << testDataDir.c_str() << "' for test input data does not exist!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	testDataDirectory = testDataDir;
 }
@@ -107,7 +107,7 @@ std::string utils::Test::getTestDataFilename(const std::string& file, bool check
 	if (!fileExists(fullPath.c_str()) and checkExistence) {
 		std::ostringstream error_message;
 		error_message << "File " << fullPath << " for test input data does not exist!" << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	return fullPath;
 }

--- a/src/utils/Testing.cpp
+++ b/src/utils/Testing.cpp
@@ -94,7 +94,7 @@ utils::Test::~Test() { }
 void utils::Test::setTestDataDirectory(std::string& testDataDir) {
 	if (!fileExists(testDataDir.c_str())) {
 		test_log->error() << "Directory '" << testDataDirectory << "' for test input data does not exist!" << std::endl;
-		MARDYN_EXIT(-1);
+		MARDYN_EXIT(error_message);
 	}
 	testDataDirectory = testDataDir;
 }
@@ -105,7 +105,7 @@ std::string utils::Test::getTestDataFilename(const std::string& file, bool check
 
 	if (!fileExists(fullPath.c_str()) and checkExistence) {
 		test_log->error() << "File " << fullPath << " for test input data does not exist!" << std::endl;
-		MARDYN_EXIT(-1);
+		MARDYN_EXIT(error_message);
 	}
 	return fullPath;
 }

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -147,18 +147,18 @@ void ReplicaFiller::readXML(XMLfileUnits& xmlconfig) {
 		xmlconfig.getNodeValue("@type", inputPluginName);
 		if (inputPluginName != "BinaryReader") {
 			Log::global_log->error() << "[ReplicaFiller] ReplicaFiller only works with inputPlugins: BinaryReader at the moment" << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		setInputReader(std::make_shared<BinaryReader>());
 		_inputReader->readXML(xmlconfig);
 		if (_inputReader == nullptr) {
 			Log::global_log->error() << "[ReplicaFiller] Could not create input reader " << inputPluginName << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		xmlconfig.changecurrentnode("..");
 	} else {
 		Log::global_log->error() << "[ReplicaFiller] Input reader for original not specified." << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	if (xmlconfig.changecurrentnode("origin")) {
 		Coordinate3D origin;
@@ -177,7 +177,7 @@ void ReplicaFiller::readXML(XMLfileUnits& xmlconfig) {
 		const size_t numComps = global_simulation->getEnsemble()->getComponents()->size();
 		if ((componentid < 1) || (componentid > numComps)) {
 			Log::global_log->error() << "[ReplicaFiller] Specified componentid is invalid. Valid range: 1 <= componentid <= " << numComps << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		_componentid = componentid - 1;  // Internally stored in array starting at index 0
 		_keepComponent = false;
@@ -206,7 +206,7 @@ void ReplicaFiller::init() {
 
 	if (numberOfParticles == 0) {
 		Log::global_log->error_always_output() << "[ReplicaFiller] No molecules in replica, aborting! " << std::endl;
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 
 	Log::global_log->info() << "[ReplicaFiller] Setting simulation time to 0.0" << std::endl;

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -146,19 +146,22 @@ void ReplicaFiller::readXML(XMLfileUnits& xmlconfig) {
 		std::string inputPluginName;
 		xmlconfig.getNodeValue("@type", inputPluginName);
 		if (inputPluginName != "BinaryReader") {
-			Log::global_log->error() << "[ReplicaFiller] ReplicaFiller only works with inputPlugins: BinaryReader at the moment" << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "[ReplicaFiller] ReplicaFiller only works with inputPlugins: BinaryReader at the moment" << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		setInputReader(std::make_shared<BinaryReader>());
 		_inputReader->readXML(xmlconfig);
 		if (_inputReader == nullptr) {
-			Log::global_log->error() << "[ReplicaFiller] Could not create input reader " << inputPluginName << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "[ReplicaFiller] Could not create input reader " << inputPluginName << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		xmlconfig.changecurrentnode("..");
 	} else {
-		Log::global_log->error() << "[ReplicaFiller] Input reader for original not specified." << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "[ReplicaFiller] Input reader for original not specified." << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 	if (xmlconfig.changecurrentnode("origin")) {
 		Coordinate3D origin;
@@ -176,8 +179,9 @@ void ReplicaFiller::readXML(XMLfileUnits& xmlconfig) {
 	if (xmlconfig.getNodeValue("componentid", componentid)) {
 		const size_t numComps = global_simulation->getEnsemble()->getComponents()->size();
 		if ((componentid < 1) || (componentid > numComps)) {
-			Log::global_log->error() << "[ReplicaFiller] Specified componentid is invalid. Valid range: 1 <= componentid <= " << numComps << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "[ReplicaFiller] Specified componentid is invalid. Valid range: 1 <= componentid <= " << numComps << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		_componentid = componentid - 1;  // Internally stored in array starting at index 0
 		_keepComponent = false;
@@ -205,8 +209,9 @@ void ReplicaFiller::init() {
 	Log::global_log->info() << "[ReplicaFiller] Number of molecules in the replica: " << numberOfParticles << std::endl;
 
 	if (numberOfParticles == 0) {
-		Log::global_log->error_always_output() << "[ReplicaFiller] No molecules in replica, aborting! " << std::endl;
-		MARDYN_EXIT(1);
+		std::ostringstream error_message;
+		error_message << "[ReplicaFiller] No molecules in replica, aborting! " << std::endl;
+		MARDYN_EXIT(error_message);
 	}
 
 	Log::global_log->info() << "[ReplicaFiller] Setting simulation time to 0.0" << std::endl;

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -148,20 +148,20 @@ void ReplicaFiller::readXML(XMLfileUnits& xmlconfig) {
 		if (inputPluginName != "BinaryReader") {
 			std::ostringstream error_message;
 			error_message << "[ReplicaFiller] ReplicaFiller only works with inputPlugins: BinaryReader at the moment" << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		setInputReader(std::make_shared<BinaryReader>());
 		_inputReader->readXML(xmlconfig);
 		if (_inputReader == nullptr) {
 			std::ostringstream error_message;
 			error_message << "[ReplicaFiller] Could not create input reader " << inputPluginName << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		xmlconfig.changecurrentnode("..");
 	} else {
 		std::ostringstream error_message;
 		error_message << "[ReplicaFiller] Input reader for original not specified." << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	if (xmlconfig.changecurrentnode("origin")) {
 		Coordinate3D origin;
@@ -181,7 +181,7 @@ void ReplicaFiller::readXML(XMLfileUnits& xmlconfig) {
 		if ((componentid < 1) || (componentid > numComps)) {
 			std::ostringstream error_message;
 			error_message << "[ReplicaFiller] Specified componentid is invalid. Valid range: 1 <= componentid <= " << numComps << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		_componentid = componentid - 1;  // Internally stored in array starting at index 0
 		_keepComponent = false;
@@ -211,7 +211,7 @@ void ReplicaFiller::init() {
 	if (numberOfParticles == 0) {
 		std::ostringstream error_message;
 		error_message << "[ReplicaFiller] No molecules in replica, aborting! " << std::endl;
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 
 	Log::global_log->info() << "[ReplicaFiller] Setting simulation time to 0.0" << std::endl;

--- a/src/utils/mardyn_assert.h
+++ b/src/utils/mardyn_assert.h
@@ -10,6 +10,8 @@
 
 #include <string>
 #include <sstream>
+#include <iostream>
+#include <cstdlib>
 
 #include "Logger.h"
 
@@ -17,14 +19,15 @@
 #define MARDYN_EXIT(exit_message) mardyn_exit(exit_message, __FILE__, __LINE__)
 
 inline void mardyn_exit(const std::ostringstream & exit_message,
-						const char* file, const int line) {
-	Log::global_log->error_always_output()
-		<< "Exit called in file `" << file << ":" << line << "`" << std::endl;
-	Log::global_log->error_always_output()
-		<< exit_message << std::endl;
+						const char* file, const int line, const int exit_code=EXIT_FAILURE) {
+	if (exit_code == EXIT_FAILURE) {
+		Log::global_log->error_always_output()
+			<< "Exit called in file `" << file << ":" << line << "` with message:" << std::endl;
+		std::cerr << exit_message.str() << std::endl;
+	}
 #ifdef ENABLE_MPI
 	// terminate all mpi processes and return exitcode
-	MPI_Abort(MPI_COMM_WORLD, code);
+	MPI_Abort(MPI_COMM_WORLD, exit_code);
 #else
 	// call global abort - this stops the debugger at the right spot.
 	::abort();

--- a/src/utils/mardyn_assert.h
+++ b/src/utils/mardyn_assert.h
@@ -27,14 +27,14 @@ inline void mardyn_exit(const std::string & exit_message,
 	// The following code extracts this relative path from "filepath"
 	// It starts searching from the end (i.e. from the right) to avoid user-specific "src" dirs
 	const char* filepath_truncated = nullptr;
-    const char* temp = filepath;
-    while ((temp = std::strstr(temp, "/src/")) != nullptr) {
-        filepath_truncated = temp;
-        temp++;
-    }
-    if (filepath_truncated == nullptr) {
-        filepath_truncated = filepath;
-    }
+	const char* temp = filepath;
+	while ((temp = std::strstr(temp, "/src/")) != nullptr) {
+		filepath_truncated = temp;
+		temp++;
+	}
+	if (filepath_truncated == nullptr) {
+		filepath_truncated = filepath;
+	}
 
 	// Print code location from which MARDYN_EXIT() was called
 	Log::global_log->error_always_output()
@@ -43,17 +43,17 @@ inline void mardyn_exit(const std::string & exit_message,
 		<< "` with message:" << std::endl;
 
 	// Print exit message line by line to always have Logger output
-    std::stringstream ss(exit_message);
-    std::string exit_message_line;
-    std::vector<std::string> exit_message_lines;
+	std::stringstream ss(exit_message);
+	std::string exit_message_line;
+	std::vector<std::string> exit_message_lines;
 	// First, split exit message by "\n"
-    while (std::getline(ss, exit_message_line, '\n')) {
-        exit_message_lines.push_back(exit_message_line);
-    }
-    // Second, print each line separately and prepend Logger output
-    for (const auto& message_line : exit_message_lines) {
-        Log::global_log->error_always_output() << message_line << std::endl;
-    }
+	while (std::getline(ss, exit_message_line, '\n')) {
+		exit_message_lines.push_back(exit_message_line);
+	}
+	// Second, print each line separately and prepend Logger output
+	for (const auto& message_line : exit_message_lines) {
+		Log::global_log->error_always_output() << message_line << std::endl;
+	}
 
 #ifdef ENABLE_MPI
 	// terminate all mpi processes and return exitcode

--- a/src/utils/mardyn_assert.h
+++ b/src/utils/mardyn_assert.h
@@ -8,15 +8,20 @@
 #ifndef SRC_UTILS_MARDYN_ASSERT_H_
 #define SRC_UTILS_MARDYN_ASSERT_H_
 
+#include <string>
+#include <sstream>
+
 #include "Logger.h"
 
-// Macro to wrap mardyn_exit and pass the caller function, file and line
-#define MARDYN_EXIT(code) mardyn_exit(code, __FUNCTION__, __FILE__, __LINE__)
+// Macro to wrap mardyn_exit and pass the caller file and line
+#define MARDYN_EXIT(exit_message) mardyn_exit(exit_message, __FILE__, __LINE__)
 
-inline void mardyn_exit(int code, const char* caller_function, const char* file, int line) {
-	std::cerr << "Exit with exit code " << code
-			  << " called from function \"" << caller_function
-			  << "\" in file " << file << ":" << line << std::endl;
+inline void mardyn_exit(const std::ostringstream & exit_message,
+						const char* file, const int line) {
+	Log::global_log->error_always_output()
+		<< "Exit called in file `" << file << ":" << line << "`" << std::endl;
+	Log::global_log->error_always_output()
+		<< exit_message << std::endl;
 #ifdef ENABLE_MPI
 	// terminate all mpi processes and return exitcode
 	MPI_Abort(MPI_COMM_WORLD, code);
@@ -27,8 +32,9 @@ inline void mardyn_exit(int code, const char* caller_function, const char* file,
 }
 
 inline void __mardyn_assert__(const char * expr, const char* file, int line) {
-	Log::global_log->error_always_output() << "Assertion \"" << expr << "\" failed at " << file << ":" << line << std::endl;
-	MARDYN_EXIT(1);
+	std::ostringstream error_message;
+	error_message << "Assertion \"" << expr << "\" failed at " << file << ":" << line << std::endl;
+	MARDYN_EXIT(error_message);
 }
 
 #ifdef NDEBUG

--- a/src/utils/mardyn_assert.h
+++ b/src/utils/mardyn_assert.h
@@ -40,7 +40,7 @@ inline void mardyn_exit(const std::string & exit_message,
 	}
 
 	// Print code location from which MARDYN_EXIT() was called
-	Log::global_log->error()
+	Log::global_log->error_always_output()
 		<< "Exit called from function `" << function << "`"
 		<< " in file `" << filepath_truncated << ":" << line
 		<< "` with message:" << std::endl;
@@ -50,7 +50,7 @@ inline void mardyn_exit(const std::string & exit_message,
 	std::string exit_message_line;
 	// Split exit message by "\n" and print via Logger
 	while (std::getline(ss, exit_message_line, '\n')) {
-		Log::global_log->error() << exit_message_line << std::endl;
+		Log::global_log->error_always_output() << exit_message_line << std::endl;
 	}
 
 #ifdef ENABLE_MPI

--- a/src/utils/mardyn_assert.h
+++ b/src/utils/mardyn_assert.h
@@ -18,11 +18,11 @@
 // Macro to wrap mardyn_exit and pass the caller file and line
 #define MARDYN_EXIT(exit_message) mardyn_exit(exit_message, __FILE__, __LINE__)
 
-inline void mardyn_exit(const std::ostringstream & exit_message,
+inline void mardyn_exit(const std::string & exit_message,
 						const char* file, const int line) {
 	Log::global_log->error_always_output()
 		<< "Exit called in file `" << file << ":" << line << "` with message:" << std::endl;
-	std::cerr << exit_message.str() << std::endl;
+	std::cerr << exit_message << std::endl;
 #ifdef ENABLE_MPI
 	// terminate all mpi processes and return exitcode
 	MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
@@ -35,7 +35,7 @@ inline void mardyn_exit(const std::ostringstream & exit_message,
 inline void __mardyn_assert__(const char * expr, const char* file, int line) {
 	std::ostringstream error_message;
 	error_message << "Assertion \"" << expr << "\" failed at " << file << ":" << line << std::endl;
-	MARDYN_EXIT(error_message);
+	MARDYN_EXIT(error_message.str());
 }
 
 #ifdef NDEBUG

--- a/src/utils/mardyn_assert.h
+++ b/src/utils/mardyn_assert.h
@@ -19,15 +19,13 @@
 #define MARDYN_EXIT(exit_message) mardyn_exit(exit_message, __FILE__, __LINE__)
 
 inline void mardyn_exit(const std::ostringstream & exit_message,
-						const char* file, const int line, const int exit_code=EXIT_FAILURE) {
-	if (exit_code == EXIT_FAILURE) {
-		Log::global_log->error_always_output()
-			<< "Exit called in file `" << file << ":" << line << "` with message:" << std::endl;
-		std::cerr << exit_message.str() << std::endl;
-	}
+						const char* file, const int line) {
+	Log::global_log->error_always_output()
+		<< "Exit called in file `" << file << ":" << line << "` with message:" << std::endl;
+	std::cerr << exit_message.str() << std::endl;
 #ifdef ENABLE_MPI
 	// terminate all mpi processes and return exitcode
-	MPI_Abort(MPI_COMM_WORLD, exit_code);
+	MPI_Abort(MPI_COMM_WORLD, EXIT_FAILURE);
 #else
 	// call global abort - this stops the debugger at the right spot.
 	::abort();

--- a/src/utils/mardyn_assert.h
+++ b/src/utils/mardyn_assert.h
@@ -10,20 +10,25 @@
 
 #include "Logger.h"
 
-inline void mardyn_exit(int code) {
+// Macro to wrap mardyn_exit and pass the caller function, file and line
+#define MARDYN_EXIT(code) mardyn_exit(code, __FUNCTION__, __FILE__, __LINE__)
+
+inline void mardyn_exit(int code, const char* caller_function, const char* file, int line) {
+	std::cerr << "Exit with exit code " << code
+			  << " called from function \"" << caller_function
+			  << "\" in file " << file << ":" << line << std::endl;
 #ifdef ENABLE_MPI
 	// terminate all mpi processes and return exitcode
 	MPI_Abort(MPI_COMM_WORLD, code);
 #else
 	// call global abort - this stops the debugger at the right spot.
-	Log::global_log->error_always_output() << "Exit code would have been " << code << std::endl;
 	::abort();
 #endif
 }
 
 inline void __mardyn_assert__(const char * expr, const char* file, int line) {
 	Log::global_log->error_always_output() << "Assertion \"" << expr << "\" failed at " << file << ":" << line << std::endl;
-	mardyn_exit(1);
+	MARDYN_EXIT(1);
 }
 
 #ifdef NDEBUG

--- a/src/utils/mardyn_assert.h
+++ b/src/utils/mardyn_assert.h
@@ -25,7 +25,7 @@ inline void mardyn_exit(const std::string & exit_message,
 	
 	// Only print the file path relative to the "/src/" directory
 	// The following code extracts this relative path from "filepath"
-	// It starts searching from the end (i.e. from the right) to avoid user-specific "src" dirs
+	// Search until last "/src/" was found to avoid user-specific "src" dirs
 	const char* filepath_truncated = nullptr;
 	const char* temp = filepath;
 	while ((temp = std::strstr(temp, "/src/")) != nullptr) {
@@ -33,26 +33,24 @@ inline void mardyn_exit(const std::string & exit_message,
 		temp++;
 	}
 	if (filepath_truncated == nullptr) {
+		// Print absolute path if "/src/" not found
 		filepath_truncated = filepath;
+	} else {
+  		filepath_truncated++;  // +1 to ignore the first "/"
 	}
 
 	// Print code location from which MARDYN_EXIT() was called
-	Log::global_log->error_always_output()
+	Log::global_log->error()
 		<< "Exit called from function `" << function << "`"
-		<< " in file `" << filepath_truncated+1 << ":" << line  // +1 to ignore the first "/"
+		<< " in file `" << filepath_truncated << ":" << line
 		<< "` with message:" << std::endl;
 
 	// Print exit message line by line to always have Logger output
 	std::stringstream ss(exit_message);
 	std::string exit_message_line;
-	std::vector<std::string> exit_message_lines;
-	// First, split exit message by "\n"
+	// Split exit message by "\n" and print via Logger
 	while (std::getline(ss, exit_message_line, '\n')) {
-		exit_message_lines.push_back(exit_message_line);
-	}
-	// Second, print each line separately and prepend Logger output
-	for (const auto& message_line : exit_message_lines) {
-		Log::global_log->error_always_output() << message_line << std::endl;
+		Log::global_log->error() << exit_message_line << std::endl;
 	}
 
 #ifdef ENABLE_MPI

--- a/src/utils/xmlfile.cpp
+++ b/src/utils/xmlfile.cpp
@@ -193,9 +193,10 @@ bool XMLfile::initfile_local(const std::string& filepath) {
 	//version using ifstream
 	std::ifstream fstrm(filepathTrimmed.c_str(),std::ifstream::binary|std::ifstream::ate);
 	if(!fstrm) {
-		std::cerr << "ERROR opening " << filepathTrimmed << std::endl;
+		std::ostringstream error_message;
+		error_message << "ERROR opening " << filepathTrimmed << std::endl;
 		clear();
-		MARDYN_EXIT(1);
+		MARDYN_EXIT(error_message);
 	}
 	std::ifstream::pos_type filesize=fstrm.tellg();
 	fstrm.close(); fstrm.clear();
@@ -538,17 +539,19 @@ template<typename T> bool XMLfile::Node::getValue(T& value) const
 		// Check if input has correct sign
 		if (std::is_unsigned_v<T>) {
 			if (ss.str().find_first_of("-") != std::string::npos) {
-				std::cerr << "ERROR parsing \"" << ss.str() << "\" to data type " << typeid(T).name() << " from tag \"<" << name() << ">\" in xml file" << std::endl;
-				std::cerr << "The tag contains a negative value but an unsigned value was expected." << std::endl;
-				MARDYN_EXIT(1);
+				std::ostringstream error_message;
+				error_message << "ERROR parsing \"" << ss.str() << "\" to data type " << typeid(T).name() << " from tag \"<" << name() << ">\" in xml file" << std::endl;
+				error_message << "The tag contains a negative value but an unsigned value was expected." << std::endl;
+				MARDYN_EXIT(error_message);
 			}
 		}
 		ss >> value;
 		// Check if the entire string was consumed
 		if (!ss.eof() || ss.fail()) {
-			std::cerr << "ERROR parsing all chars of \"" << ss.str() << "\" from tag \"<" << name() << ">\" in xml file" << std::endl;
-			std::cerr << "This might be the result of using a float while an integer is expected." << std::endl;
-			MARDYN_EXIT(1);
+			std::ostringstream error_message;
+			error_message << "ERROR parsing all chars of \"" << ss.str() << "\" from tag \"<" << name() << ">\" in xml file" << std::endl;
+			error_message << "This might be the result of using a float while an integer is expected." << std::endl;
+			MARDYN_EXIT(error_message);
 		}
 		return true;
 	}
@@ -582,9 +585,10 @@ template<> bool XMLfile::Node::getValue<bool>(bool& value) const
 		} else if (v == "FALSE" || v == "NO" || v == "OFF") {
 			value = false;
 		} else {
-			std::cerr << "ERROR parsing \"" << v << "\" to boolean from tag \"" << name() << "\" in xml file."
+			std::ostringstream error_message;
+			error_message << "ERROR parsing \"" << v << "\" to boolean from tag \"" << name() << "\" in xml file."
 				<< " Valid values are: true, false, yes, no, on, off. " << std::endl;
-			MARDYN_EXIT(1);
+			MARDYN_EXIT(error_message);
 		}
 	}
 	return found;

--- a/src/utils/xmlfile.cpp
+++ b/src/utils/xmlfile.cpp
@@ -195,7 +195,7 @@ bool XMLfile::initfile_local(const std::string& filepath) {
 	if(!fstrm) {
 		std::cerr << "ERROR opening " << filepathTrimmed << std::endl;
 		clear();
-		mardyn_exit(1);
+		MARDYN_EXIT(1);
 	}
 	std::ifstream::pos_type filesize=fstrm.tellg();
 	fstrm.close(); fstrm.clear();
@@ -540,7 +540,7 @@ template<typename T> bool XMLfile::Node::getValue(T& value) const
 			if (ss.str().find_first_of("-") != std::string::npos) {
 				std::cerr << "ERROR parsing \"" << ss.str() << "\" to data type " << typeid(T).name() << " from tag \"<" << name() << ">\" in xml file" << std::endl;
 				std::cerr << "The tag contains a negative value but an unsigned value was expected." << std::endl;
-				mardyn_exit(1);
+				MARDYN_EXIT(1);
 			}
 		}
 		ss >> value;
@@ -548,7 +548,7 @@ template<typename T> bool XMLfile::Node::getValue(T& value) const
 		if (!ss.eof() || ss.fail()) {
 			std::cerr << "ERROR parsing all chars of \"" << ss.str() << "\" from tag \"<" << name() << ">\" in xml file" << std::endl;
 			std::cerr << "This might be the result of using a float while an integer is expected." << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 		return true;
 	}
@@ -584,7 +584,7 @@ template<> bool XMLfile::Node::getValue<bool>(bool& value) const
 		} else {
 			std::cerr << "ERROR parsing \"" << v << "\" to boolean from tag \"" << name() << "\" in xml file."
 				<< " Valid values are: true, false, yes, no, on, off. " << std::endl;
-			mardyn_exit(1);
+			MARDYN_EXIT(1);
 		}
 	}
 	return found;

--- a/src/utils/xmlfile.cpp
+++ b/src/utils/xmlfile.cpp
@@ -196,7 +196,7 @@ bool XMLfile::initfile_local(const std::string& filepath) {
 		std::ostringstream error_message;
 		error_message << "ERROR opening " << filepathTrimmed << std::endl;
 		clear();
-		MARDYN_EXIT(error_message);
+		MARDYN_EXIT(error_message.str());
 	}
 	std::ifstream::pos_type filesize=fstrm.tellg();
 	fstrm.close(); fstrm.clear();
@@ -542,7 +542,7 @@ template<typename T> bool XMLfile::Node::getValue(T& value) const
 				std::ostringstream error_message;
 				error_message << "ERROR parsing \"" << ss.str() << "\" to data type " << typeid(T).name() << " from tag \"<" << name() << ">\" in xml file" << std::endl;
 				error_message << "The tag contains a negative value but an unsigned value was expected." << std::endl;
-				MARDYN_EXIT(error_message);
+				MARDYN_EXIT(error_message.str());
 			}
 		}
 		ss >> value;
@@ -551,7 +551,7 @@ template<typename T> bool XMLfile::Node::getValue(T& value) const
 			std::ostringstream error_message;
 			error_message << "ERROR parsing all chars of \"" << ss.str() << "\" from tag \"<" << name() << ">\" in xml file" << std::endl;
 			error_message << "This might be the result of using a float while an integer is expected." << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 		return true;
 	}
@@ -588,7 +588,7 @@ template<> bool XMLfile::Node::getValue<bool>(bool& value) const
 			std::ostringstream error_message;
 			error_message << "ERROR parsing \"" << v << "\" to boolean from tag \"" << name() << "\" in xml file."
 				<< " Valid values are: true, false, yes, no, on, off. " << std::endl;
-			MARDYN_EXIT(error_message);
+			MARDYN_EXIT(error_message.str());
 		}
 	}
 	return found;


### PR DESCRIPTION
# Description

For now, the exit codes are just randomly set.
This PR makes the exit message more meaningful by adding the file, function and line where the exit code was called.
In addition, it enforces an error message to be passed.

This was achieved by adding the wrapper `MARDYN_EXIT` to `src/utils/mardyn_assert.h` and calling the wrapper when exiting instead of the function `mardyn_exit`.

An example error output now looks like this (each rank prints the error messages, see comments below):
```
ERROR:  20241010T205703 0.001553 [0]    Exit called from function `getValue` in file `src/utils/xmlfile.cpp:554` with message:
ERROR:  20241010T205703 0.001561 [0]    ERROR parsing all chars of "100000." from tag "<steps>" in xml file
ERROR:  20241010T205703 0.001567 [0]    This might be the result of using a float while an integer is expected.
```

## Resolved Issues

- [x] #195 


## Questions

~Should we replace the current codes with something else? If so, what? e.g. that one:~
--> We decided to drop all exit codes and just print a meaningful error message and exit with EXIT_FAILURE. See comments below and edit history of this comment for details.
