### PR TITLE
Addclangformat

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,11 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
 
+# abort old runs if a new one is started
+concurrency:
+  group: ${{ github.head_ref }}-tests
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/ls1_format.yml
+++ b/.github/workflows/ls1_format.yml
@@ -1,0 +1,64 @@
+name: clang-format check for ls1
+
+on:
+  push:
+    # pushes to master
+    branches: [ master ]
+  pull_request:
+    # PRs to master
+    branches: [ master ]
+
+# abort old runs if a new one is started
+concurrency:
+  group: ${{ github.head_ref }}-tests
+  cancel-in-progress: true
+
+jobs:
+  clang-format-check:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install clang-format
+        run: sudo apt-get install -y clang-format
+
+      - name: Run clang-format and check for differences
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "actions@github.com"
+          # Run clang-format and collect changes
+          clang-format -i $(find . -regex '.*\.\(cpp\|h\|hpp\|c\)')
+          git diff > patch.diff
+          
+      - name: Check if clang-format made changes
+        id: check_diff
+        run: |
+          if [ -s patch.diff ]; then
+            echo "Formatting issues detected!"
+            echo "::set-output name=formatting_issues::true"
+          else
+            echo "No formatting issues found"
+            echo "::set-output name=formatting_issues::false"
+          fi
+
+      - name: Fail if clang-format found issues
+        if: ${{ steps.check_diff.outputs.formatting_issues == 'true' }}
+        run: exit 1
+
+      - name: Post comment if clang-format failed
+        if: ${{ steps.check_diff.outputs.formatting_issues == 'true' }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const { context, github } = require('@actions/github');
+            const issue_number = context.payload.pull_request.number;
+
+            const body = `The CI detected formatting issues in this pull request. Please run clang-format locally to resolve them.`;
+
+            await github.issues.createComment({
+              ...context.repo,
+              issue_number: issue_number,
+              body: body
+            });

--- a/cmake/modules/clangformat.cmake
+++ b/cmake/modules/clangformat.cmake
@@ -1,0 +1,21 @@
+# Find clang-format
+find_program(CLANG_FORMAT_BIN clang-format)
+
+if (NOT CLANG_FORMAT_BIN)
+    message(FATAL_ERROR "clang-format not found!")
+endif()
+
+# List of file extensions to format
+set(FORMAT_EXTENSIONS cpp h hpp c)
+
+# Recursively find all files with the specified extensions
+file(GLOB_RECURSE ALL_SOURCE_FILES 
+    ${PROJECT_SOURCE_DIR}/*.[ch]pp
+    ${PROJECT_SOURCE_DIR}/*.[ch])
+
+# Define clang-format target
+add_custom_target(clang-format
+    COMMAND ${CLANG_FORMAT_BIN} -i ${ALL_SOURCE_FILES}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    COMMENT "Running clang-format"
+)

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,108 +1,19 @@
 ---
 Language:        Cpp
-# BasedOnStyle:  Google
-AccessModifierOffset: -4
-AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlines: Left
-AlignOperands:   true
-AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: true
-AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
-BinPackArguments: true
-BinPackParameters: true
-BraceWrapping:   
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
-BreakBeforeInheritanceComma: false
-BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: true
-ColumnLimit:     120
-CommentPragmas:  '^ IWYU pragma:'
-CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: true
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: true
-ForEachMacros:   
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IncludeCategories: 
-  - Regex:           '^<.*\.h>'
-    Priority:        1
-  - Regex:           '^<.*'
-    Priority:        2
-  - Regex:           '.*'
-    Priority:        3
-IncludeIsMainRegex: '([-_](test|unittest))?$'
-IndentCaseLabels: true
-IndentWidth:     4
-IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 1
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
-ReflowComments:  true
-SortIncludes:    true
-SortUsingDeclarations: true
-SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: true
-SpaceBeforeAssignmentOperators: true
-SpaceBeforeParens: ControlStatements
-SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 2
-SpacesInAngles:  false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
-SpacesInSquareBrackets: false
-Standard:        Auto
-TabWidth:        4
-UseTab:          ForContinuationAndIndentation
-...
-
+BasedOnStyle:  Google
+AccessModifierOffset: -2  #-2
+AllowShortBlocksOnASingleLine: Empty #Never
+AllowShortIfStatementsOnASingleLine: Never  #Never
+AllowShortLoopsOnASingleLine: false  #false
+  BeforeCatch:     true #false
+  BeforeElse:      true #false
+BreakBeforeBraces: Custom #Attach
+ColumnLimit:     120 #80
+IncludeBlocks:   Preserve  #Preserve
+IndentCaseLabels: false  #false
+IndentWidth:     4 #4
+ObjCBlockIndentWidth: 4 #4
+PenaltyReturnTypeOnItsOwnLine: 2000000 #60
+PointerAlignment: Right #Right
+TabWidth:        4 #8
+UseTab:          Always #Never


### PR DESCRIPTION
# Description

As discussed in issue #276 , we want to add a clang-format file to enforce an unified style in ls1.
For this, we have to:

- [ ] Agree on the content of `.clang-format` file
- [ ] Agree on clang-format version (and add it to CI file)
- [ ] Add CI to check format
- [ ] Add target to `CMake` to just run command `make clang-format` for formatting

If we want to be very fancy, we could do something like in [MegaMol](https://github.com/UniStuttgart-VISUS/megamol/blob/e8d8e7d995a10570bbaef5a8fbbc7fada04cb4b5/.github/workflows/style_check_comment.yml#L53).

## Resolved Issues

- [ ] #276


I would recommend that this PR does not apply the formatting to the whole code base in ls1. This should be done in a separate PR for the sake of clarity.
