### PR TITLE
Fix option parser's long option handling

### DIFF
--- a/src/utils/OptionParser.cpp
+++ b/src/utils/OptionParser.cpp
@@ -216,7 +216,7 @@ const Option& OptionParser::lookup_long_opt(const std::string& opt) const {
 
 	std::list<std::string> matching;
 	for (optMap::const_iterator it = _optmap_l.begin(); it != _optmap_l.end(); ++it) {
-		if (it->first.compare(0, opt.length(), opt) == 0)
+		if (it->first == opt)
 			matching.push_back(it->first);
 	}
 	if (matching.size() > 1) {


### PR DESCRIPTION
Long option names were only compared to known options based on the length of the option name given as arguments, resulting in strange matches, e.g., '--step' was matching '--steps'.

This resolves the parsing issue in #351 
