### PR TITLE
Remove mardy_assert from OptionParser to prevent initialisation order issues

### DIFF
--- a/src/utils/OptionParser.cpp
+++ b/src/utils/OptionParser.cpp
@@ -7,11 +7,10 @@
 
 #include "OptionParser.h"
 
-#include "utils/mardyn_assert.h"
-
-#include <cstdlib>
 #include <algorithm>
 #include <complex>
+#include <cstdlib>
+#include <iostream>
 #include <sstream>
 
 #ifdef ENABLE_MPI
@@ -448,15 +447,13 @@ void OptionParser::print_version() const {
 }
 
 void OptionParser::exit() const {
-	std::ostringstream error_message;
-	error_message << "OptionParser::exit() called" << std::endl;
-	MARDYN_EXIT(error_message.str());
+	std::cerr << "OptionParser::exit() called" << std::endl;
+	std::exit(1);
 }
 void OptionParser::error(const std::string& msg) const {
+	std::cerr << "Optionparser error: " << msg << std::endl;
 	print_usage(std::cerr);
-	std::ostringstream error_message;
-	error_message << prog() << ": " << _("error") << ": " << msg << std::endl;
-	MARDYN_EXIT(error_message.str());
+	std::exit(1);
 }
 ////////// } class OptionParser //////////
 


### PR DESCRIPTION
MarDyn_assert uses the logger infrastructure of ls1 internally. However the logger is initialized with command line options causing a circular dependence. Therefore, remove mardyn_assert from the OptionParser. If something is wrong with the command line it is early in the execution and therefore no need for the extensive logger infrastructure to be used.

This resolves the segfault brought up during the review of PR https://github.com/ls1mardyn/ls1-mardyn/pull/355#pullrequestreview-2492385453
