### PR TITLE
Logger update

### DIFF
--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -134,7 +134,10 @@ int run_unit_tests(const Values &options, const std::vector<std::string> &args) 
 int main(int argc, char** argv) {
 #ifdef ENABLE_MPI
 	MPI_Init(&argc, &argv);
+	int world_rank = 0;
+	MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
 #endif
+	Log::global_log = std::make_unique<Log::Logger>(Log::Info);
 
 	// Open scope to exclude MPI_Init() and MPI_Finalize().
 	// This way, all simulation objects are cleaned up before MPI finalizes.
@@ -150,10 +153,13 @@ int main(int argc, char** argv) {
 		// Print to file
 		std::string logfileNamePrefix(options.get("logfile"));
 		std::cout << "Using logfile with prefix " << logfileNamePrefix << std::endl;
-		Log::global_log = std::make_unique<Log::Logger>(Log::Info, logfileNamePrefix);
-	} else {
-		// Print to stream (default: std::cout)
-		Log::global_log = std::make_unique<Log::Logger>(Log::Info);
+		std::string logfile_name = logfileNamePrefix;
+#ifdef ENABLE_MPI
+		logfile_name += "_R" + std::to_string(world_rank);
+#endif
+		logfile_name += ".log";
+		std::shared_ptr<std::ostream> logfile_ptr = std::make_shared<std::ofstream>(logfile_name);
+		Log::global_log->set_log_stream(logfile_ptr);
 	}
 
 #ifdef ENABLE_MPI

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -152,12 +152,12 @@ int main(int argc, char** argv) {
 	if( options.is_set_by_user("logfile") ) {
 		// Print to file
 		std::string logfileNamePrefix(options.get("logfile"));
-		std::cout << "Using logfile with prefix " << logfileNamePrefix << std::endl;
 		std::string logfile_name = logfileNamePrefix;
 #ifdef ENABLE_MPI
 		logfile_name += "_R" + std::to_string(world_rank);
 #endif
 		logfile_name += ".log";
+		Log::global_log->info() << "Using logfile " << logfile_name << " for further log output." << std::endl;
 		std::shared_ptr<std::ostream> logfile_ptr = std::make_shared<std::ofstream>(logfile_name);
 		Log::global_log->set_log_stream(logfile_ptr);
 	}

--- a/src/plugins/VectorizationTuner.h
+++ b/src/plugins/VectorizationTuner.h
@@ -8,9 +8,9 @@ enum MoleculeCntIncreaseTypeEnum{
 	both         //!< both, do linear and exponential measurements, linear measurements will stop after 32 molecules.
 };
 
-
-#include <vector>
+#include <fstream>
 #include <string>
+#include <vector>
 
 #include "particleContainer/adapter/CellProcessor.h"
 #include "particleContainer/adapter/FlopCounter.h"

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -11,7 +11,7 @@ std::unique_ptr<Logger> global_log;
 // Write to stream
 Logger::Logger(logLevel level, std::ostream *os) :
 	_log_level(level), _msg_log_level(Log::Error),
-	_do_output(true), _filename(""),
+	_do_output(true),
 	// std::cout is managed globally,
 	// so do nothing when _log_stream goes out of scope
 	// --> any passed ostream other than std::cout needs to be
@@ -24,27 +24,6 @@ Logger::Logger(logLevel level, std::ostream *os) :
 #ifdef ENABLE_MPI
 	MPI_Comm_rank(MPI_COMM_WORLD, &_rank);
 #endif
-	*_log_stream << std::boolalpha;  // Print boolean as true/false
-}
-
-// Write to file
-Logger::Logger(logLevel level, std::string prefix) :
-	_log_level(level), _msg_log_level(Log::Error),
-	_do_output(true), _filename(""), _log_stream(nullptr),
-	logLevelNames(), _starttime(), _rank(0)
-{
-	init_starting_time();
-	this->init_log_levels();
-	std::stringstream filenamestream;
-	filenamestream << prefix;
-#ifdef ENABLE_MPI
-	MPI_Comm_rank(MPI_COMM_WORLD, &_rank);
-	filenamestream << "_R" << _rank;
-#endif
-	filenamestream << ".log";
-	_filename = filenamestream.str();
-	
-	_log_stream = std::make_shared<std::ofstream>(_filename.c_str());
 	*_log_stream << std::boolalpha;  // Print boolean as true/false
 }
 

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -2,8 +2,6 @@
 
 #include "Logger.h"
 
-#include <memory>
-
 namespace Log {
 
 std::unique_ptr<Logger> global_log;

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -9,14 +9,10 @@ namespace Log {
 std::unique_ptr<Logger> global_log;
 
 // Write to stream
-Logger::Logger(logLevel level, std::ostream *os) :
+Logger::Logger(logLevel level, std::shared_ptr<std::ostream> os) :
 	_log_level(level), _msg_log_level(Log::Error),
 	_do_output(true),
-	// std::cout is managed globally,
-	// so do nothing when _log_stream goes out of scope
-	// --> any passed ostream other than std::cout needs to be
-	// deleted manually!
-	_log_stream(os, [](std::ostream*){/* no-op deleter */}),
+	_log_stream(os),
 	logLevelNames(), _starttime(), _rank(0)
 {
 	init_starting_time();

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -3,16 +3,15 @@
 
 #define USE_GETTIMEOFDAY
 
-#include <iostream>
-#include <fstream>
-#include <cstdlib>
-#include <iomanip>
-#include <map>
-#include <ctime>
-#include <string>
-#include <sstream>
 #include <chrono>
+#include <ctime>
+#include <cctype>
+#include <iomanip>
+#include <iostream>
+#include <map>
 #include <memory>
+#include <string>
+#include <utility>
 
 #ifdef ENABLE_MPI
 #include <mpi.h>

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -163,7 +163,7 @@ public:
 			const auto now = std::chrono::system_clock::now();
 			const auto time_since_start = now - _starttime;
 
-			auto now_time_t = std::chrono::system_clock::to_time_t(now);
+			const auto now_time_t = std::chrono::system_clock::to_time_t(now);
 			std::tm now_local{};
 			localtime_r(&now_time_t, &now_local);
 			std::stringstream timestampstream;

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -102,14 +102,6 @@ private:
 		logLevelNames.insert(std::pair<logLevel, std::string>(All,     "ALL"      ));
 	}
 
-	// don't allow copy-construction
-	Logger(const Logger&) : _log_level(Log::Error), _msg_log_level(Log::Error), _do_output(true),
-			_log_stream(nullptr), logLevelNames(), _starttime(), _rank(0)
-	{ }
-
-	// don't allow assignment
-	Logger& operator=(const Logger&) { return *this; }
-
 public:
 	/**
 	 * Constructor for a logger to a stream.

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -162,7 +162,6 @@ public:
 			const auto now_time_t = std::chrono::system_clock::to_time_t(now);
 			std::tm now_local{};
 			localtime_r(&now_time_t, &now_local);
-			std::stringstream timestampstream;
 			*_log_stream << logLevelNames[level] << ":\t" << std::put_time(&now_local, "%Y-%m-%dT%H:%M:%S") << " ";
 			*_log_stream << std::setw(8) << std::chrono::duration<double>(time_since_start).count() << " ";
 

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -189,10 +189,8 @@ public:
 	}
 	/// set log level from string
 	logLevel set_log_level(std::string l) {
-		// identify the loglevel by comparing the first char of the names
 		for (const auto& [lvl, name] : logLevelNames) {
-			// case-insensitive matching
-			if (std::toupper(name[0]) == std::toupper(l[0])) {
+			if (name == l) {
 				_log_level = lvl;
 				return _log_level;
 			}

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -120,11 +120,10 @@ public:
 	 *
 	 * Initializes the log level, log stream and the list of log level names.
 	 * If ENABLE_MPI is enabled by default, all process perform logging output.
-	 * Note: Due to the default argument (std::cout), the passed ostream pointer
-	 * will not be deleted automatically! Any passed ostream pointer other than
-	 * std::cout must be deleted manually!
+	 * Note: The default stream used (std::cout) cannot be deleted. Therefore the
+	 * passed shared pointer to it uses a no-op deleter function.
 	 */
-	Logger(logLevel level = Log::Error, std::ostream *os = &(std::cout));
+	Logger(logLevel level = Log::Error, std::shared_ptr<std::ostream> os = std::shared_ptr<std::ostream>(&std::cout, [](void*){ /* no-op */}));
 
 	~Logger() = default;
 

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -67,11 +67,7 @@ typedef enum {
 
 /** @brief The Logger class provides a simple interface to handle log messages.
  *
- * Provides easy interface to handle log messages. Initialize either with
- * output level and stream or use default constructor values (Error, &(std::cout)).
- * Note: Due to the default argument (std::cout), the passed ostream pointer
- * will not be deleted automatically! Any passed ostream pointer other than
- * std::cout must be deleted manually!
+ * The logger provides an easy way to output logging messages with various log levels.
  * For writing log messages use fatal(), error(), warning(), info() or debug() as
  * with normal streams, e.g.
  * > log.error() << "Wrong parameter." << std::endl;

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -233,6 +233,10 @@ public:
 		return _log_level;
 	}
 
+	void set_log_stream(std::shared_ptr<std::ostream> os) {
+		_log_stream = os;
+	}
+
 	/// switch on / off output
 	bool set_do_output(bool val) {
 		return _do_output = val;

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -68,13 +68,10 @@ typedef enum {
 /** @brief The Logger class provides a simple interface to handle log messages.
  *
  * Provides easy interface to handle log messages. Initialize either with
- * output level and stream or output level and filename or use default constructor
- * values (Error, &(std::cout)).
+ * output level and stream or use default constructor values (Error, &(std::cout)).
  * Note: Due to the default argument (std::cout), the passed ostream pointer
  * will not be deleted automatically! Any passed ostream pointer other than
  * std::cout must be deleted manually!
- * With a given file basename and MPI Support each rank will create
- * and write to its own file.
  * For writing log messages use fatal(), error(), warning(), info() or debug() as
  * with normal streams, e.g.
  * > log.error() << "Wrong parameter." << std::endl;
@@ -92,7 +89,6 @@ private:
 	logLevel _log_level;
 	logLevel _msg_log_level;
 	bool _do_output;
-	std::string _filename;
 	std::shared_ptr<std::ostream> _log_stream;
 	std::map<logLevel, std::string> logLevelNames;
 
@@ -112,7 +108,7 @@ private:
 
 	// don't allow copy-construction
 	Logger(const Logger&) : _log_level(Log::Error), _msg_log_level(Log::Error), _do_output(true),
-			_filename(""), _log_stream(nullptr), logLevelNames(), _starttime(), _rank(0)
+			_log_stream(nullptr), logLevelNames(), _starttime(), _rank(0)
 	{ }
 
 	// don't allow assignment
@@ -129,13 +125,6 @@ public:
 	 * std::cout must be deleted manually!
 	 */
 	Logger(logLevel level = Log::Error, std::ostream *os = &(std::cout));
-	/**
-	 * Constructor for a logger to a file.
-	 *
-	 * Initializes the log level, log stream and the list of log level names.
-	 * If ENABLE_MPI is enabled by default, all process perform logging output.
-	 */
-	Logger(logLevel level, std::string prefix);
 
 	~Logger() = default;
 


### PR DESCRIPTION
Added the possibility to change the output stream of the logger. The logger is now default initialized with output to std::cout right after `MPI_init`. The output is changed to a log file later if requested via command line arguments. This resolves the segfault brought up during the review of PR #355 and takes into account the comments on the initial fix in PR https://github.com/ls1mardyn/ls1-mardyn/pull/358.

As the explicit constructor for logfiles is not needed any more, now, got rid of this in preparation for removing dependencies to MPI.
Also, refactored the time output code to use std::chrono where possible

Update:
Allow copying of loggers.
Fixed setting the log level by string: now case-matches instead of just looking for the leading character.