### PR TITLE
Fix CI for Ubuntu 24.04

### DIFF
--- a/.github/workflows/ls1_test.yml
+++ b/.github/workflows/ls1_test.yml
@@ -87,6 +87,7 @@ jobs:
           cmake -DVECTOR_INSTRUCTIONS=${{ matrix.vector }} \
                 -DCMAKE_BUILD_TYPE=${{ matrix.target }} \
                 -DENABLE_AUTOPAS=${{ matrix.autopas }} \
+                -DAUTOPAS_ENABLE_RULES_BASED_AND_FUZZY_TUNING=ON \
                 -DENABLE_ALLLBL=$alllbl_enabled \
                 -DOPENMP=${{ matrix.openmp }} \
                 -DENABLE_MPI=$mpi_enabled \
@@ -149,6 +150,7 @@ jobs:
           cmake -DVECTOR_INSTRUCTIONS=${{ matrix.vector }} \
                 -DCMAKE_BUILD_TYPE=${{ matrix.target }} \
                 -DENABLE_AUTOPAS=${{ matrix.autopas }} \
+                -DAUTOPAS_ENABLE_RULES_BASED_AND_FUZZY_TUNING=ON \
                 -DENABLE_ALLLBL=$alllbl_enabled \
                 -DOPENMP=${{ matrix.openmp }} \
                 -DENABLE_MPI=$mpi_enabled \

--- a/.github/workflows/ls1_test.yml
+++ b/.github/workflows/ls1_test.yml
@@ -57,7 +57,7 @@ jobs:
         sudo apt-get update
         # MPICH 4.0.3 seems to have a bug that triggers a FP exception in our collective communication when doing 0+0.
         sudo apt-get install -y \
-          automake              \
+          uuid                  \
           libcppunit-dev        \
           libopenmpi-dev        \
           libomp-dev            \

--- a/.github/workflows/ls1_test.yml
+++ b/.github/workflows/ls1_test.yml
@@ -57,6 +57,7 @@ jobs:
         sudo apt-get update
         # MPICH 4.0.3 seems to have a bug that triggers a FP exception in our collective communication when doing 0+0.
         sudo apt-get install -y \
+          automake              \
           libcppunit-dev        \
           libopenmpi-dev        \
           libomp-dev            \

--- a/.github/workflows/ls1_test.yml
+++ b/.github/workflows/ls1_test.yml
@@ -57,7 +57,7 @@ jobs:
         sudo apt-get update
         # MPICH 4.0.3 seems to have a bug that triggers a FP exception in our collective communication when doing 0+0.
         sudo apt-get install -y \
-          uuid                  \
+          uuid-dev              \
           libcppunit-dev        \
           libopenmpi-dev        \
           libomp-dev            \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Prerequisites
 * [FFTW3](http://www.fftw.org)
 * [VTK](http://www.vtk.org)
 * [QuickSched](https://arxiv.org/abs/1601.05384)
-
+* If [AutoPas](https://autopas.github.io/doxygen_documentation/git-master/) is enabled, make sure to have [its requirements](https://github.com/AutoPas/AutoPas/blob/master/docs/userdoc/Building.md) installed.
 
 Installation
 ------------

--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -23,8 +23,8 @@ if (ENABLE_AUTOPAS)
     set(AUTOPAS_USE_VECTORIZATION ${USE_VECTORIZATION} CACHE BOOL "Set via USE_VECTORIZATION" FORCE)
     set(AUTOPAS_VECTOR_INSTRUCTIONS ${VECTOR_INSTRUCTIONS} CACHE STRING "Set via VECTOR_INSTRUCTIONS_OPTIONS" FORCE)
 
-    # Merge of #830 (fixRegionIterators); includes #787 (combined tuning)
-    set(AUTOPAS_TAG faef573 CACHE STRING "AutoPas Git tag or commit id to use")
+    # Last version without 3 Body support. Newer versions have API changes
+    set(AUTOPAS_TAG v2.0.0 CACHE STRING "AutoPas Git tag or commit id to use")
 
     FetchContent_Declare(
             autopasfetch


### PR DESCRIPTION
# Description

Github updated their `ubuntu-latest` runners to `24.04`. [This lead to widespread issues](https://github.com/actions/runner-images/issues/10636). This PR gets the CI working again.

- [x] install automake

## Related Pull Requests

All currently open PRs are affected.

## ~Resolved Issues~

## How Has This Been Tested?

- [x] CI is working again

## Documentation
- [x] update requirements in README
