### PR TITLE
Improve parsability of output of ResultWriter

### DIFF
--- a/src/io/ResultWriter.cpp
+++ b/src/io/ResultWriter.cpp
@@ -46,7 +46,7 @@ void ResultWriter::init(ParticleContainer * /*particleContainer*/,
 		const auto nowStr = std::put_time(localtime_r(&now, &unused), "%c");
 		resultStream << "# ls1 MarDyn simulation started at " << nowStr << std::endl;
 		resultStream << "# Averages are the accumulated values over " << _U_pot_acc->getWindowLength()  << " time steps."<< std::endl;
-		resultStream << std::setw(10) << "# step" << std::setw(_writeWidth) << "time"
+		resultStream << std::setw(10) << "simstep" << std::setw(_writeWidth) << "time"
 			<< std::setw(_writeWidth) << "U_pot"
 			<< std::setw(_writeWidth) << "U_pot_avg"
 			<< std::setw(_writeWidth) << "U_kin"


### PR DESCRIPTION
# Description

Currently, there is a `#` in the output of the ResultWriter, which makes the header row technically a comment. This is a problem when trying to parse the whole file. It is much easier with `simstep` instead of `# step`. This can be parse in python just with:
`df = pd.read_csv(path2File, delim_whitespace=True, comment="#", engine="python")`

