### PR TITLE
Fix MPICheckpointWriter

### DIFF
--- a/examples/Generators/mkesfera/config.xml
+++ b/examples/Generators/mkesfera/config.xml
@@ -109,7 +109,7 @@
 				<outputprefix>mkesfera</outputprefix>
 				<appendTimestamp>true</appendTimestamp>
 				<datarep>native</datarep>
-				<measureTime>1</measureTime>
+				<measureTime>true</measureTime>
 				<mpi_info>
 					<hint> <key>striping_factor</key> <value>4</value> </hint>
 					<hint> <key>striping_unit</key> <value>65536</value> </hint>

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -417,7 +417,7 @@
         <outputprefix>default</outputprefix>
         <appendTimestamp>true</appendTimestamp>
         <datarep>native</datarep>
-        <measureTime>1</measureTime>
+        <measureTime>true</measureTime>
       </outputplugin>
 
       <!-- more output plugins -->

--- a/src/io/MPICheckpointWriter.cpp
+++ b/src/io/MPICheckpointWriter.cpp
@@ -55,20 +55,14 @@ void MPICheckpointWriter::readXML(XMLfileUnits& xmlconfig)
 	Log::global_log->info() << "[MPICheckpointWriter]\toutput prefix: " << _outputPrefix << std::endl;
 
 	_incremental = false;
-	int incremental = 1;
-	xmlconfig.getNodeValue("incremental", incremental);
-	//_incremental = (incremental != 0);
-	if(incremental > 0) {
-		_incremental = true;
+	xmlconfig.getNodeValue("incremental", _incremental);
+	if(_incremental) {
 		Log::global_log->info() << "[MPICheckpointWriter]\tusing incremental numbers in file names" << std::endl;
 	}
 
 	_appendTimestamp = false;
-	int appendTimestamp = 0;
-	xmlconfig.getNodeValue("appendTimestamp", appendTimestamp);
-	//_appendTimestamp = (appendTimestamp != 0);
-	if(appendTimestamp > 0) {
-		_appendTimestamp = true;
+	xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
+	if(_appendTimestamp) {
 		Log::global_log->info() << "[MPICheckpointWriter]\tappend timestamp to file names" << std::endl;
 	}
 
@@ -79,11 +73,8 @@ void MPICheckpointWriter::readXML(XMLfileUnits& xmlconfig)
 		Log::global_log->info() << "[MPICheckpointWriter]\tdata representation: " << _datarep << std::endl;
 
 	_measureTime = false;
-	int measureTime = 0;
-	xmlconfig.getNodeValue("measureTime", measureTime);
-	//_measureTime = (measureTime != 0);
-	if(measureTime > 0) {
-		_measureTime = true;
+	xmlconfig.getNodeValue("measureTime", _measureTime);
+	if(_measureTime) {
 		Log::global_log->info() << "[MPICheckpointWriter]\texecution wall time will be measured" << std::endl;
 	}
 

--- a/src/io/MPICheckpointWriter.cpp
+++ b/src/io/MPICheckpointWriter.cpp
@@ -48,34 +48,34 @@ void MPICheckpointWriter::readXML(XMLfileUnits& xmlconfig)
 {
 	_writeFrequency = 1;
 	xmlconfig.getNodeValue("writefrequency", _writeFrequency);
-	Log::global_log->info() << "[MPICheckpointWriter]\twrite frequency: " << _writeFrequency << std::endl;
+	Log::global_log->info() << "[MPICheckpointWriter] write frequency: " << _writeFrequency << std::endl;
 
 	_outputPrefix = "mardyn";
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
-	Log::global_log->info() << "[MPICheckpointWriter]\toutput prefix: " << _outputPrefix << std::endl;
+	Log::global_log->info() << "[MPICheckpointWriter] output prefix: " << _outputPrefix << std::endl;
 
 	_incremental = false;
 	xmlconfig.getNodeValue("incremental", _incremental);
 	if(_incremental) {
-		Log::global_log->info() << "[MPICheckpointWriter]\tusing incremental numbers in file names" << std::endl;
+		Log::global_log->info() << "[MPICheckpointWriter] using incremental numbers in file names" << std::endl;
 	}
 
 	_appendTimestamp = false;
 	xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
 	if(_appendTimestamp) {
-		Log::global_log->info() << "[MPICheckpointWriter]\tappend timestamp to file names" << std::endl;
+		Log::global_log->info() << "[MPICheckpointWriter] appending timestamps to file names" << std::endl;
 	}
 
 	_datarep = "";	// -> NULL
 	//_datarep = "external32";	// "native", "internal", "external32"
 	xmlconfig.getNodeValue("datarep", _datarep);
 	if(!_datarep.empty())
-		Log::global_log->info() << "[MPICheckpointWriter]\tdata representation: " << _datarep << std::endl;
+		Log::global_log->info() << "[MPICheckpointWriter] data representation: " << _datarep << std::endl;
 
 	_measureTime = false;
 	xmlconfig.getNodeValue("measureTime", _measureTime);
 	if(_measureTime) {
-		Log::global_log->info() << "[MPICheckpointWriter]\texecution wall time will be measured" << std::endl;
+		Log::global_log->info() << "[MPICheckpointWriter] execution wall time will be measured" << std::endl;
 	}
 
 	if(xmlconfig.changecurrentnode("mpi_info")) {
@@ -93,9 +93,9 @@ void MPICheckpointWriter::readXML(XMLfileUnits& xmlconfig)
 	if(_particlesbuffersize)
 	{
 #ifdef ENABLE_MPI
-		Log::global_log->info() << "[MPICheckpointWriter]\tparticles buffer size: " << _particlesbuffersize << std::endl;
+		Log::global_log->info() << "[MPICheckpointWriter] particles buffer size: " << _particlesbuffersize << std::endl;
 #else
-		Log::global_log->info() << "[MPICheckpointWriter]\tparticles buffer size (" << _particlesbuffersize << ") only used in parallel/MPI version" << std::endl;
+		Log::global_log->info() << "[MPICheckpointWriter] particles buffer size (" << _particlesbuffersize << ") only used in parallel/MPI version" << std::endl;
 #endif
 	}
 }
@@ -155,14 +155,14 @@ void MPICheckpointWriter::endStep(ParticleContainer *particleContainer, DomainDe
 		filenamestream << ".MPIrestart.dat";
 
 		std::string filename = filenamestream.str();
-		Log::global_log->info() << "[MPICheckpointWriter]\tfilename: " << filename << std::endl;
+		Log::global_log->info() << "[MPICheckpointWriter] filename: " << filename << std::endl;
 
 		unsigned long numParticles_global = domain->getglobalNumMolecules(true, particleContainer, domainDecomp);
 		unsigned long numParticles = particleContainer->getNumberOfParticles();	// local
 		unsigned long numbb{1ul};
 #ifdef ENABLE_MPI
-		Log::global_log->info() << "[MPICheckpointWriter]\tnumber of particles: " << numParticles_global
-		                   << "\t(*" << sizeof(ParticleData) << "=" << numParticles_global*sizeof(ParticleData) << " Bytes in memory)"
+		Log::global_log->info() << "[MPICheckpointWriter] number of particles: " << numParticles_global
+		                   << " (*" << sizeof(ParticleData) << "=" << numParticles_global*sizeof(ParticleData) << " Bytes in memory)"
 				   << std::endl;
 		//global_log->set_mpi_output_all()
 		int num_procs;
@@ -251,10 +251,10 @@ void MPICheckpointWriter::endStep(ParticleContainer *particleContainer, DomainDe
 		mpioffset+=sizeof(unsigned long);
 		MPI_CHECK( MPI_File_write_at(mpifh,mpioffset,&numParticles,1,MPI_UNSIGNED_LONG,&mpistat) );
 		mpioffset+=sizeof(unsigned long);
-		Log::global_log->debug() << "[MPICheckpointWriter](" << ownrank << ")\tBB " << ":\t"
+		Log::global_log->debug() << "[MPICheckpointWriter](" << ownrank << ") BB " << ": "
 		                    << bbmin[0] << ", " << bbmin[1] << ", " << bbmin[2] << " - "
 		                    << bbmax[0] << ", " << bbmax[1] << ", " << bbmax[2]
-		                    << "\tstarting index=" << startidx << " numParticles=" << numParticles << std::endl;
+		                    << " starting index=" << startidx << " numParticles=" << numParticles << std::endl;
 		//
 		MPI_Datatype mpidtParticleM, mpidtParticleD;
 		ParticleData::getMPIType(mpidtParticleM);
@@ -276,7 +276,7 @@ void MPICheckpointWriter::endStep(ParticleContainer *particleContainer, DomainDe
 		Log::global_log->debug()
 			<< "[MPICheckpointWriter]("
 			<< ownrank
-			<< ")\twriting molecule data for "
+			<< ") writing molecule data for "
 			<< numParticles
 			<< " particles of size "
 			<< mpidtParticleDts
@@ -354,20 +354,20 @@ void MPICheckpointWriter::endStep(ParticleContainer *particleContainer, DomainDe
 			// global_simulation->timers()->stop("MPI_CHECKPOINT_WRITER_INPUT");
 			// double mpimeasuredtime=global_simulation->timers()->getTime("MPI_CHECKPOINT_WRITER_INPUT");
 			if(ownrank==0) {
-				Log::global_log->info() << "[MPICheckpointWriter]\tmeasured time: " << mpimeasuredtime << " sec (par., "
+				Log::global_log->info() << "[MPICheckpointWriter] measured time: " << mpimeasuredtime << " sec (par., "
 										<< num_procs << " proc.; " << numParticles_global << "*" << mpidtParticleDts
 										<< "=" << numParticles_global * mpidtParticleDts << " Bytes)" << std::endl;
 			}
 		}
 #else
-		Log::global_log->info() << "[MPICheckpointWriter]\tnumber of particles: " << numParticles_global
-		                   << "\t(*" << 2*sizeof(unsigned long)+13*sizeof(double) << "=" << numParticles_global*(2*sizeof(unsigned long)+13*sizeof(double)) << " Bytes in memory)"
+		Log::global_log->info() << "[MPICheckpointWriter] number of particles: " << numParticles_global
+		                   << " (*" << 2*sizeof(unsigned long)+13*sizeof(double) << "=" << numParticles_global*(2*sizeof(unsigned long)+13*sizeof(double)) << " Bytes in memory)"
 				   << std::endl;
 		unsigned long gap=7+3+sizeof(unsigned long)+(6*sizeof(double)+2*sizeof(unsigned long));
 		unsigned int i;
 		unsigned int offset=0;
 		if (!_datarep.empty()) {
-			Log::global_log->warning() << "[MPICheckpointWriter]\tsetting data representation (" << _datarep
+			Log::global_log->warning() << "[MPICheckpointWriter] setting data representation (" << _datarep
 									   << ") is not supported (yet) in sequential version" << std::endl;
 		}
 		// should use Timer instead
@@ -433,7 +433,7 @@ void MPICheckpointWriter::endStep(ParticleContainer *particleContainer, DomainDe
 			double measuredtime=(double)(tod_end.tv_sec-tod_start.tv_sec)+(double)(tod_end.tv_usec-tod_start.tv_usec)/1.E6;
 			// global_simulation->timers()->stop("MPI_CHECKPOINT_WRITER_INPUT");
 			// double measuredtime=global_simulation->timers()->getTime("MPI_CHECKPOINT_WRITER_INPUT");
-			Log::global_log->info() << "[MPICheckpointWriter]\tmeasured time: " << measuredtime << " sec (seq.)" << std::endl;
+			Log::global_log->info() << "[MPICheckpointWriter] measured time: " << measuredtime << " sec (seq.)" << std::endl;
 		}
 #endif
 	}

--- a/src/io/MPICheckpointWriter.h
+++ b/src/io/MPICheckpointWriter.h
@@ -40,6 +40,20 @@ public:
 	                   , std::string datarep=std::string(""));
 	//~MPICheckpointWriter() {};
 
+	/** @brief Read in XML configuration for MPICheckpointWriter and all its included objects.
+	 *
+	 * The following xml object structure is handled by this method:
+	 * \code{.xml}
+		<outputplugin name="MPICheckpointWriter">
+			<writefrequency>INTEGER</writefrequency> <!-- Frequency in which the output is written; Default: 1 -->
+			<outputprefix>STRING</outputprefix> <!-- Prefix of the output file; Default: "mardyn" -->
+			<incremental>BOOL</incremental> <!-- Checkpoint files will get individual numbers; Default: false -->
+			<appendTimestamp>BOOL</appendTimestamp> <!-- Append timestamp to checkpoint files; Default: false -->
+			<datarep>STRING</datarep> <!-- MPI I/O output representation to use, valid values are "native", "internal", "external32"; Default: "" -->
+			<mpi_info><!-- see MPI_Info_object class documentation --></mpi_info> <!-- MPI infos to be used for MPI file I/O writing the checkpoint files -->
+		</outputplugin>
+	   \endcode
+	 */
 	void readXML(XMLfileUnits& xmlconfig);
 
 	void init(ParticleContainer *particleContainer,

--- a/src/io/MPICheckpointWriter.h
+++ b/src/io/MPICheckpointWriter.h
@@ -38,7 +38,6 @@ public:
 	MPICheckpointWriter(unsigned long writeFrequency
 	                   , std::string outputPrefix, bool incremental=true
 	                   , std::string datarep=std::string(""));
-	//~MPICheckpointWriter() {};
 
 	/** @brief Read in XML configuration for MPICheckpointWriter and all its included objects.
 	 *


### PR DESCRIPTION
# Description

- Fix an issue with the readXML method not parsing bools after the XML reader update.
- cleaned up code
- added documentation

Note: Just some initial work on this writer. I plan to go over this and the other MPI I/O-based reader/writers and consolidate and update them so we have a working high-performance MPI I/O for checkpointing again.

#
- [x] Used Generators/mkesfera enabling the MPICheckpoint writer.

## Documentation
(Only relevant if this PR introduces new features)
- [x] `all-options.xml` documents how to use the feature.
- [x] The responsible `readXML()` documents how to use the feature.

Related PRs:
- This is part of the work and discussion in https://github.com/ls1mardyn/ls1-mardyn/pull/332