### PR TITLE
Remove MPI dependence in Logger

### DIFF
--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -163,8 +163,7 @@ int main(int argc, char** argv) {
 	}
 
 #ifdef ENABLE_MPI
-	Log::global_log->set_mpi_output_root(0);
-	//global_log->set_mpi_output_all();
+	Log::global_log->set_log_level((world_rank == 0) ? Log::Info : Log::Error);
 #endif
 
 	Log::global_log->info() << "Running ls1-MarDyn version " << MARDYN_VERSION << std::endl;

--- a/src/MarDyn.cpp
+++ b/src/MarDyn.cpp
@@ -132,12 +132,14 @@ int run_unit_tests(const Values &options, const std::vector<std::string> &args) 
  * all classes.
  */
 int main(int argc, char** argv) {
+	Log::global_log = std::make_unique<Log::Logger>(Log::Info);
+
 #ifdef ENABLE_MPI
 	MPI_Init(&argc, &argv);
 	int world_rank = 0;
 	MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+	Log::global_log->set_msg_prefix("[" + std::to_string(world_rank) + "]\t");
 #endif
-	Log::global_log = std::make_unique<Log::Logger>(Log::Info);
 
 	// Open scope to exclude MPI_Init() and MPI_Finalize().
 	// This way, all simulation objects are cleaned up before MPI finalizes.

--- a/src/parallel/DomainDecompMPIBase.cpp
+++ b/src/parallel/DomainDecompMPIBase.cpp
@@ -283,24 +283,15 @@ void DomainDecompMPIBase::finishNonBlockingStageImpl(ParticleContainer* molecule
 
 void DomainDecompMPIBase::exchangeMoleculesMPI(ParticleContainer* moleculeContainer, Domain* domain,
 		MessageType msgType, bool doHaloPositionCheck, bool removeRecvDuplicates) {
-
-	Log::global_log->set_mpi_output_all();
-
 	_neighbourCommunicationScheme->exchangeMoleculesMPI(moleculeContainer, domain, msgType, removeRecvDuplicates,
 														this, doHaloPositionCheck);
-
-	Log::global_log->set_mpi_output_root(0);
 }
 
 
 
 void DomainDecompMPIBase::exchangeForces(ParticleContainer* moleculeContainer, Domain* domain) {
-	Log::global_log->set_mpi_output_all();
-
 	// Using molecule exchange method with the force message type
 	_neighbourCommunicationScheme->exchangeMoleculesMPI(moleculeContainer, domain, FORCES, false, this);
-
-	Log::global_log->set_mpi_output_root(0);
 }
 
 size_t DomainDecompMPIBase::getTotalSize() {

--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -100,9 +100,7 @@ void GeneralDomainDecomposition::balanceAndExchange(double lastTraversalTime, bo
 			// rebalance
 			Log::global_log->info() << "rebalancing..." << std::endl;
 
-			Log::global_log->set_mpi_output_all();
 			Log::global_log->debug() << "work:" << lastTraversalTime << std::endl;
-			Log::global_log->set_mpi_output_root(0);
 			auto [newBoxMin, newBoxMax] = _loadBalancer->rebalance(lastTraversalTime);
 			if (_gridSize.has_value()) {
 				std::tie(newBoxMin, newBoxMax) = latchToGridSize(newBoxMin, newBoxMax);
@@ -154,7 +152,6 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 		ownDomain.offset[i] = 0;
 		newDomain.offset[i] = 0;
 	}
-	Log::global_log->set_mpi_output_all();
 	Log::global_log->debug() << "migrating from"
 						<< " [" << oldBoxMin[0] << ", " << oldBoxMax[0] << "] x"
 						<< " [" << oldBoxMin[1] << ", " << oldBoxMax[1] << "] x"
@@ -163,7 +160,6 @@ void GeneralDomainDecomposition::migrateParticles(Domain* domain, ParticleContai
 						<< " [" << newMin[0] << ", " << newMax[0] << "] x"
 						<< " [" << newMin[1] << ", " << newMax[1] << "] x"
 						<< " [" << newMin[2] << ", " << newMax[2] << "]." << std::endl;
-	Log::global_log->set_mpi_output_root(0);
 	std::vector<HaloRegion> desiredDomain{newDomain};
 	std::vector<CommunicationPartner> sendNeighbors{}, recvNeighbors{};
 

--- a/src/parallel/KDDecomposition.cpp
+++ b/src/parallel/KDDecomposition.cpp
@@ -480,7 +480,6 @@ bool KDDecomposition::migrateParticles(const KDNode& newRoot, const KDNode& newO
 	sendTogether &= neighborschemeAllowsDirect;
 	updateSendLeavingWithCopies(sendTogether);
 
-	Log::global_log->set_mpi_output_all();
 	double waitCounter = 5.0;
 	double deadlockTimeOut = 360.0;
 	bool allDone = false;
@@ -538,8 +537,6 @@ bool KDDecomposition::migrateParticles(const KDNode& newRoot, const KDNode& newO
 		}
 
 	} // while not allDone
-
-	Log::global_log->set_mpi_output_root(0);
 
 	moleculeContainer->update();
 

--- a/src/parallel/NeighbourCommunicationScheme.cpp
+++ b/src/parallel/NeighbourCommunicationScheme.cpp
@@ -328,7 +328,6 @@ void DirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI(ParticleCo
 
 	double waitCounter = 50.0;
 	double deadlockTimeOut = 360.0;
-	Log::global_log->set_mpi_output_all();
 	while (not allDone) {
 		allDone = true;
 		if (_pushPull) {
@@ -404,8 +403,6 @@ void DirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI(ParticleCo
 		}
 
 	}  // while not allDone
-
-	Log::global_log->set_mpi_output_root(0);
 }
 
 void NeighbourCommunicationScheme::selectNeighbours(MessageType msgType, bool import) {
@@ -552,7 +549,6 @@ void IndirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI1D(Partic
 
 	double waitCounter = 50.0;
 	double deadlockTimeOut = 360.0;
-	Log::global_log->set_mpi_output_all();
 	for (int i = 0; i < numNeighbours; ++i) { // reset receive status
 		if (domainDecomp->getRank() != (*_neighbours)[d][i].getRank()) {
 			(*_neighbours)[d][i].resetReceive();
@@ -604,7 +600,6 @@ void IndirectNeighbourCommunicationScheme::finalizeExchangeMoleculesMPI1D(Partic
 		}
 
 	} // while not allDone
-	Log::global_log->set_mpi_output_root(0);
 }
 
 void IndirectNeighbourCommunicationScheme::exchangeMoleculesMPI1D(ParticleContainer* moleculeContainer, Domain* domain,

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -11,13 +11,10 @@ Logger::Logger(logLevel level, std::shared_ptr<std::ostream> os) :
 	_log_level(level), _msg_log_level(Log::Error),
 	_do_output(true),
 	_log_stream(os),
-	logLevelNames(), _starttime(), _rank(0)
+	logLevelNames(), _starttime(), _msg_prefix()
 {
-	init_starting_time();
+	this->init_starting_time();
 	this->init_log_levels();
-#ifdef ENABLE_MPI
-	MPI_Comm_rank(MPI_COMM_WORLD, &_rank);
-#endif
 	*_log_stream << std::boolalpha;  // Print boolean as true/false
 }
 

--- a/src/utils/Logger.cpp
+++ b/src/utils/Logger.cpp
@@ -21,26 +21,4 @@ Logger::Logger(logLevel level, std::shared_ptr<std::ostream> os) :
 	*_log_stream << std::boolalpha;  // Print boolean as true/false
 }
 
-/// allow logging only for a single process
-void Logger::set_mpi_output_root(int root) {
-	if (_rank != root)
-		_do_output = false;
-	else
-		_do_output = true;
-}
-
-/// all processes shall perform logging
-void Logger::set_mpi_output_all() {
-	_do_output = true;
-}
-
-/// allow a set of processes for logging
-bool Logger::set_mpi_output_ranks(int num_nums, int* nums) {
-	int i;
-	for(i = 0; i < num_nums; i++)
-		if (nums[i] == _rank)
-			_do_output = true;
-	return _do_output;
-}
-
 } /* end namespace Log */

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -70,10 +70,6 @@ typedef enum {
  * For writing log messages use fatal(), error(), warning(), info() or debug() as
  * with normal streams, e.g.
  * > log.error() << "Wrong parameter." << std::endl;
- * For easy handling of output within MPI applications there are the following methods:
- * set_mpi_output_root(int root)
- * set_mpi_output_rall()
- * set_mpi_output_ranks(int num_ranks, int * ranks)
  * Please include std::endl statements at the end of output as they will flush
  * the stream buffers.
  * If ENABLE_MPI is enabled logger initialization has to take place after the
@@ -222,18 +218,6 @@ public:
 	void init_starting_time() {
 		_starttime = std::chrono::system_clock::now();
 	}
-
-	/* methods for easy handling of output processes */
-
-	/// allow logging only for a single process
-	void set_mpi_output_root(int root = 0);
-
-	/// all processes shall perform logging
-	void set_mpi_output_all();
-
-	/// allow a set of processes for logging
-	bool set_mpi_output_ranks(int num_nums, int* nums);
-
 
 
 }; /* end of class Logger */

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -34,7 +34,6 @@
 
 #endif  /* ENABLE_MPI */
 
-
 /* we use a separate namespace because we have some global definitions for
  * the log level */
 namespace Log {
@@ -72,8 +71,6 @@ typedef enum {
  * > log.error() << "Wrong parameter." << std::endl;
  * Please include std::endl statements at the end of output as they will flush
  * the stream buffers.
- * If ENABLE_MPI is enabled logger initialization has to take place after the
- * MPI_Init call.
  */
 class Logger {
 private:
@@ -84,7 +81,7 @@ private:
 	std::map<logLevel, std::string> logLevelNames;
 
 	std::chrono::system_clock::time_point _starttime;
-	int _rank;
+	std::string _msg_prefix;
 
 	/// initialize the list of log levels with the corresponding short names
 	void init_log_levels() {
@@ -151,8 +148,7 @@ public:
 			localtime_r(&now_time_t, &now_local);
 			*_log_stream << logLevelNames[level] << ":\t" << std::put_time(&now_local, "%Y-%m-%dT%H:%M:%S") << " ";
 			*_log_stream << std::setw(8) << std::chrono::duration<double>(time_since_start).count() << " ";
-
-			*_log_stream << "[" << _rank << "]\t";
+			*_log_stream << _msg_prefix;
 		}
 		return *this;
 	}
@@ -219,8 +215,17 @@ public:
 		_starttime = std::chrono::system_clock::now();
 	}
 
+	/// set message prefix
+	void set_msg_prefix(std::string msg_prefix) {
+		_msg_prefix = msg_prefix;
+	}
 
+	/// return message prefix
+	std::string get_msg_prefix() {
+		return _msg_prefix;
+	}
 }; /* end of class Logger */
+
 } /* end of namespace */
 
 #endif /*LOGGER_H_*/


### PR DESCRIPTION
# Description

This PR removes all dependencies to MPI inside the Logger class. The functionality was replaced by a general message prefix and setting the log levels for the different MPI processes.
Note: By default, MPI processes with rank zero will use log level `Info` and all other MPI processes  log level `Error`. This should help in identifying errors more quickly from logs. As a side effect, the `--verbose` option will now enable log level `All` for all MPI processes, which should be helpful for debugging.

## Related Pull Requests

- This is also in preparation of https://github.com/ls1mardyn/ls1-mardyn/pull/306

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] running examples
- [x] running unit tests

