### PR TITLE
Fix bug in GridFiller when using <density> option

### DIFF
--- a/src/io/ObjectGenerator.cpp
+++ b/src/io/ObjectGenerator.cpp
@@ -53,9 +53,7 @@ void ObjectGenerator::readXML(XMLfileUnits& xmlconfig) {
 		_object->readXML(xmlconfig);
 		xmlconfig.changecurrentnode("..");
 	} else {
-		std::ostringstream error_message;
-		error_message << "No object specified." << std::endl;
-		MARDYN_EXIT(error_message.str());
+		MARDYN_EXIT("No object specified.");
 	}
 
 	if(xmlconfig.changecurrentnode("velocityAssigner")) {

--- a/src/utils/generator/GridFiller.h
+++ b/src/utils/generator/GridFiller.h
@@ -27,9 +27,10 @@ public:
 
 	/** @brief Read in XML configuration for GridFiller and all its included objects.
 	 *
-	 * If a density is provided a cubic lattice will be used. If in this case also a lattice occupancy factor (0-1] is provided,
+	 * If a density is provided a face-centered cubic (or orthorhombic) lattice will be used. If in this case also a lattice occupancy factor (0-1] is provided,
 	 * a finer grid will be used and only the specified fraction of points will be used. The lattice vectors will be scaled to
 	 * achieve the desired density taking the occupancy factor into account. By default the occupancy factor is 1 (use all lattice points).
+	 * Note that the desired density is (probably) not met exactly due to the lattice structure (discrete number of molecules)
 	 *
 	 * The following xml object structure is handled by this method:
 	 * \code{.xml}
@@ -81,6 +82,8 @@ private:
 	/* Internal values/counters used during the creation by getMolecule */
 	long _baseCount;
 	double _lattice_point[3];
+
+	bool useDensity = false;
 };
 
 #endif  // GRIDFILLER_H_

--- a/src/utils/generator/Lattice.cpp
+++ b/src/utils/generator/Lattice.cpp
@@ -32,7 +32,7 @@ static const char* LatticeSystemNames[] = {
 	"cubic"
 };
 
-/** List with the number of cetneres in the different lattice centering types */
+/** List with the number of centers in the different lattice centering types */
 static int LatticeCenteringNums[6] = { 1, 2, 4, 2, 2, 2 };
 
 /** List of the names of the centerings */

--- a/src/utils/generator/Lattice.h
+++ b/src/utils/generator/Lattice.h
@@ -59,7 +59,7 @@ public:
 	   </lattice>
 	   \endcode
 	 * where system can be one of the values "triclinic", "monoclinic", "orthorombic", "tetragonal",
-	 * "rhomboedral", and "hexagonal", "cubic" and centering can be one of the values "primitive",
+	 * "rhomboedral", and "hexagonal", "cubic" (see Bravais lattices) and centering can be one of the values "primitive",
 	 * "body", "face", "base A", "base B", and "base C".
 	 */
 	void readXML(XMLfileUnits& xmlconfig);
@@ -118,6 +118,12 @@ public:
 	inline const double* b() { return _b; }
 	/** Get pointer to lattice vector c */
 	inline const double* c() { return _c; }
+	/** Set i-th element of lattice vector a */
+	void seta(short i, double a_i) { _a[i] = a_i; }
+	/** Set i-th element of lattice vector b */
+	void setb(short i, double b_i) { _b[i] = b_i; }
+	/** Set i-th element of lattice vector c */
+	void setc(short i, double c_i) { _c[i] = c_i; }
 
 
 private:

--- a/src/utils/generator/Objects.cpp
+++ b/src/utils/generator/Objects.cpp
@@ -19,8 +19,12 @@ void Cuboid::readXML(XMLfileUnits& xmlconfig) {
 	Coordinate3D upperCorner(xmlconfig, "upper");
 	lowerCorner.get(_lowerCorner);
 	upperCorner.get(_upperCorner);
-	Log::global_log->info() << "lower corner: " << _lowerCorner[0] << ", " << _lowerCorner[1] << ", " << _lowerCorner[2] << std::endl;
-	Log::global_log->info() << "upper corner: " << _upperCorner[0] << ", " << _upperCorner[1] << ", " << _upperCorner[2] << std::endl;
+	Log::global_log->info() << "Lower corner of object: " << _lowerCorner[0]
+							<< ", " << _lowerCorner[1]
+							<< ", " << _lowerCorner[2] << std::endl;
+	Log::global_log->info() << "Upper corner of object: " << _upperCorner[0]
+							<< ", " << _upperCorner[1]
+							<< ", " << _upperCorner[2] << std::endl;
 }
 
 bool Cuboid::isInside(double r[3]) {


### PR DESCRIPTION
# Description

Currently, the GridFiller might place particles in a way that leads to `explosions` at the beginning of the simulation. This is due to the close distance of some particles across the periodic boundary conditions when the entire simulation domain should be filled with a grid. See also issues below.
The problem is, in my opinion, that the size of the unit cell is [calculated with the desired density](https://github.com/ls1mardyn/ls1-mardyn/blob/65b3f7a6c4b5fb8482a4b0b7ff9b19d9b9ae3547/src/utils/generator/GridFiller.cpp#L142). However, the desired density is probably not met at the end due to the lattice and therefore the discrete number of inserted particles. Another issue could be that a cubic unit cell is used.
This PR solves this problem by scaling the unit cell so that the object box size is evenly divisible by the unit cell size. This leads to the same distance between all unit cells even across the PBC.

This PR also cleans up the readXML method of the GridFiller since (as already written in the doc) the `<lattice>` option is ignored/overwritten when the `<density>` option is set. Therefore, `<lattice>` is only read if `<density>` was not specified.
This is also the reason why `<lattice>` was deleted in the config xmls in files where `<density>` was set.

#### Further improvements
In the future, it would be nice to add a mechanism which ensures that the desired density is met, e.g. by deleting particles. Currently, there is no generator that just creates a simulation with a given density and temperature (like in _ms2_).
This is not part of the present PR.

## Resolved Issues

- [x] fixes #224 
- [x] fixes #372

## How Has This Been Tested?

There are explosions when running [this example](https://github.com/ls1mardyn/ls1-mardyn/blob/298197533fcb3c7966b7c7dbb7c9cd6f8fba3737/examples/DropletCoalescence/liq/config_1_generateLiq.xml), see also PR #371.
With the changes of the present PR, the explosions are gone. It was also tested what happens when both `<lattice>` and `<density>` are specified (--> `<lattice>` is ignored as expected).

