### PR TITLE
Fix velocity assignment in CubicGridGenerator (and others)

### DIFF
--- a/src/io/CubicGridGeneratorInternal.cpp
+++ b/src/io/CubicGridGeneratorInternal.cpp
@@ -17,7 +17,6 @@
 #include "parallel/DomainDecompBase.h"
 #include "particleContainer/ParticleContainer.h"
 #include "utils/Logger.h"
-#include "utils/Random.h"
 #include "utils/mardyn_assert.h"
 
 #include <cmath>
@@ -86,8 +85,7 @@ unsigned long CubicGridGeneratorInternal::readPhaseSpace(ParticleContainer *part
 		global_simulation->getEnsemble()->getComponents()->at(1).updateMassInertia();
 	}
 
-	unsigned long int id = particleContainer->initCubicGrid(
-		numMoleculesPerDim, simBoxLength, static_cast<size_t>(domainDecomp->getRank()) * mardyn_get_max_threads());
+	unsigned long int id = particleContainer->initCubicGrid(numMoleculesPerDim, simBoxLength);
 
 	Log::global_log->info() << "Finished reading molecules: 100%" << std::endl;
 

--- a/src/io/IOHelpers.h
+++ b/src/io/IOHelpers.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "molecules/Component.h"
-#include "utils/Random.h"
 
 class ParticleContainer;
 class DomainDecompBase;

--- a/src/io/IOHelpers.h
+++ b/src/io/IOHelpers.h
@@ -46,14 +46,4 @@ void initializeVelocityAccordingToTemperature(ParticleContainer* particleContain
 unsigned long makeParticleIdsUniqueAndGetTotalNumParticles(ParticleContainer* particleContainer,
 														   DomainDecompBase* domainDecomp);
 
-/**
- * Generates a velocity vector according to the given temperature.
- * The generated velocity vector lies on the surface of a sphere with radius sqrt(3. * temperature).
- * If this function is called multiple times, the generated velocity vectors will be equally distributed on the surface
- * of the sphere.
- * @param temperature
- * @param RNG
- * @return
- */
-std::array<double, 3> getRandomVelocityAccordingToTemperature(double temperature, Random& RNG);
 }  // namespace IOHelpers

--- a/src/io/PerCellGenerator.cpp
+++ b/src/io/PerCellGenerator.cpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <random>
+#include <array>
 
 #include "Domain.h"
 #include "IOHelpers.h"

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -675,7 +675,7 @@ std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> AutoPasContaine
 }
 
 unsigned long AutoPasContainer::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
-											  std::array<double, 3> simBoxLength, size_t seed_offset) {
+											  std::array<double, 3> simBoxLength) {
 
 	vcp_real_calc T = global_simulation->getEnsemble()->T();
 	EqualVelocityAssigner eqVeloAssigner(T);

--- a/src/particleContainer/AutoPasContainer.h
+++ b/src/particleContainer/AutoPasContainer.h
@@ -111,7 +111,7 @@ public:
 	getMoleculeAtPosition(const double pos[3]) override;
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
-								std::array<double, 3> simBoxLength, size_t seed_offset) override;
+								std::array<double, 3> simBoxLength) override;
 
 	double *getCellLength() override;
 

--- a/src/particleContainer/LinkedCells.cpp
+++ b/src/particleContainer/LinkedCells.cpp
@@ -13,7 +13,6 @@
 #include "particleContainer/adapter/ParticlePairs2PotForceAdapter.h"
 #include "particleContainer/handlerInterfaces/ParticlePairsHandler.h"
 #include "utils/Logger.h"
-#include "utils/Random.h"
 #include "utils/mardyn_assert.h"
 #include "utils/GetChunkSize.h"
 
@@ -939,7 +938,7 @@ void LinkedCells::getCellIndicesOfRegion(const double startRegion[3], const doub
 	endIndex = getCellIndexOfPoint(endRegion);
 }
 
-unsigned long LinkedCells::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength, size_t seed_offset) {
+unsigned long LinkedCells::initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength) {
 	const unsigned long numCells = _cells.size();
 
 	std::vector<unsigned long> numMoleculesPerThread;
@@ -953,15 +952,13 @@ unsigned long LinkedCells::initCubicGrid(std::array<unsigned long, 3> numMolecul
 		const int myID = mardyn_get_thread_num();
 		const unsigned long myStart = numCells * myID / numThreads;
 		const unsigned long myEnd = numCells * (myID + 1) / numThreads;
-		const int seed = seed_offset + myID;
 
 		unsigned long numMoleculesByThisThread = 0;
-		Random threadPrivateRNG{seed};
 
 		// manual "static" scheduling important, because later this thread needs to traverse the same cells
 		for (unsigned long cellIndex = myStart; cellIndex < myEnd; ++cellIndex) {
 			ParticleCell & cell = _cells[cellIndex];
-			numMoleculesByThisThread += cell.initCubicGrid(numMoleculesPerDimension, simBoxLength, threadPrivateRNG);
+			numMoleculesByThisThread += cell.initCubicGrid(numMoleculesPerDimension, simBoxLength);
 		}
 
 		// prefix sum of numMoleculesByThisThread

--- a/src/particleContainer/LinkedCells.h
+++ b/src/particleContainer/LinkedCells.h
@@ -260,7 +260,7 @@ public:
 	bool requiresForceExchange() const override; // new
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
-								std::array<double, 3> simBoxLength, size_t seed_offset) override;
+								std::array<double, 3> simBoxLength) override;
 
 	std::vector<unsigned long> getParticleCellStatistics() override;
 

--- a/src/particleContainer/ParticleCellBase.cpp
+++ b/src/particleContainer/ParticleCellBase.cpp
@@ -7,7 +7,6 @@
 
 #include "ParticleCellBase.h"
 #include "ensemble/EnsembleBase.h"
-#include "utils/Random.h"
 #include "Simulation.h"
 #include "utils/generator/EqualVelocityAssigner.h"
 
@@ -50,7 +49,7 @@ bool PositionIsInBox3D(const T l[3], const T u[3], const T r[3]) {
 }
 
 unsigned long ParticleCellBase::initCubicGrid(const std::array<unsigned long, 3> &numMoleculesPerDimension,
-											  const std::array<double, 3> &simBoxLength, Random &RNG) {
+											  const std::array<double, 3> &simBoxLength) {
 
 	std::array<double, 3> spacing{};
 	std::array<double, 3> origin1{}; // origin of the first DrawableMolecule
@@ -133,7 +132,6 @@ unsigned long ParticleCellBase::initCubicGrid(const std::array<unsigned long, 3>
 					// Init molecule with zero velocity and use the EqualVelocityAssigner in the next step
 					Molecule dummy(0, &(global_simulation->getEnsemble()->getComponents()->at(0)),
 						x2, y2, z2, 0.0, 0.0, 0.0);
-					
 					eqVeloAssigner.assignVelocity(&dummy);
 					buffer.push_back(dummy);
 				}

--- a/src/particleContainer/ParticleCellBase.cpp
+++ b/src/particleContainer/ParticleCellBase.cpp
@@ -9,6 +9,7 @@
 #include "ensemble/EnsembleBase.h"
 #include "utils/Random.h"
 #include "Simulation.h"
+#include "utils/generator/EqualVelocityAssigner.h"
 
 CellBorderAndFlagManager ParticleCellBase::_cellBorderAndFlagManager;
 
@@ -27,28 +28,6 @@ bool ParticleCellBase::deleteMoleculeByID(unsigned long molid) {
 		deleteMoleculeByIndex(index);
 	}
 	return found;
-}
-
-template <typename T>
-std::array<T, 3> getRandomVelocity(T temperature, Random& RNG) {
-	std::array<T,3> ret{};
-
-	// Velocity
-	for (int dim = 0; dim < 3; dim++) {
-		ret[dim] = RNG.uniformRandInRange(-0.5f, 0.5f);
-	}
-	T dotprod_v = 0;
-	for (unsigned int i = 0; i < ret.size(); i++) {
-		dotprod_v += ret[i] * ret[i];
-	}
-	// Velocity Correction
-	const T three = static_cast<T>(3.0);
-	T vCorr = sqrt(three * temperature / dotprod_v);
-	for (unsigned int i = 0; i < ret.size(); i++) {
-		ret[i] *= vCorr;
-	}
-
-	return ret;
 }
 
 template <typename T>
@@ -83,6 +62,7 @@ unsigned long ParticleCellBase::initCubicGrid(const std::array<unsigned long, 3>
 	}
 
 	vcp_real_calc T = global_simulation->getEnsemble()->T();
+	EqualVelocityAssigner eqVeloAssigner(T);
 
 	double boxMin[3] = {getBoxMin(0), getBoxMin(1), getBoxMin(2)};
 	double boxMax[3] = {getBoxMax(0), getBoxMax(1), getBoxMax(2)};
@@ -141,17 +121,20 @@ unsigned long ParticleCellBase::initCubicGrid(const std::array<unsigned long, 3>
 
 				if (x1In and y1In and z1In) {
 					++numInserted;
-					std::array<vcp_real_calc,3> v = getRandomVelocity<vcp_real_calc>(T, RNG);
+					// Init molecule with zero velocity and use the EqualVelocityAssigner in the next step
 					Molecule dummy(0, &(global_simulation->getEnsemble()->getComponents()->at(0)),
-						x1, y1, z1, v[0], -v[1], v[2]);
+						x1, y1, z1, 0.0, 0.0, 0.0);
+					eqVeloAssigner.assignVelocity(&dummy);
 					buffer.push_back(dummy);
 				}
 
 				if (x2In and y2In and z2In) {
 					++numInserted;
-					std::array<vcp_real_calc,3> v = getRandomVelocity<vcp_real_calc>(T, RNG);
+					// Init molecule with zero velocity and use the EqualVelocityAssigner in the next step
 					Molecule dummy(0, &(global_simulation->getEnsemble()->getComponents()->at(0)),
-						x2, y2, z2, v[0], -v[1], v[2]);
+						x2, y2, z2, 0.0, 0.0, 0.0);
+					
+					eqVeloAssigner.assignVelocity(&dummy);
 					buffer.push_back(dummy);
 				}
 			}

--- a/src/particleContainer/ParticleCellBase.h
+++ b/src/particleContainer/ParticleCellBase.h
@@ -16,8 +16,6 @@
 #include <quicksched.h>
 #endif
 
-class Random;
-
 /** @brief ParticleCellBase defines the interface for cells used by the LinkedCells data structure to store molecule data.
  */
 class ParticleCellBase: public Cell {
@@ -83,7 +81,7 @@ public:
 	virtual void prefetchForForce() const {/*TODO*/}
 
 	unsigned long initCubicGrid(const std::array<unsigned long, 3> &numMoleculesPerDimension,
-								const std::array<double, 3> &simBoxLength, Random &RNG);
+								const std::array<double, 3> &simBoxLength);
 
 //protected: Do not use! use SingleCellIterator instead!
 	// multipurpose:

--- a/src/particleContainer/ParticleContainer.h
+++ b/src/particleContainer/ParticleContainer.h
@@ -235,10 +235,9 @@ public:
      * Generates a body-centered cubic grid.
      * @param numMoleculesPerDimension
      * @param simBoxLength
-     * @param seed_offset
      * @return
      */
-	virtual unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength, size_t seed_offset) = 0;
+	virtual unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension, std::array<double, 3> simBoxLength) = 0;
 
 	virtual double* getCellLength() = 0;
 

--- a/src/utils/generator/ReplicaFiller.cpp
+++ b/src/utils/generator/ReplicaFiller.cpp
@@ -116,7 +116,7 @@ class ParticleContainerToBasisWrapper : public ParticleContainer {
 	std::variant<ParticleIterator, SingleCellIterator<ParticleCell>> getMoleculeAtPosition(const double pos[3]) override { return {}; }
 
 	unsigned long initCubicGrid(std::array<unsigned long, 3> numMoleculesPerDimension,
-								std::array<double, 3> simBoxLength, size_t seed_offset) override { return 0; }
+								std::array<double, 3> simBoxLength) override { return 0; }
 
 	size_t getTotalSize() override { return _basis.numMolecules() * sizeof(Molecule); }
 


### PR DESCRIPTION
# Description

As described in issue #376, the CubicGridGenerator uses the initCubicGrid method which uses the getRandomVelocity method.
The latter method can only handle particles with mass=1 correctly. This is fixed with the present PR by using the EqualVelocityAssigner to get the random initial velocities.

In addition, the CubicGridGenerator removes the overall drift, which is very beneficial. Unfortunately, this is not done properly as the velocities need to be scaled afterwards again to match the desired temperature. This was also fixed in the present PR.


## Resolved Issues

- [x] fixes #376 

## How Has This Been Tested?

- example DropletCoalescence/liq/config_1_generateLiq.xml was run and the initial temperatures where checked. Everthing looks good now and the initial temperatures are now the target temperatures. Without the rescaling, they would be too low and without considering the mass, the temperatures would be completely off (`explosion`)


### Further improvements (not part of the present PR)
In the future, it would be nice
- to add a mechanism which ensures that the desired density is met, e.g. by deleting particles. Currently, there is no generator that just creates a simulation with a given density and temperature (like in _ms2_).
- to add the possibility to select the velocity assigner to be used, see comment below.
- to clean up the class, e.g. get rid of "Internal" in names and move `initCubicGrid` from the particle container to the generator/helper class.
