### PR TITLE
Fix Logger output by using case-insensitive comparison

### DIFF
--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -194,10 +194,10 @@ public:
 		std::string l_upper = l;
 		std::transform(l_upper.begin(), l_upper.end(), l_upper.begin(), [](unsigned char c){ return std::toupper(c);});
 		for (const auto& [lvl, name] : logLevelNames) {
-			if (name == l_upper) { 
-				_log_level = lvl; 
-				return _log_level; 
-			} 
+			if (name == l_upper) {
+				_log_level = lvl;
+				return _log_level;
+			}
 		}
 		error_always_output() << "Logger::set_log_level() unknown argument '" << l
 							  << "'. Falling back to output everything!" << std::endl;

--- a/src/utils/Logger.h
+++ b/src/utils/Logger.h
@@ -3,6 +3,7 @@
 
 #define USE_GETTIMEOFDAY
 
+#include <algorithm>
 #include <chrono>
 #include <ctime>
 #include <cctype>
@@ -189,11 +190,14 @@ public:
 	}
 	/// set log level from string
 	logLevel set_log_level(std::string l) {
+		// Compare case-insensitive
+		std::string l_upper = l;
+		std::transform(l_upper.begin(), l_upper.end(), l_upper.begin(), [](unsigned char c){ return std::toupper(c);});
 		for (const auto& [lvl, name] : logLevelNames) {
-			if (name == l) {
-				_log_level = lvl;
-				return _log_level;
-			}
+			if (name == l_upper) { 
+				_log_level = lvl; 
+				return _log_level; 
+			} 
 		}
 		error_always_output() << "Logger::set_log_level() unknown argument '" << l
 							  << "'. Falling back to output everything!" << std::endl;


### PR DESCRIPTION
# Description

This PR fixes issue #374 by making the comparison in the Logger case-insensitive.

See also [this comment](https://github.com/ls1mardyn/ls1-mardyn/pull/373#issuecomment-2624912190).