### PR TITLE
added missing openmp directive

### DIFF
--- a/src/longRange/Homogeneous.cpp
+++ b/src/longRange/Homogeneous.cpp
@@ -146,7 +146,9 @@ void Homogeneous::calculateLongRange() {
 		VirialCorr/(3.*globalNumMolecules),
 	};
 	// double uPotCorrPerMol = UpotCorr/globalNumMolecules;
-
+	#if defined(_OPENMP)
+	#pragma omp parallel
+	#endif
 	for (auto tempMol = _particleContainer->iterator(ParticleIterator::ONLY_INNER_AND_BOUNDARY); tempMol.isValid(); ++tempMol) {
 		tempMol->Viadd(virialCorrPerMol);
 		// tempMol->Uadd(uPotCorrPerMol);  // Not implemented in Molecule class yet


### PR DESCRIPTION
# Description
In `Homogeneous.cpp`, the `calculateLongRange()` function iterates over all molecules in local subdomain, but this wasn't OpenMP parallelised, causing a slowdown in full-openMP runs. In this PR I've added the missing directive.

## How Has This Been Tested?

Running on Hunter with perftools (CPU only) with a homogeneous liquid (30000 timesteps), with 1 MPI rank and 64 OpenMP ranks, and checking the output with `pat-report -O callers`, we have

Before implementing fix (only header from perftools output shown) : (runtime 576 seconds)
```
Table 1:  Profile by Function and Callers

  Samp% |     Samp | Group
        |          |  Function
        |          |   Caller
        |          |    Thread=HIDE
       
 100.0% | 57,386.0 | Total
|-----------------------------------------------------------------------------
|  92.6% | 53,144.0 | USER
||----------------------------------------------------------------------------
||  26.9% | 15,412.0 | FullMolecule::Viadd
3|  26.6% | 15,271.0 |  Homogeneous::calculateLongRange
4|        |          |   Simulation::simulateOneTimestep
5|        |          |    Simulation::simulate
6|        |          |     main
7|        |          |      __libc_start_call_main
||  17.3% |  9,946.0 | VectorizedCellProcessor::_calculatePairs<>
|||---------------------------------------------------------------------------
3||  15.6% |  8,955.0 | VectorizedCellProcessor::processCellPair
4||        |          |  C08CellPairTraversal<>::traverseCellPairsBackend.LOOP@li.218
5||        |          |   C08CellPairTraversal<>::traverseCellPairsBackend
6||        |          |    C08CellPairTraversal<>::traverseCellPairs.BARRIER@li.70(ovhd)
7||        |          |     C08CellPairTraversal<>::traverseCellPairs.REGION@li.57
8||        |          |      C08CellPairTraversal<>::traverseCellPairs.REGION@li.57(ovhd)
9||        |          |       C08CellPairTraversal<>::traverseCellPairs
10|        |          |        LinkedCells::traverseCells
11|  15.6% |  8,954.0 |         Simulation::simulateOneTimestep
12|        |          |          Simulation::simulate
13|        |          |           main
14|        |          |            __libc_start_call_main
3||   1.7% |    991.0 | VectorizedCellProcessor::processCell
4||        |          |  C08CellPairTraversal<>::traverseCellPairsBackend.LOOP@li.218
5||        |          |   C08CellPairTraversal<>::traverseCellPairsBackend
6||        |          |    C08CellPairTraversal<>::traverseCellPairs.BARRIER@li.70(ovhd)
7||        |          |     C08CellPairTraversal<>::traverseCellPairs.REGION@li.57
8||        |          |      C08CellPairTraversal<>::traverseCellPairs.REGION@li.57(ovhd)
9||        |          |       C08CellPairTraversal<>::traverseCellPairs
10|        |          |        LinkedCells::traverseCells
11|        |          |         Simulation::simulateOneTimestep
12|        |          |          Simulation::simulate
13|        |          |           main
14|        |          |            __libc_start_call_main
|||===========================================================================
||  13.7% |  7,878.0 | Homogeneous::calculateLongRange
3|        |          |  Simulation::simulateOneTimestep
4|        |          |   Simulation::simulate
5|        |          |    main

```

After fix (runtime 346.09 s):
```
 100.0% | 34,369.0 | Total
|-----------------------------------------------------------------------------
|  88.8% | 30,522.0 | USER
||----------------------------------------------------------------------------
||  29.8% | 10,241.0 | VectorizedCellProcessor::_calculatePairs<>
|||---------------------------------------------------------------------------
3||  26.8% |  9,206.0 | VectorizedCellProcessor::processCellPair
4||        |          |  C08CellPairTraversal<>::traverseCellPairsBackend.LOOP@li.218
5||        |          |   C08CellPairTraversal<>::traverseCellPairsBackend
6||        |          |    C08CellPairTraversal<>::traverseCellPairs.BARRIER@li.70(ovhd)
7||        |          |     C08CellPairTraversal<>::traverseCellPairs.REGION@li.57
8||        |          |      C08CellPairTraversal<>::traverseCellPairs.REGION@li.57(ovhd)
9||        |          |       C08CellPairTraversal<>::traverseCellPairs
10|        |          |        LinkedCells::traverseCells
11|        |          |         Simulation::simulateOneTimestep
12|        |          |          Simulation::simulate
13|        |          |           main
14|        |          |            __libc_start_call_main
3||   3.0% |  1,035.0 | VectorizedCellProcessor::processCell
4||        |          |  C08CellPairTraversal<>::traverseCellPairsBackend.LOOP@li.218
5||        |          |   C08CellPairTraversal<>::traverseCellPairsBackend
6||        |          |    C08CellPairTraversal<>::traverseCellPairs.BARRIER@li.70(ovhd)
7||        |          |     C08CellPairTraversal<>::traverseCellPairs.REGION@li.57
8||        |          |      C08CellPairTraversal<>::traverseCellPairs.REGION@li.57(ovhd)
9||        |          |       C08CellPairTraversal<>::traverseCellPairs
10|        |          |        LinkedCells::traverseCells
11|        |          |         Simulation::simulateOneTimestep
12|        |          |          Simulation::simulate
13|        |          |           main
14|        |          |            __libc_start_call_main

```

(Which is as expected)

Approx 40% speedup in this scenario, so very significant.
