### PR TITLE
Check if RAPL energy counter files can be read.

### DIFF
--- a/src/plugins/EnergyRAPL.cpp
+++ b/src/plugins/EnergyRAPL.cpp
@@ -21,6 +21,10 @@ EnergyRAPL::RAPLCounter::RAPLCounter(const std::string& domainBasePath) {
 	std::ostringstream rangeMicroJoulePath;
 	rangeMicroJoulePath << domainBasePath << "/max_energy_range_uj";
 	std::ifstream rangeMicroJouleFile(rangeMicroJoulePath.str());
+	if(!rangeMicroJouleFile) {
+		Log::global_log->error() << "Failed to open RAPL counter file " << rangeMicroJoulePath.str() << std::endl;
+		exit(1);
+	}
 	rangeMicroJouleFile >> _rangeMicroJoule;
 	reset();
 }
@@ -35,6 +39,10 @@ void EnergyRAPL::RAPLCounter::reset() {
 double EnergyRAPL::RAPLCounter::update() {
 	long long currentMicroJoule;
 	std::ifstream microJouleFile(_microJoulePath);
+	if(!microJouleFile) {
+		Log::global_log->error() << "Failed to open RAPL counter file " << _microJoulePath << std::endl;
+		exit(1);
+	}
 	microJouleFile >> currentMicroJoule;
 	long long deltaMicroJoule = currentMicroJoule - _lastMicroJoule;
 	// Correct counter overflow (occurs around every 60 seconds)


### PR DESCRIPTION
In many Linux environments the RAPL energy counters can only be read by root. Therefore, check if we can access them and exit in case of problems.

Fixes https://github.com/ls1mardyn/ls1-mardyn/issues/381

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Running described scenario with Argon Input example as regular user and via sudo/root

