### PR TITLE
Update AutoPas to Version 3.0

### DIFF
--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -24,7 +24,7 @@ if (ENABLE_AUTOPAS)
     set(AUTOPAS_VECTOR_INSTRUCTIONS ${VECTOR_INSTRUCTIONS} CACHE STRING "Set via VECTOR_INSTRUCTIONS_OPTIONS" FORCE)
 
     # Last version without 3 Body support. Newer versions have API changes
-    set(AUTOPAS_TAG v2.0.0 CACHE STRING "AutoPas Git tag or commit id to use")
+    set(AUTOPAS_TAG 0338ff17d55cc770a403efee69740a69753d64ad CACHE STRING "AutoPas Git tag or commit id to use")
 
     FetchContent_Declare(
             autopasfetch

--- a/cmake/modules/autopas.cmake
+++ b/cmake/modules/autopas.cmake
@@ -23,7 +23,7 @@ if (ENABLE_AUTOPAS)
     set(AUTOPAS_USE_VECTORIZATION ${USE_VECTORIZATION} CACHE BOOL "Set via USE_VECTORIZATION" FORCE)
     set(AUTOPAS_VECTOR_INSTRUCTIONS ${VECTOR_INSTRUCTIONS} CACHE STRING "Set via VECTOR_INSTRUCTIONS_OPTIONS" FORCE)
 
-    # Last version without 3 Body support. Newer versions have API changes
+    # Version from March 19th, 2025. Includes PMT energy measurements, dynamic rebuilding and 3-body interactions.
     set(AUTOPAS_TAG 0338ff17d55cc770a403efee69740a69753d64ad CACHE STRING "AutoPas Git tag or commit id to use")
 
     FetchContent_Declare(

--- a/examples/Adsorption/Generator/adsorption_autopas_tuning.xml
+++ b/examples/Adsorption/Generator/adsorption_autopas_tuning.xml
@@ -84,7 +84,7 @@
     <algorithm>
       <parallelisation type="DomainDecomposition"/>
       <datastructure type="AutoPas">
-        <allowedTraversals>c01, c04, c08, c18, sli</allowedTraversals>
+        <allowedTraversals>lc_c01, lc_c04, lc_c04_HCP, lc_c08, lc_c18, lc_sliced</allowedTraversals>
         <allowedContainers>linkedCells</allowedContainers>
         <selectorStrategy>fastestMedian</selectorStrategy>
         <dataLayouts>SoA</dataLayouts>

--- a/examples/Argon/200K_18mol_l/config_autopas_allOptions.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_allOptions.xml
@@ -45,8 +45,8 @@
       -->
       <datastructure type="AutoPas">
         <loglevel>off</loglevel><!--Level for the AutoPas logger-->
-        <allowedTraversals>ds_sequential, lc_sliced, lc_sliced_balanced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c01_cuda, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vcc_cluster_iteration_cuda, vcl_cluster_iteration, vcl_c06, vcl_c01_balanced, vl_list_iteration, vlc_c01, vlc_c18, vlc_sliced, vlc_sliced_balanced, vlc_sliced_c02, vvl_as_built</allowedTraversals>
-        <allowedContainers>DirectSum,LinkedCells, VerletLists, VerletListsCells, VerletClusterLists,VarVerletListsAsBuild,VerletClusterCells</allowedContainers>
+        <allowedTraversals>ds_sequential, lc_sliced, lc_sliced_balanced, lc_sliced_c02, lc_c01, lc_c01_combined_SoA, lc_c04, lc_c04_HCP, lc_c04_combined_SoA, lc_c08, lc_c18, vcl_cluster_iteration, vcl_c06, vcl_c01_balanced, vcl_sliced, vcl_sliced_c02, vcl_sliced_balanced, vl_list_iteration, vlc_c01, vlc_c18, vlc_c08, vlc_sliced, vlc_sliced_balanced, vlc_sliced_c02, vvl_as_built, vlp_sliced, vlp_sliced_c02, vlp_c18, vlp_c01, vlp_sliced_balanced, vlp_c08, ot_c18, ot_c01</allowedTraversals>
+        <allowedContainers>DirectSum, LinkedCells, LinkedCellsReferences, VerletLists, VerletListsCells, VerletClusterLists, VarVerletListsAsBuild, PairwiseVerletLists, Octree</allowedContainers>
         <selectorStrategy>fastestMean</selectorStrategy><!--fastestMedian,fastestAbs-->
         <tuningStrategies>predictive,rulebased</tuningStrategies><!--Predictive, RuleBased, BayesianSearch, ...; Leave empty for full search-->
         <dataLayouts>AoS, SoA</dataLayouts>
@@ -54,8 +54,8 @@
         <tuningAcquisitionFunction>lower-confidence-bound</tuningAcquisitionFunction> <!--only relevant for BayesianSearch-->
         <maxEvidence>20</maxEvidence>
         <tuningInterval>1000</tuningInterval>
-        <tuningSamples>10</tuningSamples>
-        <ruleFile>AutoPas/examples/md-flexible/input/tuningRules.rule</ruleFile><!--check the AutoPas repo for examples-->
+        <tuningSamples>3</tuningSamples>
+        <ruleFile>tuningRules.rule</ruleFile><!--check the AutoPas repo for examples-->
         <rebuildFrequency>10</rebuildFrequency>
         <skin>0.5</skin>
       </datastructure>

--- a/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_lc_ALL.xml
@@ -40,7 +40,8 @@
             <datastructure type="AutoPas">
                 <!-- <logLevel>info</logLevel> -->
                 <allowedContainers>linkedCells</allowedContainers>
-                <tuningStrategies>predictive,ruleBased</tuningStrategies>
+                <tuningStrategies>predictive, ruleBased</tuningStrategies>
+                <ruleFile>tuningRules.rule</ruleFile><!--check the AutoPas repo for examples-->
                 <tuningInterval>10000</tuningInterval>
                 <tuningSamples>10</tuningSamples>
                 <rebuildFrequency>10</rebuildFrequency>
@@ -57,7 +58,7 @@
             <outputplugin name="DecompWriter">
                 <writefrequency>5</writefrequency>
                 <outputprefix>decomp</outputprefix>
-                <incremental>1</incremental>
+                <incremental>true</incremental>
                 <appendTimestamp>false</appendTimestamp>
             </outputplugin>
             <!--<outputplugin name="MmpldWriter" type="simple">

--- a/examples/Argon/200K_18mol_l/config_autopas_soa.xml
+++ b/examples/Argon/200K_18mol_l/config_autopas_soa.xml
@@ -71,7 +71,7 @@
       </outputplugin>
       <outputplugin name="VTKMoleculeWriter">
         <outputprefix>vtkOutput</outputprefix>
-        <writefrequency>1</writefrequency>
+        <writefrequency>100</writefrequency>
       </outputplugin>
     </output>
 	<plugin name="TestPlugin">

--- a/examples/Argon/200K_18mol_l/config_noAP_ALL.xml
+++ b/examples/Argon/200K_18mol_l/config_noAP_ALL.xml
@@ -51,7 +51,7 @@
 			<outputplugin name="DecompWriter">
 				<writefrequency>5</writefrequency>
 				<outputprefix>decomp</outputprefix>
-				<incremental>1</incremental>
+				<incremental>true</incremental>
 				<appendTimestamp>false</appendTimestamp>
 			</outputplugin>
 		</output>

--- a/examples/Argon/200K_18mol_l/config_temp_control.xml
+++ b/examples/Argon/200K_18mol_l/config_temp_control.xml
@@ -93,7 +93,7 @@
       </outputplugin>
       <outputplugin name="VTKMoleculeWriter">
         <outputprefix>vtkOutput</outputprefix>
-        <writefrequency>1</writefrequency>
+        <writefrequency>100</writefrequency>
       </outputplugin>
       <outputplugin name="LoadbalanceWriter">
         <writefrequency>10</writefrequency>
@@ -101,7 +101,7 @@
         <outputfilename>lb.dat</outputfilename>
         <timers> <!-- additional timers -->
           <timer> <name>LoadbalanceWriter_default</name> <warninglevel>2</warninglevel> </timer>
-          <timer> <name>SIMULATION_FORCE_CALCULATION</name> <warninglevel>2</warninglevel> <incremental>1</incremental> </timer>
+          <timer> <name>SIMULATION_FORCE_CALCULATION</name> <warninglevel>2</warninglevel> <incremental>true</incremental> </timer>
         </timers>
       </outputplugin>
     </output>

--- a/examples/Argon/200K_18mol_l/tuningRules.rule
+++ b/examples/Argon/200K_18mol_l/tuningRules.rule
@@ -1,0 +1,63 @@
+define_list AllContainers = "DirectSum", "LinkedCells", "LinkedCellsReferences", "VarVerletListsAsBuild", "VerletClusterLists", "VerletLists", "VerletListsCells", "PairwiseVerletLists", "Octree";
+define_list LinkedCellsContainer = "LinkedCells", "LinkedCellsReferences";
+define_list VerletListsContainer = "VerletLists", "VerletClusterLists", "VerletListsCells", "PairwiseVerletLists", "VarVerletListsAsBuild";
+
+# #############################################################################################
+# Make sure overhead of empty cells in the LinkedCells container does not destroy performance
+# Idea: For each empty cell,the LinkedCells implementation has overhead. All containers except VerletClusterLists (and DirectSum) use 
+# this container in their implementation. Thus, if the domain has a lot more empty cells than particles, do not use them, use VerletClusterLists.
+
+# The overhead consists of at least accessing the std::vector 
+define maxFactorOfEmptyCellsOverNumParticles = 100.0;
+define isDomainExtremelyEmpty = numEmptyCells / numParticles > maxFactorOfEmptyCellsOverNumParticles;
+
+if isDomainExtremelyEmpty:
+	define_list AllExceptClusterLists = "LinkedCells", "LinkedCellsReferences", "VarVerletListsAsBuild", "VerletLists", "VerletListsCells", "PairwiseVerletLists", "Octree";
+	[container="VerletClusterLists"] >= [container=AllExceptClusterLists];
+endif
+
+# #############################################################################################
+# Calculate whether skin size makes VerletLists useless in normal scenarios
+# Idea: From a theoretical perspective, Verlet Lists only have the advantage to save some of the neighbor distance calculations compared to LinkedCells.
+#       If the skin is too large, we know for sure that no neighbor distance calculations are saved.
+define PI = 3.1415926;
+define LC_NeighborVolume = cutoff * cutoff * cutoff * 27;
+define interactionLength = cutoff + skin;
+define VL_NeighborVolume = 4.0/3 * PI * interactionLength * interactionLength * interactionLength;
+
+define neighborVolumeRel = VL_NeighborVolume / LC_NeighborVolume;
+
+# Define magic number when it is surely not worth it to use VL over LC in terms of the number of neighbor distance calculations
+define maxReasonableNeighborVolumeRel = 0.9;
+
+# This holds only if the domain is not extremely empty. Does it also hold with not being extremely empty, but numParticlesPerCell << 1?
+if neighborVolumeRel > maxReasonableNeighborVolumeRel and not isDomainExtremelyEmpty:
+	[container="LinkedCells", traversal="lc_c08"] >= [container=VerletListsContainer] with same dataLayout, newton3;
+endif
+
+# #############################################################################################
+# Next Comment
+
+
+# if numParticles > LCVLThreshold and avgParticlesPerCell > LCVLThresholdPerCell:
+# 	[container="LinkedCells", dataLayout="SoA", newton3="enabled", traversal="lc_c08"] >= [container=VerletListsContainer];
+# endif
+
+if numParticles > 1000: [container="LinkedCells"] >= [container="DirectSum"]; endif
+
+if numParticles < 100: [container="DirectSum"] >= [container="LinkedCells"]; endif
+
+# if numCells < numParticles and numParticles > 50000:
+# 	[container="LinkedCells", dataLayout="SoA", newton3="enabled"] >= [container="LinkedCells", dataLayout="AoS", newton3="enabled"] with same traversal;
+# 	[container="LinkedCells", newton3="enabled"] >= [container="LinkedCells", newton3="disabled"] with same traversal;
+# endif
+
+if avgParticlesPerCell < 6:
+    [container="VerletListsCells", dataLayout="AoS"] >= [container="VerletListsCells", dataLayout="SoA"] with same newton3, traversal, loadEstimator;
+endif
+
+[container="VarVerletListsAsBuild", dataLayout="AoS"] >= [container="VarVerletListsAsBuild", dataLayout="SoA"] with same newton3, traversal;
+
+if avgParticlesPerCell < 100:
+    [container="VerletListsCells"] >= [container="PairwiseVerletLists"];
+endif

--- a/examples/ExplodingLiquid/config.xml
+++ b/examples/ExplodingLiquid/config.xml
@@ -65,7 +65,7 @@
             -->
             <datastructure type="AutoPas">
                 <!-- <tuningStragegy>fullsearch</tuningStragegy> -->
-                <tuningStragegy>predictive-tuning</tuningStragegy>
+                <tuningStragegy>predictive</tuningStragegy>
                 <extrapolationMethod>linear-regression</extrapolationMethod>
                 <blacklistRange>3</blacklistRange>
 

--- a/examples/SpinodalDecomposition/config_2_spinDec.xml
+++ b/examples/SpinodalDecomposition/config_2_spinDec.xml
@@ -48,7 +48,7 @@
             <parallelisation type="DomainDecomposition"></parallelisation>
 
             <datastructure type="AutoPas">
-                <allowedTraversals>c08, sli</allowedTraversals>
+                <allowedTraversals>lc_c08, lc_sliced</allowedTraversals>
                 <allowedContainers>linkedCells</allowedContainers>
                 <traversalSelectorStrategy>fastestMedian</traversalSelectorStrategy>
                 <containerSelectorStrategy>fastestMedian</containerSelectorStrategy>

--- a/examples/all-options.xml
+++ b/examples/all-options.xml
@@ -259,11 +259,11 @@
       </datastructure>
 
       <datastructure type="AutoPas">
-        <!-- for a list of possible options see the setter functions in https://www5.in.tum.de/AutoPas/doxygen_doc/master/classautopas_1_1AutoPas.html -->
-        <!-- for possible values see the respective options in https://www5.in.tum.de/AutoPas/doxygen_doc/master/namespaceautopas_1_1options.html-->
+        <!-- for a list of possible options see the setter functions in https://autopas.github.io/doxygen_documentation/git-master/classautopas_1_1AutoPas.html -->
+        <!-- for possible values see the respective options in https://autopas.github.io/doxygen_documentation/git-master/namespaceautopas_1_1options.html -->
 
         <!-- specify all allowed traversals as a comma separated list -->
-        <allowedTraversals>c08, sli</allowedTraversals>
+        <allowedTraversals>lc_c08, lc_sliced</allowedTraversals>
         <!-- specify all allowed containers as a comma separated list -->
         <!-- possible values include:
            - DirectSum
@@ -272,11 +272,11 @@
            - VerletListsCells
            - VerletClusterLists
            - VarVerletListsAsBuild
-           - VerletClusterCells
+           - Octree
         -->
         <allowedContainers>linkedCells, verletlists, verletclusterlists</allowedContainers>
         <!-- specify what metric the selector should use to determine the optimal traversal -->
-        <!-- possible values: fastetAbsolute, fastestMean, fastestMedian -->
+        <!-- possible values: fastestAbsolute, fastestMean, fastestMedian -->
         <selectorStrategy>fastestAbsolute</selectorStrategy>
         <!-- set the tuning auto tuning pipeline -->
         <!-- Leave this empty for an exhaustive full search or add any number of strategies that are applied in the stated order -->

--- a/src/io/CavityWriter.cpp
+++ b/src/io/CavityWriter.cpp
@@ -22,16 +22,10 @@ void CavityWriter::readXML(XMLfileUnits &xmlconfig) {
     xmlconfig.getNodeValue("outputprefix", _outputPrefix);
     Log::global_log->info() << "[CavityWriter] Output prefix: " << _outputPrefix << std::endl;
 
-    int incremental = 1;
-    xmlconfig.getNodeValue("incremental", incremental);
-    _incremental = (incremental != 0);
+    xmlconfig.getNodeValue("incremental", _incremental);
     Log::global_log->info() << "[CavityWriter] Incremental numbers: " << _incremental << std::endl;
 
-    int appendTimestamp = 0;
-    xmlconfig.getNodeValue("appendTimestamp", appendTimestamp);
-    if (appendTimestamp > 0) {
-        _appendTimestamp = true;
-    }
+    xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
     Log::global_log->info() << "[CavityWriter] Append timestamp: " << _appendTimestamp << std::endl;
 
 

--- a/src/io/CheckpointWriter.cpp
+++ b/src/io/CheckpointWriter.cpp
@@ -42,18 +42,10 @@ void CheckpointWriter::readXML(XMLfileUnits& xmlconfig) {
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
 	Log::global_log->info() << "Output prefix: " << _outputPrefix << std::endl;
 
-	int incremental = 1;
-	xmlconfig.getNodeValue("incremental", incremental);
-	_incremental = (incremental != 0);
+	xmlconfig.getNodeValue("incremental", _incremental);
 	Log::global_log->info() << "Incremental numbers: " << _incremental << std::endl;
 
-	int appendTimestamp = 0;
-	xmlconfig.getNodeValue("appendTimestamp", appendTimestamp);
-	if(appendTimestamp > 0) {
-		_appendTimestamp = true;
-	}else{
-		_appendTimestamp = false;
-	}
+	xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
 	Log::global_log->info() << "Append timestamp: " << _appendTimestamp << std::endl;
 }
 

--- a/src/io/CheckpointWriter.h
+++ b/src/io/CheckpointWriter.h
@@ -21,7 +21,7 @@ public:
 	     <type>ASCII|binary</type>
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
-	     <incremental>INTEGER</incremental>
+	     <incremental>BOOL</incremental>
 	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode

--- a/src/io/CommunicationPartnerWriter.cpp
+++ b/src/io/CommunicationPartnerWriter.cpp
@@ -29,18 +29,10 @@ void CommunicationPartnerWriter::readXML(XMLfileUnits& xmlconfig) {
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
 	Log::global_log->info() << "Output prefix: " << _outputPrefix << std::endl;
 
-	int incremental = 1;
-	xmlconfig.getNodeValue("incremental", incremental);
-	_incremental = (incremental != 0);
+	xmlconfig.getNodeValue("incremental", _incremental);
 	Log::global_log->info() << "Incremental numbers: " << _incremental << std::endl;
 
-	int appendTimestamp = 0;
-	xmlconfig.getNodeValue("appendTimestamp", appendTimestamp);
-	if(appendTimestamp > 0) {
-		_appendTimestamp = true;
-	}else{
-		_appendTimestamp = false;
-	}
+	xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
 	Log::global_log->info() << "Append timestamp: " << _appendTimestamp << std::endl;
 }
 

--- a/src/io/CommunicationPartnerWriter.h
+++ b/src/io/CommunicationPartnerWriter.h
@@ -22,7 +22,7 @@ public:
 	   <outputplugin name="CommunicationPartnerWriter">
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
-	     <incremental>INTEGER</incremental>
+	     <incremental>BOOL</incremental>
 	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode

--- a/src/io/DecompWriter.cpp
+++ b/src/io/DecompWriter.cpp
@@ -23,16 +23,10 @@ void DecompWriter::readXML(XMLfileUnits& xmlconfig) {
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
 	Log::global_log->info() << "Output prefix: " << _outputPrefix << std::endl;
 
-	int incremental = 1;
-	xmlconfig.getNodeValue("incremental", incremental);
-	_incremental = (incremental != 0);
+	xmlconfig.getNodeValue("incremental", _incremental);
 	Log::global_log->info() << "Incremental numbers: " << _incremental << std::endl;
 
-	int appendTimestamp = 0;
-	xmlconfig.getNodeValue("appendTimestamp", appendTimestamp);
-	if(appendTimestamp > 0) {
-		_appendTimestamp = true;
-	}
+	xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
 	Log::global_log->info() << "Append timestamp: " << _appendTimestamp << std::endl;
 }
 

--- a/src/io/DecompWriter.h
+++ b/src/io/DecompWriter.h
@@ -24,7 +24,7 @@ public:
 	   <outputplugin name="DecompWriter">
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
-	     <incremental>INTEGER</incremental>
+	     <incremental>BOOL</incremental>
 	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode

--- a/src/io/HaloParticleWriter.h
+++ b/src/io/HaloParticleWriter.h
@@ -24,7 +24,7 @@ public:
 	   <outputplugin name="HaloParticleWriter">
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
-	     <incremental>INTEGER</incremental>
+	     <incremental>BOOL</incremental>
 	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode

--- a/src/io/KDTreePrinter.cpp
+++ b/src/io/KDTreePrinter.cpp
@@ -26,18 +26,10 @@ void KDTreePrinter::readXML(XMLfileUnits &xmlconfig) {
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
 	Log::global_log->info() << "Output prefix: " << _outputPrefix << std::endl;
 
-	int incremental = 1;
-	xmlconfig.getNodeValue("incremental", incremental);
-	_incremental = (incremental != 0);
+	xmlconfig.getNodeValue("incremental", _incremental);
 	Log::global_log->info() << "Incremental numbers: " << _incremental << std::endl;
 
-	int appendTimestamp = 0;
-	xmlconfig.getNodeValue("appendTimestamp", appendTimestamp);
-	if (appendTimestamp > 0) {
-		_appendTimestamp = true;
-	} else {
-		_appendTimestamp = false;
-	}
+	xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
 	Log::global_log->info() << "Append timestamp: " << _appendTimestamp << std::endl;
 }
 

--- a/src/io/KDTreePrinter.h
+++ b/src/io/KDTreePrinter.h
@@ -12,7 +12,7 @@ public:
 	   <outputplugin name="KDTreePrinter">
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
-	     <incremental>INTEGER</incremental>
+	     <incremental>BOOL</incremental>
 	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode

--- a/src/io/MmspdBinWriter.cpp
+++ b/src/io/MmspdBinWriter.cpp
@@ -39,11 +39,7 @@ void MmspdBinWriter::readXML(XMLfileUnits& xmlconfig) {
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
 	Log::global_log->info() << "Output prefix: " << _outputPrefix << std::endl;
 
-	int appendTimestamp = 0;
-	xmlconfig.getNodeValue("appendTimestamp", appendTimestamp);
-	if(appendTimestamp > 0) {
-		_appendTimestamp = true;
-	}
+	xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
 	Log::global_log->info() << "Append timestamp: " << _appendTimestamp << std::endl;
 }
 

--- a/src/io/MmspdWriter.cpp
+++ b/src/io/MmspdWriter.cpp
@@ -40,11 +40,7 @@ void MmspdWriter::readXML(XMLfileUnits& xmlconfig) {
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
 	Log::global_log->info() << "Output prefix: " << _outputPrefix << std::endl;
 
-	int appendTimestamp = 0;
-	xmlconfig.getNodeValue("appendTimestamp", appendTimestamp);
-	if(appendTimestamp > 0) {
-		_appendTimestamp = true;
-	}
+	xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
 	Log::global_log->info() << "Append timestamp: " << _appendTimestamp << std::endl;
 }
 

--- a/src/io/PovWriter.cpp
+++ b/src/io/PovWriter.cpp
@@ -38,18 +38,10 @@ void PovWriter::readXML(XMLfileUnits& xmlconfig) {
 	xmlconfig.getNodeValue("outputprefix", _outputPrefix);
 	Log::global_log->info() << "Output prefix: " << _outputPrefix << std::endl;
 
-	int incremental = 1;
-	xmlconfig.getNodeValue("incremental", incremental);
-	_incremental = (incremental != 0);
+	xmlconfig.getNodeValue("incremental", _incremental);
 	Log::global_log->info() << "Incremental numbers: " << _incremental << std::endl;
 
-	int appendTimestamp = 0;
-	xmlconfig.getNodeValue("appendTimestamp", appendTimestamp);
-	if(appendTimestamp > 0) {
-		_appendTimestamp = true;
-	} else{
-		_appendTimestamp = false;
-	}
+	xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
 	Log::global_log->info() << "Append timestamp: " << _appendTimestamp << std::endl;
 }
 

--- a/src/io/PovWriter.h
+++ b/src/io/PovWriter.h
@@ -23,6 +23,8 @@ public:
 	   <outputplugin name="PovWriter">
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
+	     <incremental>BOOL</incremental>
+	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode
 	 */

--- a/src/io/XyzWriter.h
+++ b/src/io/XyzWriter.h
@@ -23,7 +23,7 @@ public:
 	   <outputplugin name="XyzWriter">
 	     <writefrequency>INTEGER</writefrequency>
 	     <outputprefix>STRING</outputprefix>
-	     <incremental>INTEGER</incremental>
+	     <incremental>BOOL</incremental>
 	     <appendTimestamp>BOOL</appendTimestamp>
 	   </outputplugin>
 	   \endcode

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -16,7 +16,7 @@
 #include "parallel/DomainDecompBase.h"
 #include "utils/generator/EqualVelocityAssigner.h"
 
-// Declare the main AutoPas class and the iteratePairwise() methods with all used functors as extern template
+// Declare the main AutoPas class and the computeInteractions() methods with all used functors as extern template
 // instantiation. They are instantiated in the respective cpp file inside the templateInstantiations folder.
 //! @cond Doxygen_Suppress
 extern template class autopas::AutoPas<Molecule>;
@@ -87,7 +87,7 @@ extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		> *);
 #endif
 #ifdef __ARM_FEATURE_SVE
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctorSVE<
 				Molecule,
 				/*applyShift*/ true,
@@ -95,7 +95,7 @@ extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
 				autopas::FunctorN3Modes::Both,
 				/*calculateGlobals*/ true
 		> *);
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctorSVE<
 				Molecule,
 				/*applyShift*/ true,
@@ -103,7 +103,7 @@ extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
 				autopas::FunctorN3Modes::Both,
 				/*calculateGlobals*/ true
 		> *);
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctorSVE<
 				Molecule,
 				/*applyShift*/ false,
@@ -111,7 +111,7 @@ extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
 				autopas::FunctorN3Modes::Both,
 				/*calculateGlobals*/ true
 		> *);
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctorSVE<
 				Molecule,
 				/*applyShift*/ false,
@@ -435,7 +435,7 @@ void AutoPasContainer::addParticles(std::vector<Molecule> &particles, bool check
 
 template <typename F>
 std::pair<double, double> AutoPasContainer::iterateWithFunctor(F &&functor) {
-	// here we call the actual autopas' iteratePairwise method to compute the forces.
+	// here we call the actual autopas' computeInteractions method to compute the forces.
 	_autopasContainer.computeInteractions(&functor);
 	const double upot = functor.getPotentialEnergy();
 	const double virial = functor.getVirial();

--- a/src/particleContainer/AutoPasContainer.cpp
+++ b/src/particleContainer/AutoPasContainer.cpp
@@ -20,7 +20,7 @@
 // instantiation. They are instantiated in the respective cpp file inside the templateInstantiations folder.
 //! @cond Doxygen_Suppress
 extern template class autopas::AutoPas<Molecule>;
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctor<
 				Molecule,
 				/*applyShift*/ true,
@@ -28,7 +28,7 @@ extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
 				autopas::FunctorN3Modes::Both,
 				/*calculateGlobals*/ true
 		> *);
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctor<
 				Molecule,
 				/*applyShift*/ true,
@@ -36,7 +36,7 @@ extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
 				autopas::FunctorN3Modes::Both,
 				/*calculateGlobals*/ true
 		> *);
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctor<
 				Molecule,
 				/*applyShift*/ false,
@@ -44,7 +44,7 @@ extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
 				autopas::FunctorN3Modes::Both,
 				/*calculateGlobals*/ true
 		> *);
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctor<
 				Molecule,
 				/*applyShift*/ false,
@@ -53,7 +53,7 @@ extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
 				/*calculateGlobals*/ true
 		> *);
 #ifdef __AVX__
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctorAVX<
 				Molecule,
 				/*applyShift*/ true,
@@ -61,7 +61,7 @@ extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
 				autopas::FunctorN3Modes::Both,
 				/*calculateGlobals*/ true
 		> *);
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctorAVX<
 				Molecule,
 				/*applyShift*/ true,
@@ -69,7 +69,7 @@ extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
 				autopas::FunctorN3Modes::Both,
 				/*calculateGlobals*/ true
 		> *);
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctorAVX<
 				Molecule,
 				/*applyShift*/ false,
@@ -77,7 +77,7 @@ extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
 				autopas::FunctorN3Modes::Both,
 				/*calculateGlobals*/ true
 		> *);
-extern template bool autopas::AutoPas<Molecule>::iteratePairwise(
+extern template bool autopas::AutoPas<Molecule>::computeInteractions(
 		mdLib::LJFunctorAVX<
 				Molecule,
 				/*applyShift*/ false,
@@ -317,7 +317,7 @@ bool AutoPasContainer::rebuild(double *bBoxMin, double *bBoxMax) {
 	_autopasContainer.setBoxMin(boxMin);
 	_autopasContainer.setBoxMax(boxMax);
 	_autopasContainer.setCutoff(_cutoff);
-	_autopasContainer.setVerletSkinPerTimestep(_verletSkin / _verletRebuildFrequency);
+	_autopasContainer.setVerletSkin(_verletSkin);
 	_autopasContainer.setVerletRebuildFrequency(_verletRebuildFrequency);
 	_autopasContainer.setVerletClusterSize(_verletClusterSize);
 	_autopasContainer.setTuningInterval(_tuningFrequency);
@@ -436,7 +436,7 @@ void AutoPasContainer::addParticles(std::vector<Molecule> &particles, bool check
 template <typename F>
 std::pair<double, double> AutoPasContainer::iterateWithFunctor(F &&functor) {
 	// here we call the actual autopas' iteratePairwise method to compute the forces.
-	_autopasContainer.iteratePairwise(&functor);
+	_autopasContainer.computeInteractions(&functor);
 	const double upot = functor.getPotentialEnergy();
 	const double virial = functor.getVirial();
 	return std::make_pair(upot, virial);
@@ -566,8 +566,8 @@ void AutoPasContainer::traverseCells(CellProcessor &cellProcessor) {
 		if (_particlePropertiesLibrary.getNumberRegisteredSiteTypes() == 0) {
 			const auto components = global_simulation->getEnsemble()->getComponents();
 			for (const auto &c : *components) {
-				_particlePropertiesLibrary.addSiteType(c.getLookUpId(), c.ljcenter(0).eps(), c.ljcenter(0).sigma(),
-												   c.ljcenter(0).m());
+				_particlePropertiesLibrary.addSiteType(c.getLookUpId(),c.ljcenter(0).m());
+				_particlePropertiesLibrary.addLJParametersToSite(c.getLookUpId(), c.ljcenter(0).eps(), c.ljcenter(0).sigma());
 			}
 			_particlePropertiesLibrary.calculateMixingCoefficients();
 			size_t numComponentsAdded = 0;
@@ -735,4 +735,4 @@ RegionParticleIterator AutoPasContainer::regionIterator(const double *startCorne
 	return RegionParticleIterator{
 		_autopasContainer.getRegionIterator(lowCorner, highCorner, convertBehaviorToAutoPas(t))};
 }
-std::string AutoPasContainer::getConfigurationAsString() { return _autopasContainer.getCurrentConfig().toString(); }
+std::string AutoPasContainer::getConfigurationAsString() { return _autopasContainer.getCurrentConfigs().at(autopas::InteractionTypeOption::pairwise).get().toString(); }

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXNoShiftMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXNoShiftMix.cpp
@@ -10,7 +10,7 @@
 #include "molecularDynamicsLibrary/LJFunctorAVX.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctorAVX<
 				Molecule,
 				/*applyShift*/ false,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXNoShiftNoMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXNoShiftNoMix.cpp
@@ -10,7 +10,7 @@
 #include "molecularDynamicsLibrary/LJFunctorAVX.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctorAVX<
 				Molecule,
 				/*applyShift*/ false,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXShiftMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXShiftMix.cpp
@@ -10,7 +10,7 @@
 #include "molecularDynamicsLibrary/LJFunctorAVX.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctorAVX<
 				Molecule,
 				/*applyShift*/ true,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXShiftNoMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorAVXShiftNoMix.cpp
@@ -10,7 +10,7 @@
 #include "molecularDynamicsLibrary/LJFunctorAVX.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctorAVX<
 				Molecule,
 				/*applyShift*/ true,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorNoShiftMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorNoShiftMix.cpp
@@ -9,7 +9,7 @@
 #include "molecularDynamicsLibrary/LJFunctor.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctor<
 				Molecule,
 				/*applyShift*/ false,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorNoShiftNoMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorNoShiftNoMix.cpp
@@ -9,7 +9,7 @@
 #include "molecularDynamicsLibrary/LJFunctor.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctor<
 				Molecule,
 				/*applyShift*/ false,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorSVENoShiftMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorSVENoShiftMix.cpp
@@ -10,7 +10,7 @@
 #include "molecularDynamicsLibrary/LJFunctorSVE.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctorSVE<
 				Molecule,
 				/*applyShift*/ false,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorSVENoShiftNoMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorSVENoShiftNoMix.cpp
@@ -10,7 +10,7 @@
 #include "molecularDynamicsLibrary/LJFunctorSVE.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctorSVE<
 				Molecule,
 				/*applyShift*/ false,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorSVEShiftMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorSVEShiftMix.cpp
@@ -10,7 +10,7 @@
 #include "molecularDynamicsLibrary/LJFunctorSVE.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctorSVE<
 				Molecule,
 				/*applyShift*/ true,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorSVEShiftNoMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorSVEShiftNoMix.cpp
@@ -10,7 +10,7 @@
 #include "molecularDynamicsLibrary/LJFunctorSVE.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctorSVE<
 				Molecule,
 				/*applyShift*/ true,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorShiftMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorShiftMix.cpp
@@ -9,7 +9,7 @@
 #include "molecularDynamicsLibrary/LJFunctor.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctor<
 				Molecule,
 				/*applyShift*/ true,

--- a/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorShiftNoMix.cpp
+++ b/src/particleContainer/AutoPasTemplateInstantiations/iteratePairwiseLJFunctorShiftNoMix.cpp
@@ -9,7 +9,7 @@
 #include "molecularDynamicsLibrary/LJFunctor.h"
 
 //! @cond Doxygen_Suppress
-template bool autopas::AutoPas<AutoPasSimpleMolecule>::iteratePairwise(
+template bool autopas::AutoPas<AutoPasSimpleMolecule>::computeInteractions(
 		mdLib::LJFunctor<
 				Molecule,
 				/*applyShift*/ true,


### PR DESCRIPTION
# Description

This PR updates AutoPas to the newest version (current commit on master).
This PR only updates the interface and some smaller fixes that were needed to run the autopas examples.

The new AutoPas version enables 3-Body interactions, dynamic containers and better energy measurements for further PRs.

## How Has This Been Tested?

- [x] Unit Tests
- [x] Running all autopas examples locally
- [x] @amartyads had tested the setup for ARM experiments

## Documentation
Updated the documentation and reading for the xml parameters `incremental` and `appendTimestamp`, which are part of several output writers, to consistently use booleans. They had caused errors with some of the autopas examples before.