### PR TITLE
DomainDecomposition memoryleak fix

### DIFF
--- a/src/parallel/DomainDecomposition.cpp
+++ b/src/parallel/DomainDecomposition.cpp
@@ -36,8 +36,15 @@ void DomainDecomposition::initMPIGridDims() {
 		}
 	}
 
+	MPI_Comm previous_comm = _comm;
 	MPI_CHECK(MPI_Dims_create( _numProcs, DIMgeom, _gridSize.data()));
 	MPI_CHECK(MPI_Cart_create(_comm, DIMgeom, _gridSize.data(), period, reorder, &_comm));
+
+	// If initMPIGridDims has already been executed, the previous communicator is deleted.
+	if (_cartCommunicatorCreated) {
+		MPI_Comm_free(&previous_comm);
+	}
+	_cartCommunicatorCreated = true;
 
 	Log::global_log->info() << "MPI grid dimensions: " << _gridSize[0] << ", " << _gridSize[1] << ", " << _gridSize[2] << std::endl;
 	MPI_CHECK(MPI_Comm_rank(_comm, &_rank));

--- a/src/parallel/DomainDecomposition.cpp
+++ b/src/parallel/DomainDecomposition.cpp
@@ -36,13 +36,13 @@ void DomainDecomposition::initMPIGridDims() {
 		}
 	}
 
-	MPI_Comm previous_comm = _comm;
+	MPI_Comm previousComm = _comm;
 	MPI_CHECK(MPI_Dims_create( _numProcs, DIMgeom, _gridSize.data()));
 	MPI_CHECK(MPI_Cart_create(_comm, DIMgeom, _gridSize.data(), period, reorder, &_comm));
 
 	// If initMPIGridDims has already been executed, the previous communicator is deleted.
 	if (_cartCommunicatorCreated) {
-		MPI_Comm_free(&previous_comm);
+		MPI_Comm_free(&previousComm);
 	}
 	_cartCommunicatorCreated = true;
 

--- a/src/parallel/DomainDecomposition.h
+++ b/src/parallel/DomainDecomposition.h
@@ -79,6 +79,7 @@ protected:
 
 	std::array<int, DIMgeom> _gridSize; //!< Number of processes in each dimension of the MPI process grid
 	int _coords[DIMgeom]; //!< Coordinate of the process in the MPI process grid
+	bool _cartCommunicatorCreated = false; // Indicates whether a communicator with topology information has already been created.
 };
 
 #endif /* DOMAINDECOMPOSITION_H_ */


### PR DESCRIPTION
# Description

In the DomainDecomposition constructor, initMPIGridDims is executed, creating a new communicator with topology information.
When the function DomainDecomposition::readXML is executed, initMPIGridDims is executed a second time, creating another communicator. Since the original communicator is never released, this results in a memory leak.

To fix the problem, a variable was created that indicates whether a communicator has already been created. If this is the case, the previous communicator is then deleted. 

## Related Pull Requests

none

## Resolved Issues

none

## How Has This Been Tested?

The program was tested both in cases where initMPIGridDims was executed a second time and in cases where this did not happen, with test code inserted to ensure that the communicator is now created and released correctly.

## Documentation