### PR TITLE
Improved and cleaned up readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,187 +1,96 @@
-ls1-MarDyn Overview
-===================
+# ls1-MarDyn
 
-ls1-MarDyn is a massively parallel Molecular Dynamics (MD) code for large systems. Its main target is the simulation of thermodynamics and nanofluidics. ls1-MarDyn is designed with a focus on performance and easy extensibility.
+[![CodeQL](https://github.com/ls1mardyn/ls1-mardyn/actions/workflows/codeql.yml/badge.svg)](https://github.com/ls1mardyn/ls1-mardyn/actions/workflows/codeql.yml)
+[![Documentation](https://img.shields.io/badge/docs-doxygen-blue)](https://ls1mardyn.github.io/ls1-mardyn/)
+[![License](https://img.shields.io/github/license/ls1mardyn/ls1-mardyn)](https://github.com/ls1mardyn/ls1-mardyn/blob/master/LICENSE)
+[![DOI](https://img.shields.io/badge/DOI-10.1021%2Fct500169q-blue)](https://doi.org/10.1021/ct500169q)
 
+ls1-MarDyn is a massively parallel Molecular Dynamics (MD) code designed for large-scale systems. Its primary focus is the simulation of thermodynamics and nanofluidics, with an emphasis on high performance and extensibility.
 
-Getting Started
-===============
+## Table of Contents
 
-Documentation
---------------
-The current doxygen documentation can be found [here](https://ls1mardyn.github.io/ls1-mardyn/).
+- [Documentation](#documentation)
+- [Installation](#installation)
+- [Running ls1-MarDyn](#running-ls1-mardyn)
+- [AutoPas Support](#autopas-support)
+- [Visualisation](#visualisation)
+- [Contact](#contact)
 
-Prerequisites
---------------
-### mandatory requirements
-* a C++17 compiler (GCC, Clang, Intel, PGI, Cray, NEC SX, IBM XL, ...)
-* a working MPI installation compatible with the MPI 3.0 specification or later (Open MPI, MPICH, MVAPICH, Intel MPI, Cray MPI, NEC MPI, IBM Platform MPI, ...)
+## Documentation
+The current doxygen documentation can be found [here](https://ls1mardyn.github.io/ls1-mardyn/). It includes information about the following topics
+* ls1-MarDyn input files
+* Unit tests
+* Graphical simulation output
+* Source code internals
 
-### optional requirements
+## Installation
+
+### Prerequisites
+#### mandatory requirements
+* a C++17 capable compiler
+* an MPI installation compatible with the MPI 3.0 specification or later
+
+#### optional requirements
+* [Doxygen](https://www.doxygen.nl/) to build the ls1-MarDyn documentation
+* [Adios2](https://github.com/ornladios/ADIOS2) for support of reading and writing files in the Adios2 format
 * [FFTW3](http://www.fftw.org)
-* [VTK](http://www.vtk.org)
+* [VTK](http://www.vtk.org) for support of creating VTK files
 * [QuickSched](https://arxiv.org/abs/1601.05384)
-* If [AutoPas](https://autopas.github.io/doxygen_documentation/git-master/) is enabled, make sure to have [its requirements](https://github.com/AutoPas/AutoPas/blob/master/docs/userdoc/Building.md) installed.
-
-Installation
-------------
+* [AutoPas](https://autopas.github.io/doxygen_documentation/git-master/) for alternative particle containers and auto tuning (if enabled, make sure to have the [AutoPas dependencies](https://github.com/AutoPas/AutoPas/blob/master/docs/userdoc/Building.md) installed, as well)
 
 ### Installing ls1-MarDyn using cmake
-This is the recommended way of building ls1-MarDyn.
-
-#### Quick guide
-
-Run the following commands to build ls1-MarDyn with the Clang compiler. Adjust options (e.g. ENABLE_MPI) according to the individual needs.
-```bash
-mkdir build
-cd build
-CC=clang CXX=clang++ ccmake ..
-make -j $(nproc)
+ls1-MarDyn uses CMake as its build system. Run the following commands to configure ls1. Adjust options (e.g. `ENABLE_MPI`) according to your needs.
+```sh
+git clone https://github.com/ls1mardyn/ls1-mardyn.git
+cd ls1-mardyn
+cmake -B build/ -S . -DENABLE_MPI=ON
 ```
 
-#### Detailed guide
-To build ls1-MarDyn using cmake first create an additional directory on the root ls1-MarDyn directory and change into that directory.
-```bash
-mkdir build
-cd build
+ls1-MarDyn provides many configuration options. To list all configuration options run:
+```sh
+cmake -LAH build/
 ```
-Next, `cmake` has to be executed. In most cases, you will have to specify the compiler with which ls1-MarDyn should be built:
-```bash
-CC=clang CXX=clang++ cmake ..
-```
-Some of the most common compilers are
-| Compiler      | CC    | CXX     |
-|---------------|-------|---------|
-| GCC           | `gcc`   | `g++`     |
-| Intel oneAPI  | `icx`   | `icpx`    |
-| Clang         | `clang` | `clang++` |
-
-The Intel Classic Compiler (`icc` and `icpc`) is not recommended to use, since it is deprecated and does not work with AutoPas.
-
-Note: The Intel oneAPI compiler may rely on some external C++ libraries shipped with gcc (see [this issue](https://github.com/ls1mardyn/ls1-mardyn/issues/297) for details).
-
-Specifying the compiler this way is only possible at the first execution of cmake.
-If you want to change the compiler later on, either add another build directory, or first clear the existing build directory.
-
-To configure the options within ls1-MarDyn it is recommended to use `ccmake`:
-```bash
-ccmake ..
-```
-That way you can easily edit the available options.
-
-Alternatively, specify the configuration with use of the `cmake` command:
-```bash
-CC=clang CXX=clang++ cmake -DENABLE_MPI=ON ..
+Alternatively use the interactive interface:
+```sh
+ccmake build/
 ```
 
-Finally, build ls1-MarDyn using:
-```bash
-make
+To build the ls1-MarDyn executable run the following command. To speed up the build process it is recommended to run parallel build using the `-j` option:
+```sh
+cmake --build build/ -j
 ```
-
-For a faster build, you can make use of parallel building:
-```bash
-make -j $(nproc)
-```
-
 The executable is then found at `build/src/MarDyn`.
 
-
-### Installing ls1-MarDyn using make
-
-ls1-MarDyn is build from source code using GNU make or alternatively using cmake (see below).
-
-A default build using the GNU compiler and a MPI library providing the mpicxx compiler wrapper is done with
+To build the documentation of ls1-MarDyn locally using doxygen run
 ```sh
-  cd src
-  make
-```
-To get an overview of options to control the build process, e.g. to use another compiler, disable MPI, ... run
-```sh
-  make help
-```
-To see a list of all supported target platforms and compilers call
-```sh
-  make cfg_list
-```
-and run then make with the desired configuration:
-```sh
-  make CFG=<config name>
-```
-To display further information about the available suboptions for a configuration use
-```sh
-  make CFG=<cfg name> cfg_help
+doxygen Doxyfile
 ```
 
 
-#### ADIOS2 support
-If a visualisation with MegaMol and ADIOS2 is desired, an installation of ADIOS2 is needed. By default, ADIOS2 is downloaded and built automatically during the build process of ls1-MarDyn. If connections to external resources, e.g. on HPC systems, are blocked, the following steps (for an MPI build) are required to build ls1-MarDyn with ADIOS2.
-Download ADIOS2 locally
-```bash
-git clone https://github.com/ornladios/ADIOS2.git ADIOS2
-```
-It may be required to checkout the correct version of ADIOS2:
-```bash
-cd ADIOS2
-git checkout v2.7.1.436
-```
-Upload it together with ls1-MarDyn to the target HPC system. On the HPC system, after loading the proper modules, create a build folder in the ADIOS2 directory and run cmake. Note: The `PATH-TO-ADIOS2` string must be adjusted.
-```bash
-cd ADIOS2
-mkdir build && cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=PATH-TO-ADIOS2/ADIOS2/build/install -DADIOS2_BUILD_EXAMPLES=OFF -DADIOS2_BUILD_TESTING=OFF -DADIOS2_USE_Profiling=OFF -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpicxx
-```
-Build now using:
-```bash
-make -j install
-```
-The `-j` parameter can be adjusting to the present system.
 
-After successfully building ADIOS2, ls1-MarDyn can be build.
-In accordance to the above installation steps (section "Configuration"), an additional build directory in the root directory of ls1-MarDyn must be created. In this directory run `cmake`. Note: The `PATH-TO-ADIOS2` string must be adjusted as it was done before.
-```bash
-mkdir build
-cd build
-cmake .. -DCMAKE_C_COMPILER=mpicc -DCMAKE_CXX_COMPILER=mpicxx -DADIOS2_DIR=PATH-TO-ADIOS2/ADIOS2/build/install/lib64/cmake/adios2 -DENABLE_MPI=ON -DFIND_PACKAGE_ADIOS2=ON
-```
-
-Finally, build ls1-MarDyn using:
-```bash
-make
-```
-For a parallel and faster build please use `make`'s `-j` parameter with an appropriate number of tasks.
-
-Note: For both, ADIOS2 and ls1-MarDyn, `ccmake` can be used to configure options.
-
-Running ls1-MarDyn
-------------------
+## Running ls1-MarDyn
 The basic command to run ls1-MarDyn is as follows:
 ```sh
 MarDyn [options] <inputfile>
 ```
-where `MarDyn` is the executable build in the INSTALLATION section, `[options]` are any "--"-prefixed options as listed by `MarDyn --help` and `<inputfile>` is a input file.
-
-To get an overview of further command line options run
-```sh
-MarDyn --help
-```
+where `MarDyn` is the executable build in the installation section. The available options can be listed with `MarDyn --help`, and `<inputfile>` is an ls1-MarDyn input file.
 
 To understand how to write an input file check out [examples/all-options.xml](https://github.com/ls1mardyn/ls1-mardyn/blob/master/examples/all-options.xml), the various examples in the examples folder and the documentation of the various `readXML()` methods, e.g. via our doxygen documentation.
 
-### running examples
+### Running Examples
 ls1-MarDyn comes with a set of examples, which can be found in the examples folder.
+
 ```sh
 cd examples/EOX/305K_liq
-mpirun -np 2 ../../../src/MarDyn config.xml  --steps 10
+mpirun -np 2 ../../../build/src/MarDyn config.xml  --steps 10
 ```
 optional: to make the simulation aware of time limits like on a compute node, which should stop the simulation even if the desired amount of steps is not reached use ```loop-abort-time``` in (s) in XML or CLI:
 ```sh
-mpirun -np 2 ../../../src/MarDyn config.xml  --steps 10 --loop-abort-time 3600
+mpirun -np 2 ../../../build/src/MarDyn config.xml  --steps 10 --loop-abort-time 3600
 ```
 
-AutoPas Support
-------------------
-ls1-MarDyn supports AutoPas as a replacement for the used linked cells container and the built-in force calculation.
+## AutoPas Support
+ls1-MarDyn supports AutoPas as a replacement for the built-in linked cells container and force calculation.
 
 ### Building for AutoPas 
 To enable support for [AutoPas](https://github.com/AutoPas/AutoPas/), you will have to enable the option `ENABLE_AUTOPAS`.
@@ -195,45 +104,41 @@ To use AutoPas a few modifications to the normal `xml` config files have to be p
   Additional information for the options can be found in the [official documentation](https://www5.in.tum.de/AutoPas/doxygen_doc/master/namespaceautopas_1_1options.html)
   and within the [responsible readXML method](https://www5.in.tum.de/mardyn/doxygen_doc/html/classAutoPasContainer.html).
 
-### Limitations
+#### Limitations:
 - Using AutoPas, currently, only single-centered Lennard-Jones interactions are possible.
 
-Visualisation
-------------------
-The simulations can be visualised by two external programs which requires the inclusion of the corresponding plugin.
+## Visualisation
+ls1-MarDyn supports visualizing its simulations with various external programs. Specifically it provides plugins for MegaMol and Paraview.
 
 ### MegaMol
-The MegaMol software is developed by VISUS of the University of Stuttgart. Detailed information on how to install it can be found in its [GitHub repo](https://github.com/UniStuttgart-VISUS/megamol). It supports the import of the following two file formats. See `doc/visualisation_MegaMol.dox` for detailed information.
-
-#### mmpld
-This is the old file format for visualisation. Use the `MmpldWriter` plugin to write the visualisation files during simulation.
+The MegaMol software is a visualisation software package developed by VISUS of the University of Stuttgart. Detailed information on how to install it can be found in its [GitHub repo](https://github.com/UniStuttgart-VISUS/megamol). Visualisation with MegaMol is typically performed as a post-processing step. Input datasets for MegaMol can be provided via various file formats. See `doc/visualisation_MegaMol.dox` for detailed information.
 
 #### ADIOS2
-This kind of visualisation files is recommended. Use the `Adios2Writer` plugin to write the visualisation files during simulation. The produced files can also be used for a restart (see `Adios2Reader`).
+ADIOS2 is the recommended format to be used with MegaMol. Use the `Adios2Writer` plugin to write the visualisation files during simulation. The produced files can also be used for a restart (see `Adios2Reader`).
+
+#### mmpld
+This is the old MegaMol file format. Use the `MmpldWriter` plugin to write the visualisation files during simulation.
 
 ### Paraview
 Read the documentation in `doc/visualisation_paraview.dox` for detailed information.
 
+# Contact
 
-Additional resources
-====================
-ls1-MarDyn is documented using doxygen. To build the documentation run
-```sh
-doxygen Doxyfile
-```
-It includes information about the following topics
-* \ref ls1MarDynInputFiles Mardyn Input Files
-* \ref unitTests Unit tests
-* \ref visualisation Graphical Simulation Output
+* [ls1-mardyn.de](http://www.ls1-mardyn.de) - the official ls1-MarDyn web page.
+* [general contact](mailto:contact@ls1-mardyn.de) - general questions around ls1-MarDyn
+* [developer mailinglist](mailto:ls1-devel@lists.projects.hlrs.de) - mailinglist related to the development of ls1-MarDyn
 
-as well as the documentation of the source code.
+## Citation
+If you use ls1-MarDyn in scientific work, please cite:
 
-Contact
-=======
-
-* <http://www.ls1-mardyn.de> : the official ls1-MarDyn web page.
-* <mailto:contact@ls1-mardyn.de> : can be used for general questions around ls1-MarDyn.
-* <mailto:ls1-devel@lists.projects.hlrs.de> : can be used to reach the developers of ls1-MarDyn.
-
-
-
+```bibtex
+@article{niethammer-2014-ls1mardyn,
+  author  = {Niethammer, Christoph and Becker, Stefan and Bernreuther, Martin and Buchholz, Martin and Eckhardt, Wolfgang and Heinecke, Alexander and Werth, Stephan and Bungartz, Hans-Joachim and Glass, Colin W. and Hasse, Hans and Vrabec, Jadran and Horsch, Martin},
+  title   = {ls1 mardyn: The Massively Parallel Molecular Dynamics Code for Large Systems},
+  journal = {Journal of Chemical Theory and Computation},
+  year    = {2014},
+  volume  = {10},
+  number  = {10},
+  pages   = {4455--4464},
+  doi     = {10.1021/ct500169q}
+}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The current doxygen documentation can be found [here](https://ls1mardyn.github.i
 * [Doxygen](https://www.doxygen.nl/) to build the ls1-MarDyn documentation
 * [Adios2](https://github.com/ornladios/ADIOS2) for support of reading and writing files in the Adios2 format
 * [FFTW3](http://www.fftw.org)
-* [VTK](http://www.vtk.org) for support of creating VTK files
+* [Xerces](https://xerces.apache.org/xerces-c/) for support of creating [VTK](http://www.vtk.org) files
 * [QuickSched](https://arxiv.org/abs/1601.05384)
 * [AutoPas](https://autopas.github.io/doxygen_documentation/git-master/) for alternative particle containers and auto tuning (if enabled, make sure to have the [AutoPas dependencies](https://github.com/AutoPas/AutoPas/blob/master/docs/userdoc/Building.md) installed, as well)
 


### PR DESCRIPTION
# Description

The readme was confusing for first-time users and partially outdated. This update to the readme includes
* Removal of outdated or unnecessary information
* Fixed commands to allow working copy past for users
* CMake only description with modern CMake commands
* Added common badges, e.g., for documentation and CI status
* Add citation note
* Markdown fixes and styling


## How Has This Been Tested?

- [x] Checked all commands in the updated README to work locally 
