### PR TITLE
added missing directive

### DIFF
--- a/src/parallel/GeneralDomainDecomposition.cpp
+++ b/src/parallel/GeneralDomainDecomposition.cpp
@@ -130,7 +130,9 @@ void GeneralDomainDecomposition::balanceAndExchange(double lastTraversalTime, bo
 				DomainDecompMPIBase::exchangeMoleculesMPI(moleculeContainer, domain, LEAVING_AND_HALO_COPIES);
 			} else {
 				DomainDecompMPIBase::exchangeMoleculesMPI(moleculeContainer, domain, LEAVING_ONLY);
+#ifndef MARDYN_AUTOPAS
 				moleculeContainer->deleteOuterParticles();
+#endif
 				DomainDecompMPIBase::exchangeMoleculesMPI(moleculeContainer, domain, HALO_COPIES);
 			}
 		}


### PR DESCRIPTION
# Description

See discussion in https://github.com/ls1mardyn/ls1-mardyn/issues/321#issuecomment-4011456282
The directive makes GeneralDomainDecomposition consistent with other decompositions. I'm not aware if there was a specific reason this directive was missing, so I would appreciate input.

## Issues

#321 

## How Has This Been Tested?

Tests are also available in the issue.
