### PR TITLE
Remove test when no executable is created

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,7 +56,9 @@ target_compile_definitions(MarDyn PUBLIC
         ${ADIOS2_COMPILE_DEFINITION}
 )
 
+if(NOT MAMICO_COUPLING)
 add_test(
         NAME MarDyn_test
         COMMAND MarDyn -t -d ${PROJECT_SOURCE_DIR}/test_input
 )
+endif()


### PR DESCRIPTION
# Description

When compiling as library, this specific test cannot be run, and hence should be disabled.
