### PR TITLE
Add option to add timestep to filename in XYZWriter

### DIFF
--- a/src/io/XyzWriter.cpp
+++ b/src/io/XyzWriter.cpp
@@ -38,13 +38,13 @@ void XyzWriter::endStep(ParticleContainer *particleContainer, DomainDecompBase *
 		std::stringstream filenamestream;
 		filenamestream << _outputPrefix;
 
-		unsigned long numTimesteps = _simulation.getNumTimesteps();
 		if(_incremental) {
 			/* align file numbers with preceding '0's in the required range from 0 to _numberOfTimesteps. */
+			unsigned long numTimesteps = _simulation.getNumTimesteps();
 			int num_digits = (int) ceil( log( double( numTimesteps / _writeFrequency ) ) / log(10.) );
 			filenamestream << "-" << aligned_number( simstep / _writeFrequency, num_digits, '0' );
 		} else {
-			filenamestream << "-" << numTimesteps;
+			filenamestream << "-" << simstep;
 		}
 		if(_appendTimestamp) {
 			filenamestream << "-" << gettimestring();

--- a/src/io/XyzWriter.cpp
+++ b/src/io/XyzWriter.cpp
@@ -38,11 +38,13 @@ void XyzWriter::endStep(ParticleContainer *particleContainer, DomainDecompBase *
 		std::stringstream filenamestream;
 		filenamestream << _outputPrefix;
 
+		unsigned long numTimesteps = _simulation.getNumTimesteps();
 		if(_incremental) {
 			/* align file numbers with preceding '0's in the required range from 0 to _numberOfTimesteps. */
-			unsigned long numTimesteps = _simulation.getNumTimesteps();
 			int num_digits = (int) ceil( log( double( numTimesteps / _writeFrequency ) ) / log(10.) );
 			filenamestream << "-" << aligned_number( simstep / _writeFrequency, num_digits, '0' );
+		} else {
+			filenamestream << "-" << numTimesteps;
 		}
 		if(_appendTimestamp) {
 			filenamestream << "-" << gettimestring();

--- a/src/io/XyzWriter.cpp
+++ b/src/io/XyzWriter.cpp
@@ -26,6 +26,9 @@ void XyzWriter::readXML(XMLfileUnits& xmlconfig) {
 
 	xmlconfig.getNodeValue("appendTimestamp", _appendTimestamp);
 	Log::global_log->info() << "Append timestamp: " << _appendTimestamp << std::endl;
+
+	xmlconfig.getNodeValue("appendTimestep", _appendTimestep);
+	Log::global_log->info() << "Append timestep: " << _appendTimestep << std::endl;
 }
 
 void XyzWriter::init(ParticleContainer * /*particleContainer*/, DomainDecompBase * /*domainDecomp*/,
@@ -43,7 +46,8 @@ void XyzWriter::endStep(ParticleContainer *particleContainer, DomainDecompBase *
 			unsigned long numTimesteps = _simulation.getNumTimesteps();
 			int num_digits = (int) ceil( log( double( numTimesteps / _writeFrequency ) ) / log(10.) );
 			filenamestream << "-" << aligned_number( simstep / _writeFrequency, num_digits, '0' );
-		} else {
+		}
+		if(_appendTimestep) {
 			filenamestream << "-" << simstep;
 		}
 		if(_appendTimestamp) {

--- a/src/io/XyzWriter.h
+++ b/src/io/XyzWriter.h
@@ -25,6 +25,7 @@ public:
 	     <outputprefix>STRING</outputprefix>
 	     <incremental>BOOL</incremental>
 	     <appendTimestamp>BOOL</appendTimestamp>
+		 <appendTimestep>BOOL</appendTimestep>
 	   </outputplugin>
 	   \endcode
 	 */
@@ -51,6 +52,7 @@ private:
 	std::string _outputPrefix;
 	unsigned long _writeFrequency {0ul};
 	bool _appendTimestamp {false};
+	bool _appendTimestep {false};
 	bool _incremental {false};
 };
 


### PR DESCRIPTION
# Description

If "incremental" and "timestamp" was not enabled in the config for XYZWriter, the plugin would overwrite the same file again and again. This fixes that issue by appending the simstep.

## How Has This Been Tested?

Single rank single thread run on HSUper

