### PR TITLE
Handling Stale Branches

### DIFF
--- a/.github/workflows/notifyOwnersOldBranches.yml
+++ b/.github/workflows/notifyOwnersOldBranches.yml
@@ -1,0 +1,97 @@
+name: Notify Owners of Old Branches
+
+on:
+  workflow_dispatch:
+
+jobs:
+  NotifyOwnersOldBranches:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0  # Needed to retrieve full commit log
+
+      - name: Setup Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.x'
+
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      - name: Find Stale Branches and List Owners
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        run: |
+          AGE_CUTOFF=360 # In days
+          MAIN_BRANCH=master
+
+          # Fetch all branches
+          git branch -r | grep -v '\->' | sed 's/origin\///' > branches.txt
+
+          # Variable for collecting GitHub usernames
+          allContributors=""
+  
+          reportText="The branches listed below have been inactive for over one year. Therefore, they are scheduled for removal in 60 days. "
+          reportText+="If you need any of these branches, please let us know before the deadline."
+          issueBody=$'## Old Branches\n\n'"$reportText"$'\n\n```text\nBRANCH                 AGE                  OWNER\n---------------------------------------------------------------\n'
+
+          # Loop through branches
+          while read branch; do
+            # Skip main branch
+            if [ "$branch" = "master" ] || [ "$branch" = "main" ]; then
+              continue
+            fi
+
+            # Skip if open PR exists
+            open_prs=$(gh pr list --head "$branch" --json number --jq 'length')
+            if [ "$open_prs" -gt 0 ]; then
+              continue
+            fi
+
+            # Get last commit date
+            lastCommitDate=$(gh api repos/${{ github.repository }}/commits/$branch --jq '.commit.committer.date')
+
+            # Calculate branch age in days
+            branchAgeDays=$(( ($(date -u +%s) - $(date -u -d "$lastCommitDate" +%s)) / 86400 ))
+
+            # Check whether the branch is old enough
+            if [ $branchAgeDays -ge $AGE_CUTOFF ]; then
+              # Get contributors to the branch
+              commitData=$(gh api "repos/${{ github.repository }}/compare/$MAIN_BRANCH...$branch")
+              contributors=$(printf '%s\n' "$commitData" | jq -r '.commits[] | select(.author.login != null) | "\(.commit.author.name) (@\(.author.login))"' | sort -u)
+              contributors=$(printf '%s\n' "$contributors" | paste -sd ', ' -)
+
+              BLUE='\033[34m'
+              RED='\033[31m'
+              GREEN='\033[32m'
+              NC='\033[0m'
+              printf "BRANCH=${BLUE}%-20s${NC} AGE=${RED}%-20s${NC} OWNER=${GREEN}%s${NC}\n" "$branch" "${branchAgeDays} days old" "$contributors"
+
+              #create an issue
+              issueBody+=$(printf '%-20s 🔴 %-15s 🟢 %s' "$branch" "$branchAgeDays days old" "$contributors")
+              issueBody+=$'\n'
+
+              # Get only GitHub usernames for notifications
+              contributorLogins=$(gh api "repos/${{ github.repository }}/compare/$MAIN_BRANCH...$branch" --jq '.commits[].author.login' | sort -u)
+
+              # Add the usernames to the global contributor list
+              allContributors+="$contributorLogins"$'\n'	      
+            fi
+          done < branches.txt
+
+          # Remove duplicate usernames and create GitHub mentions
+          mentions=$(printf '%s\n' "$allContributors" | sed '/^null$/d' | sed '/^$/d' | sort -u | sed 's/^/@/' | paste -sd ' ' -)
+
+          # Close the code block
+          issueBody+=$'\n```'
+
+          # Add the mentions to the issue body
+          issueBody+=$'\n\n'"$mentions"
+
+          gh issue create  --title "Report of Old Branches"  --body "$issueBody"

--- a/.github/workflows/pickOldBranchesAndOwners.yml
+++ b/.github/workflows/pickOldBranchesAndOwners.yml
@@ -1,0 +1,69 @@
+name: Pick Old Branches & Owners
+
+on:
+  workflow_dispatch:
+
+jobs:
+  PickOldBranchesAndOwners:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0  # Needed to retrieve full commit log
+
+      - name: Setup Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: '3.x'
+
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      - name: Find Stale Branches and List Owners
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        run: |
+          AGE_CUTOFF=360 # In days
+          MAIN_BRANCH=master
+
+          # Fetch all branches
+          git branch -r | grep -v '\->' | sed 's/origin\///' > branches.txt
+
+          # Loop through branches
+          while read branch; do
+            # Skip main branch
+            if [ "$branch" = "master" ] || [ "$branch" = "main" ]; then
+              continue
+            fi
+
+            # Skip if open PR exists
+            open_prs=$(gh pr list --head "$branch" --json number --jq 'length')
+            if [ "$open_prs" -gt 0 ]; then
+              continue
+            fi
+
+            # Get last commit date
+            lastCommitDate=$(gh api repos/${{ github.repository }}/commits/$branch --jq '.commit.committer.date')
+
+            # Calculate branch age in days
+            branchAgeDays=$(( ($(date -u +%s) - $(date -u -d "$lastCommitDate" +%s)) / 86400 ))
+
+            # Check whether the branch is old enough
+            if [ $branchAgeDays -ge $AGE_CUTOFF ]; then
+              # Get contributors to the branch
+              commitData=$(gh api "repos/${{ github.repository }}/compare/$MAIN_BRANCH...$branch")
+              contributors=$(printf '%s\n' "$commitData" | jq -r '.commits[] | select(.author.login != null) | "\(.commit.author.name) (@\(.author.login))"' | sort -u)
+              contributors=$(printf '%s\n' "$contributors" | paste -sd ', ' -)
+
+              BLUE='\033[34m'
+              RED='\033[31m'
+              GREEN='\033[32m'
+              NC='\033[0m'
+              printf "BRANCH=${BLUE}%-20s${NC} AGE=${RED}%-20s${NC} OWNER=${GREEN}%s${NC}\n" "$branch" "${branchAgeDays} days old" "$contributors"
+            fi
+          done < branches.txt


### PR DESCRIPTION
# Description
The following workflows have been created for testing the two preliminary steps for handling old branches. Thus, they are not the final solution.

1. pickOldBranchesAndOwners.yml:
   This workflow collects the branches that are inactive more than 360 days. It also collects the contributors to each branch. This workflow runs only manually and creates a report inside the workflow log. It applies no modifications to the repository at all. It aims only at testing the first step before moving to the following steps.

2. notifyOwnersOldBranches.yml:
   This workflow not only contains the previous step (for collecting the old branches and their contributors), but it also sends a notification to the owners whose branches are old and inform them that their branches have been scheduled for removal in 60 days. However, it does not remove any branches at this stage.


## How Has This Been Tested?
These two workflows have been tested extensively against another toy example repository. To test it on the ls1-mardy repository, they need to be part of the master branch; otherwise the workflows do not run. However, they are harmless since they do not modify the repository and run only manually.