### PR TITLE
Mamico linked cell fixes

### DIFF
--- a/src/plugins/MamicoCoupling.cpp
+++ b/src/plugins/MamicoCoupling.cpp
@@ -12,12 +12,22 @@ void MamicoCoupling::beforeForces(ParticleContainer *particleContainer, DomainDe
 	if (_couplingEnabled) {
 		// This object should be set by MaMiCo after the plugins are created in the simulation readxml file.
 		// Even though this method is called before the object is set, at this point the coupling switch is always off
-		_couplingCellService->processInnerCouplingCellAfterMDTimestep();
-		_couplingCellService->distributeMass(simstep);
-		_couplingCellService->applyTemperatureToMolecules(simstep);
+        _couplingCellService->processInnerCouplingCellAfterMDTimestep();
+		// Before forces are calculated, mamico would like to insert and delete particles using usher
+		// At this point in time, ls1 linked cells should have no halos, and leaving particles should not have been communicated
+		// Particle contianer is hence updated to make sure halos exist
+        global_simulation->updateParticleContainerAndDecomposition(1.0, false);
+		// Particle insertion and deletion
+        _couplingCellService->distributeMass(simstep);
+		// Mamico thermostat
+        _couplingCellService->applyTemperatureToMolecules(simstep);
+		// Remove halos, as at this point in the code there should be no halos
 #ifndef MARDYN_AUTOPAS
-		particleContainer->deleteOuterParticles();
+        particleContainer->deleteOuterParticles();
 #endif
+		// Unfortunately, at this point, leaving particles should exist on source ranks and not destination
+		// Thus this plugin does not entirely preserve the simulation state, since leaving particles are communicated
+		// Any plugins after this that work on leaving particles will find zero leaving particles
 	}
 }
 

--- a/src/plugins/MamicoCoupling.cpp
+++ b/src/plugins/MamicoCoupling.cpp
@@ -1,6 +1,7 @@
 #ifdef MAMICO_COUPLING
 
 #include "MamicoCoupling.h"
+
 #include "Domain.h"
 
 void MamicoCoupling::init(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp, Domain *domain) {
@@ -12,18 +13,18 @@ void MamicoCoupling::beforeForces(ParticleContainer *particleContainer, DomainDe
 	if (_couplingEnabled) {
 		// This object should be set by MaMiCo after the plugins are created in the simulation readxml file.
 		// Even though this method is called before the object is set, at this point the coupling switch is always off
-        _couplingCellService->processInnerCouplingCellAfterMDTimestep();
-		// Before forces are calculated, mamico would like to insert and delete particles using usher
-		// At this point in time, ls1 linked cells should have no halos, and leaving particles should not have been communicated
-		// Particle contianer is hence updated to make sure halos exist
-        global_simulation->updateParticleContainerAndDecomposition(1.0, false);
+		_couplingCellService->processInnerCouplingCellAfterMDTimestep();
+		// Before forces are calculated, mamico would like to insert and delete particles using usher.
+		// At this point in time, ls1 linked cells should have no halos, and leaving particles should not have been
+		// communicated. Particle container is hence updated to make sure halos exist.
+		global_simulation->updateParticleContainerAndDecomposition(1.0, false);
 		// Particle insertion and deletion
-        _couplingCellService->distributeMass(simstep);
+		_couplingCellService->distributeMass(simstep);
 		// Mamico thermostat
-        _couplingCellService->applyTemperatureToMolecules(simstep);
+		_couplingCellService->applyTemperatureToMolecules(simstep);
 		// Remove halos, as at this point in the code there should be no halos
 #ifndef MARDYN_AUTOPAS
-        particleContainer->deleteOuterParticles();
+		particleContainer->deleteOuterParticles();
 #endif
 		// Unfortunately, at this point, leaving particles should exist on source ranks and not destination
 		// Thus this plugin does not entirely preserve the simulation state, since leaving particles are communicated
@@ -39,4 +40,4 @@ void MamicoCoupling::afterForces(ParticleContainer *particleContainer, DomainDec
 	}
 }
 
-#endif  // MAMICO_COUPLING
+#endif	// MAMICO_COUPLING

--- a/src/plugins/MamicoCoupling.h
+++ b/src/plugins/MamicoCoupling.h
@@ -4,6 +4,7 @@
 
 #include <coupling/interface/impl/ls1/LS1RegionWrapper.h>
 #include <coupling/services/CouplingCellService.h>
+
 #include "PluginBase.h"
 
 /**
@@ -116,4 +117,4 @@ private:
 	bool _couplingEnabled = false;
 };
 
-#endif  // MAMICO_COUPLING
+#endif	// MAMICO_COUPLING

--- a/src/plugins/MamicoCoupling.h
+++ b/src/plugins/MamicoCoupling.h
@@ -16,9 +16,12 @@
  * distinct. From the inside, MaMiCo code needs to be executed at specific points within the same simulation step. This
  * plugin enables the "inside" behaviour.
  *
- * MaMiCo coupling requires the MAMICO_COUPLING flag to be set, and the MAMICO_SRD_DIR flag to point to MaMiCo source
+ * MaMiCo coupling requires the MAMICO_COUPLING flag to be set, and the MAMICO_SRC_DIR flag to point to MaMiCo source
  * files. With these enabled, ls1 compiles as a library. To make sure the program compiles and works with tests, the
  * relevant MaMiCo portions for the code are put in #ifdef regions.
+ * 
+ * This plugin alters the simulation state, as leaving particles get communicated in the beforeForces() step. Any plugins
+ * running after this plugin that wants to work on leaving particles will find zero leaving particles.
  *
  * \code{.xml}
  * <plugin name="MamicoCoupling">
@@ -50,7 +53,8 @@ public:
 	 *
 	 * The distributeMass method calls the updateParticleContainerAndDecomposition() function at the end, so we end up
 	 * with a container with halo particles present. Hence a manual halo clearance is done to restore the state of the
-	 * container.
+	 * container. Unfortunately, this does not fully restore the state, since leaving particles are communicated and
+	 * hence do not exist on source ranks anymore.
 	 */
 	void beforeForces(ParticleContainer *particleContainer, DomainDecompBase *domainDecomp,
 					  unsigned long simstep) override;
@@ -100,8 +104,7 @@ public:
 	 * when equilibrating the simulation initially.
 	 *
 	 * Set from within MaMiCo, check
-	 * https://github.com/HSU-HPC/MaMiCo/blob/master/coupling/interface/MDSimulationFactory.h,
-	 * class LS1MDSimulation
+	 * https://github.com/HSU-HPC/MaMiCo/blob/master/coupling/interface/MDSimulationFactory.h, class LS1MDSimulation
 	 */
 	void switchOffCoupling() { _couplingEnabled = false; }
 


### PR DESCRIPTION
# Description

When using Mamico with particle insertion, ls1 linked cells would sometimes experience an explosion when inserted particles would not respect halo particles, due to a lack of said particles. Here the halo is populated before the initial insertion.

## How Has This Been Tested?

Tested Mamico couette scenarios, good agreement with analytical solution